### PR TITLE
Add api_reference example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ I want to build a language that focuses on developing microservices. Which shoul
 A lot people have questions about `rooby` since it's a new language and you may get confused by the way I describe it (sorry for that 😢). Here's a list of [frequently asked questions](https://github.com/rooby-lang/rooby/wiki/Frequently-asked-questions).
 
 ## Supported features
+
+#### [API Reference](api_reference/)
+
 - **Can be compiled into bytecode (with `.robc` extension)**
 - **Can evaluate bytecode directly**
 - Everything is object

--- a/api_reference/README.md
+++ b/api_reference/README.md
@@ -1,0 +1,5 @@
+# API Reference
+
+(WIP)
+
+- [Integer](integer.md)

--- a/api_reference/integer.md
+++ b/api_reference/integer.md
@@ -1,0 +1,83 @@
+# Integer
+
+[Source code](https://github.com/rooby-lang/rooby/blob/master/vm/integer.go)
+
+### + (Integer)
+
+Returns the sum of self and another `Integer`.
+
+### - (Integer)
+
+Returns the subtraction of another `Integer` from self.
+
+### * (Integer)
+
+Returns self multiplying another `Integer`.
+
+### ** (Integer)
+
+Returns self squaring another `Integer`.
+
+### / (Integer)
+
+Returns self divided by another `Integer`.
+
+### > (Integer)
+
+Returns if self is larger than another `Integer`.
+
+### >= (Integer)
+
+Returns if self is larger than or equals to another `Integer`.
+
+### < (Integer)
+
+Returns if self is smaller than another `Integer`.
+
+### <= (Integer)
+
+Returns if self is smaller than or equals to another `Integer`.
+
+### <=> (Integer)
+
+Returns 1 if self is larger than the incoming `Integer`, -1 if smaller. Otherwise 0.
+
+### == (Integer)
+
+Returns if self is equal to another `Integer`.
+
+### != (Integer)
+
+Returns if self is not equal to another `Integer`.
+
+### ++ (Integer)
+
+Adds 1 to self and returns.
+
+### -- (Integer)
+
+Substracts 1 from self and returns.
+
+### to_s
+
+Returns a `String` representation of self.
+
+### even
+
+Returns if self is even.
+
+### odd
+
+Returns if self is odd.
+
+### next
+
+Returns self + 1.
+
+### pred
+
+Returns self - 1.
+
+### times (&block)
+
+Yields a block a number of times equals to self.


### PR DESCRIPTION
I believe API documents are good for developers who want to contribute to this project. 

This is an example of documenting API from core libraries. Since this project is not complicated for now, we can take a MVP approach to generate simple markdown documents like this. When the API becomes so complicated that it requires new format, then it can be moved to another place, maybe self-hosting or using GitHub Pages. We can discuss which format is better. 

A better approach than copying methods from the source code is to write a parser. That parser will parse the source code and generate markdown or HTML files automatically, like Rails and its API pages. That can be done after this.

You can find this example displayed on [my forked repo](https://github.com/adlerhsieh/rooby/tree/api_reference/api_reference).