### PR TITLE
Add Parser Options

### DIFF
--- a/goby.go
+++ b/goby.go
@@ -35,6 +35,12 @@ func main() {
 	}
 
 	filepath := flag.Arg(0)
+
+	if filepath == "" {
+		flag.Usage()
+		os.Exit(0)
+	}
+
 	args := flag.Args()[1:]
 
 	dir, filename, fileExt := extractFileInfo(filepath)

--- a/goby.go
+++ b/goby.go
@@ -3,26 +3,35 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/pkg/profile"
 	"github.com/goby-lang/goby/bytecode"
 	"github.com/goby-lang/goby/parser"
 	"github.com/goby-lang/goby/vm"
+	"github.com/pkg/profile"
 	"io/ioutil"
+	"log"
 	"os"
 	"path"
-	"strings"
-	"log"
 	"path/filepath"
+	"strings"
 )
+
+// Version stores current Goby version
+const Version string = "0.0.1"
 
 func main() {
 	compileOptionPtr := flag.Bool("c", false, "Compile to bytecode")
 	profileOptionPtr := flag.Bool("p", false, "Profile program execution")
+	versionOptionPtr := flag.Bool("v", false, "Show current Goby version")
 
 	flag.Parse()
 
 	if *profileOptionPtr {
 		defer profile.Start().Stop()
+	}
+
+	if *versionOptionPtr {
+		fmt.Println(Version)
+		os.Exit(0)
 	}
 
 	filepath := flag.Arg(0)


### PR DESCRIPTION
The following options are available when running `goby`:

- `-v` display version
- `-h` display help message

Also fix the error when no filepath is specified. The program now displays the help message and exit.