### PR TITLE
Fix File.chmod & Replace panic

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -270,7 +270,7 @@ var builtinArrayInstanceMethods = []*BuiltInMethod{
 				arr := receiver.(*ArrayObject)
 
 				if blockFrame == nil {
-					panic("Can't yield without a block")
+					vm.returnError("Can't yield without a block")
 				}
 
 				for _, obj := range arr.Elements {
@@ -287,7 +287,7 @@ var builtinArrayInstanceMethods = []*BuiltInMethod{
 				arr := receiver.(*ArrayObject)
 
 				if blockFrame == nil {
-					panic("Can't yield without a block")
+					vm.returnError("Can't yield without a block")
 				}
 
 				for i := range arr.Elements {
@@ -315,7 +315,7 @@ var builtinArrayInstanceMethods = []*BuiltInMethod{
 				var elements = make([]Object, len(arr.Elements))
 
 				if blockFrame == nil {
-					panic("Can't yield without a block")
+					vm.returnError("Can't yield without a block")
 				}
 
 				for i, obj := range arr.Elements {
@@ -346,7 +346,7 @@ var builtinArrayInstanceMethods = []*BuiltInMethod{
 				var elements []Object
 
 				if blockFrame == nil {
-					panic("Can't yield without a block")
+					vm.returnError("Can't yield without a block")
 				}
 
 				for _, obj := range arr.Elements {

--- a/vm/file.go
+++ b/vm/file.go
@@ -47,7 +47,7 @@ var builtinFileClassMethods = []*BuiltInMethod{
 		Fn: func(receiver Object) builtinMethodBody {
 			return func(v *VM, args []Object, blockFrame *callFrame) Object {
 				filemod := args[0].(*IntegerObject).Value
-				for i := 1; i < len(args)-1; i++ {
+				for i := 1; i < len(args); i++ {
 					filename := args[i].(*StringObject).Value
 					if !filepath.IsAbs(filename) {
 						filename = v.fileDir + filename
@@ -55,7 +55,7 @@ var builtinFileClassMethods = []*BuiltInMethod{
 
 					err := os.Chmod(filename, os.FileMode(uint32(filemod)))
 					if err != nil {
-						panic(err)
+						v.returnError(err.Error())
 					}
 				}
 
@@ -73,10 +73,10 @@ var builtinFileClassMethods = []*BuiltInMethod{
 		// @return [Integer]
 		Name: "size",
 		Fn: func(receiver Object) builtinMethodBody {
-			return func(v *VM, args []Object, blockFrame *callFrame) Object {
+			return func(vm *VM, args []Object, blockFrame *callFrame) Object {
 				filename := args[0].(*StringObject).Value
 				if !filepath.IsAbs(filename) {
-					filename = v.fileDir + filename
+					filename = vm.fileDir + filename
 				}
 
 				fileStats, err := os.Stat(filename)
@@ -98,7 +98,7 @@ var builtinFileClassMethods = []*BuiltInMethod{
 		// @return [String]
 		Name: "basename",
 		Fn: func(receiver Object) builtinMethodBody {
-			return func(v *VM, args []Object, blockFrame *callFrame) Object {
+			return func(vm *VM, args []Object, blockFrame *callFrame) Object {
 				filename := args[0].(*StringObject).Value
 				return initializeString(filepath.Base(filename))
 			}
@@ -113,7 +113,7 @@ var builtinFileClassMethods = []*BuiltInMethod{
 		// @return [String]
 		Name: "join",
 		Fn: func(receiver Object) builtinMethodBody {
-			return func(v *VM, args []Object, blockFrame *callFrame) Object {
+			return func(vm *VM, args []Object, blockFrame *callFrame) Object {
 				var elements []string
 				for i := 0; i < len(args); i++ {
 					next := args[i].(*StringObject).Value
@@ -134,7 +134,7 @@ var builtinFileClassMethods = []*BuiltInMethod{
 		// @return [Array]
 		Name: "split",
 		Fn: func(receiver Object) builtinMethodBody {
-			return func(v *VM, args []Object, blockFrame *callFrame) Object {
+			return func(vm *VM, args []Object, blockFrame *callFrame) Object {
 				filename := args[0].(*StringObject).Value
 				dir, file := filepath.Split(filename)
 


### PR DESCRIPTION
@janczer I found in `File.chmod` the loop does not update the last file in the variable array. Remove the `-1` to `i` index fix the problem. Could you confirm if I'm correct?

Also I believe we're replacing the built-in `panic` with `vm.returnError` so that Go's error message would not be displayed in Goby. (probably rename it to `vm.ReturnError` in the future since it's a public method.)

And for aligning the variable name, changing `v` to `vm` in `File` class since the latter is used in all other methods.

