### PR TITLE
Add Syntax Error to Parser

### DIFF
--- a/parser/statement_parsing.go
+++ b/parser/statement_parsing.go
@@ -221,6 +221,12 @@ func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 	p.nextToken()
 
 	for !p.curTokenIs(token.End) && !p.curTokenIs(token.Else) {
+
+		if p.curTokenIs(token.EOF) {
+			p.errors = append(p.errors, syntaxError("end", "EOF"))
+			return bs
+		}
+
 		stmt := p.parseStatement()
 		if stmt != nil {
 			bs.Statements = append(bs.Statements, stmt)
@@ -248,4 +254,8 @@ func (p *Parser) parseWhileStatement() *ast.WhileStatement {
 	ws.Body = p.parseBlockStatement()
 
 	return ws
+}
+
+func syntaxError(expecting string, unexpected string) string {
+	return "Syntax error: Expecting '" + expecting + "', unexpected '" + unexpected + "'"
 }


### PR DESCRIPTION
Currently the parser is stuck in an endless loop when a `class` or `if` statement does not end with an `end` like:

```ruby
class Foo

# end
```

This fix allows parser to create a "syntax error" message and return the block statement immediately.

![screen shot 2017-05-28 at 11 32 01 pm](https://cloud.githubusercontent.com/assets/6851886/26529133/e526c4f0-43fd-11e7-8bd1-dd2ba11b0224.png)

If we come up with an error handling mechanism later, we can integrate this into that.