### PR TITLE
Thread on simple server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 go:
   - 1.8.x
 
+before_install:
+  - sudo apt-get install apache2-utils
+
 script:
   - make test
 

--- a/bzt.yml
+++ b/bzt.yml
@@ -1,0 +1,14 @@
+# Please install Taurus first
+# Then run `bzt bzt.yml
+# See https://gettaurus.org/docs/ConfigSyntax/ for more setting options
+execution:
+  - concurrency: 50
+    throughput: 10 # requests per second
+    ramp-up: 10s
+    hold-for: 1m
+    scenario:
+      requests:
+      - http://localhost:3000/
+
+settings:
+  artifacts-dir: /tmp/%Y-%m-%d_%H-%M-%S

--- a/samples/server.gb
+++ b/samples/server.gb
@@ -2,7 +2,11 @@ require("net/simple_server")
 
 server = Net::SimpleServer.new("3000")
 
+i = 0
+
 server.mount("/") do |req, res|
+  puts(i)
+  i = i+1
   res.body = req.method + " Hello World"
   res.status = 200
 end

--- a/test.sh
+++ b/test.sh
@@ -17,6 +17,6 @@ done
 go install .
 goby test_fixtures/server.gb & PID=$!
 
-sleep 2
+ab -n 1000 -c 100 http://localhost:3000/
 
 kill $PID

--- a/test_fixtures/server.gb
+++ b/test_fixtures/server.gb
@@ -7,9 +7,4 @@ server.mount("/") do |req, res|
   res.status = 200
 end
 
-server.mount("/not_found") do |req, res|
-  res.body = "Not Found"
-  res.status = 404
-end
-
 server.start

--- a/vm/simple_server.go
+++ b/vm/simple_server.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-	"time"
 )
 
 type response struct {
@@ -77,12 +76,8 @@ var builtinSimpleServerInstanceMethods = []*BuiltInMethodObject{
 				path := args[0].(*StringObject).Value
 
 				http.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+					// Go creates one goroutine per request, so we also need to create a new Goby thread for every request.
 					thread := t.vm.newThread()
-					if t.vm.threadCount%100 == 0 {
-						log.Println("-------------------Start Sleeping-------------------------")
-						time.Sleep(100 * time.Millisecond)
-						log.Println("###################Stop Sleeping########################")
-					}
 					res := httpResponseClass.initializeInstance()
 					req := initRequest(r)
 					thread.builtInMethodYield(blockFrame, req, res)

--- a/vm/simple_server.go
+++ b/vm/simple_server.go
@@ -78,9 +78,9 @@ var builtinSimpleServerInstanceMethods = []*BuiltInMethodObject{
 
 				http.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 					thread := t.vm.newThread()
-					if t.vm.threadCount % 100 == 0 {
+					if t.vm.threadCount%100 == 0 {
 						log.Println("-------------------Start Sleeping-------------------------")
-						time.Sleep(10 * time.Second)
+						time.Sleep(100 * time.Millisecond)
 						log.Println("###################Stop Sleeping########################")
 					}
 					res := httpResponseClass.initializeInstance()

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -52,8 +52,6 @@ type VM struct {
 	args []string
 	// projectRoot is goby root's absolute path, which is $GOROOT/src/github.com/goby-lang/goby
 	projectRoot string
-
-	threadCount int
 }
 
 // New initializes a vm to initialize state and returns it.
@@ -93,7 +91,6 @@ func (vm *VM) newThread() *thread {
 	s.thread = t
 	cfs.thread = t
 	t.vm = vm
-	vm.threadCount++
 	return t
 }
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -52,6 +52,8 @@ type VM struct {
 	args []string
 	// projectRoot is goby root's absolute path, which is $GOROOT/src/github.com/goby-lang/goby
 	projectRoot string
+
+	threadCount int
 }
 
 // New initializes a vm to initialize state and returns it.
@@ -91,6 +93,7 @@ func (vm *VM) newThread() *thread {
 	s.thread = t
 	cfs.thread = t
 	t.vm = vm
+	vm.threadCount++
 	return t
 }
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -56,14 +56,8 @@ type VM struct {
 
 // New initializes a vm to initialize state and returns it.
 func New(fileDir string, args []string) *VM {
-	s := &stack{}
-	cfs := &callFrameStack{callFrames: []*callFrame{}}
-	thread := &thread{stack: s, callFrameStack: cfs, sp: 0, cfp: 0}
-	s.thread = thread
-	cfs.thread = thread
-
-	vm := &VM{mainThread: thread, args: args}
-	thread.vm = vm
+	vm := &VM{args: args}
+	vm.mainThread = vm.newThread()
 
 	vm.initConstants()
 	vm.methodISIndexTables = map[filename]*isIndexTable{
@@ -88,6 +82,16 @@ func New(fileDir string, args []string) *VM {
 	}
 
 	return vm
+}
+
+func (vm *VM) newThread() *thread {
+	s := &stack{}
+	cfs := &callFrameStack{callFrames: []*callFrame{}}
+	t := &thread{stack: s, callFrameStack: cfs, sp: 0, cfp: 0}
+	s.thread = t
+	cfs.thread = t
+	t.vm = vm
+	return t
 }
 
 // ExecBytecodes accepts a sequence of bytecodes and use vm to evaluate them.


### PR DESCRIPTION
## Load testing
Use [Boom](https://github.com/tarekziade/boom) as load testing tool. Apache Bench sometimes just hangs there.
Test script I use:
```
$ boom http://localhost:3000/ -n 100000 -c 100
```

And I call sleep function in:

```go
http.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
    thread := t.vm.newThread()
    if t.vm.threadCount % 100 == 0 {
        log.Println("-------------------Start Sleeping-------------------------")
        time.Sleep(10 * time.Second)
        log.Println("###################Stop Sleeping########################")
    }
    res := httpResponseClass.initializeInstance()
    ......
}
```

for testing if it's really running concurrently or one slow request blocks others.

## Profiling
Use [gcvis](https://github.com/davecheney/gcvis) for monitoring memory usage. Run
```
$ env GOMAXPROCS=4 gcvis go run goby.go samples/server.gb 
```

## Conclusion

- It turns out create a new thread on every requests works pretty well (at least for now). 
- The final `i` in `server.gb` will match the total request number, which means there's no obvious race condition 😁.
- The blocking test's result is as I expected: just the selected threads sleeps (and will recover later) and we can still serve other requests at the same time. 