### PR TITLE
Add New Error Types

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -448,6 +448,10 @@ var builtinArrayInstanceMethods = []*BuiltInMethodObject{
 				arr := receiver.(*ArrayObject)
 				var count int
 
+				if len(args) > 1 {
+					return initializeArgumentError("Expect one argument. got=%d", len(args))
+				}
+
 				if blockFrame != nil {
 					for _, obj := range arr.Elements {
 						result := t.builtInMethodYield(blockFrame, obj)
@@ -457,10 +461,6 @@ var builtinArrayInstanceMethods = []*BuiltInMethodObject{
 					}
 
 					return initilaizeInteger(count)
-				}
-
-				if len(args) > 1 {
-					return newError("Expect one argument. got=%d", len(args))
 				}
 
 				if len(args) == 0 {

--- a/vm/array.go
+++ b/vm/array.go
@@ -449,7 +449,7 @@ var builtinArrayInstanceMethods = []*BuiltInMethodObject{
 				var count int
 
 				if len(args) > 1 {
-					return initializeArgumentError("Expect one argument. got=%d", len(args))
+					return initializeArgumentError("Expect 1 argument, got=%v", len(args))
 				}
 
 				if blockFrame != nil {

--- a/vm/array.go
+++ b/vm/array.go
@@ -449,7 +449,7 @@ var builtinArrayInstanceMethods = []*BuiltInMethodObject{
 				var count int
 
 				if len(args) > 1 {
-					return initializeArgumentError("Expect 1 argument, got=%v", len(args))
+					return initializeError(ArgumentErrorClass, "Expect 1 argument, got=%v", len(args))
 				}
 
 				if blockFrame != nil {

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -425,13 +425,13 @@ func TestCountMethodFail(t *testing.T) {
 	for _, tt := range testsFail {
 		evaluated := testEval(t, tt.input)
 
-		err, ok := evaluated.(*ArgumentErrorObject)
+		err, ok := evaluated.(*Error)
 		if !ok {
 			t.Errorf("Expect ArgumentError. got=%T (%+v)", err, err)
 		}
 
-		if err.Message != tt.expected.Message {
-			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
+		if err.Class.ReturnName() != ArgumentError {
+			t.Errorf("Expect \"%s\". got=\"%s\"", ArgumentError, err.Class.ReturnName())
 		}
 	}
 }

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -426,12 +426,8 @@ func TestCountMethodFail(t *testing.T) {
 		evaluated := testEval(t, tt.input)
 
 		err, ok := evaluated.(*Error)
-		if !ok {
+		if !ok || err.Class.ReturnName() != ArgumentError {
 			t.Errorf("Expect ArgumentError. got=%T (%+v)", err, err)
-		}
-
-		if err.Class.ReturnName() != ArgumentError {
-			t.Errorf("Expect \"%s\". got=\"%s\"", ArgumentError, err.Class.ReturnName())
 		}
 	}
 }

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -424,10 +424,12 @@ func TestCountMethodFail(t *testing.T) {
 
 	for _, tt := range testsFail {
 		evaluated := testEval(t, tt.input)
-		err, ok := evaluated.(*Error)
+
+		err, ok := evaluated.(*ArgumentErrorObject)
 		if !ok {
-			t.Errorf("Expect error. got=%T (%+v)", err, err)
+			t.Errorf("Expect ArgumentError. got=%T (%+v)", err, err)
 		}
+
 		if err.Message != tt.expected.Message {
 			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
 		}

--- a/vm/class.go
+++ b/vm/class.go
@@ -273,6 +273,17 @@ func (c *RClass) setAttrAccessor(args interface{}) {
 	c.setAttrWriter(args)
 }
 
+func createBaseClass(className string) *BaseClass {
+	return &BaseClass{
+		Name:             className,
+		Methods:          newEnvironment(),
+		ClassMethods:     newEnvironment(),
+		Class:            classClass,
+		pseudoSuperClass: objectClass,
+		superClass:       objectClass,
+	}
+}
+
 var builtinGlobalMethods = []*BuiltInMethodObject{
 	{
 		Name: "require",

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -2,6 +2,14 @@ package vm
 
 import "testing"
 
+func TestCreateBaseClass(t *testing.T) {
+	className := "Integer"
+	c := createBaseClass(className)
+	if c.Name != className {
+		t.Fatalf("Expect createBaseClass(\"%v\") to return a %v class", className, className)
+	}
+}
+
 func TestMonkeyPatchBuiltInClass(t *testing.T) {
 	input := `
 	class String

--- a/vm/error.go
+++ b/vm/error.go
@@ -46,23 +46,9 @@ func (e *Error) returnClass() Class {
 	return e.Class
 }
 
-func initializeUndefinedMethodError(format string, args ...interface{}) *Error {
+func initializeError(errorType *RClass, format string, args ...interface{}) *Error {
 	return &Error{
-		Class:   UndefinedMethodErrorClass,
-		Message: fmt.Sprintf(UndefinedMethodError+": "+format, args...),
-	}
-}
-
-func initializeArgumentError(format string, args ...interface{}) *Error {
-	return &Error{
-		Class:   ArgumentErrorClass,
-		Message: fmt.Sprintf(ArgumentError+": "+format, args...),
-	}
-}
-
-func initializeTypeError(format string, args ...interface{}) *Error {
-	return &Error{
-		Class:   TypeErrorClass,
-		Message: fmt.Sprintf(TypeError+": "+format, args...),
+		Class:   errorType,
+		Message: fmt.Sprintf(errorType.Name+": "+format, args...),
 	}
 }

--- a/vm/error.go
+++ b/vm/error.go
@@ -13,12 +13,21 @@ var (
 	TypeErrorClass *RClass
 )
 
-func initErrors() {
-	bc := createBaseClass("UndefinedMethodError")
+const (
+	// UndefinedMethodError describes the error type in string
+	UndefinedMethodError = "UndefinedMethodError"
+	// ArgumentError describes the error type in string
+	ArgumentError = "ArgumentError"
+	// TypeError describes the error type in string
+	TypeError = "TypeError"
+)
+
+func init() {
+	bc := createBaseClass(UndefinedMethodError)
 	UndefinedMethodErrorClass = &RClass{BaseClass: bc}
-	bc = createBaseClass("ArgumentError")
+	bc = createBaseClass(ArgumentError)
 	ArgumentErrorClass = &RClass{BaseClass: bc}
-	bc = createBaseClass("TypeError")
+	bc = createBaseClass(TypeError)
 	TypeErrorClass = &RClass{BaseClass: bc}
 }
 
@@ -37,59 +46,23 @@ func (e *Error) returnClass() Class {
 	return e.Class
 }
 
-// UndefinedMethodErrorObject ...
-type UndefinedMethodErrorObject struct {
-	Class   *RClass
-	Message string
+func initializeUndefinedMethodError(format string, args ...interface{}) *Error {
+	return &Error{
+		Class:   UndefinedMethodErrorClass,
+		Message: fmt.Sprintf(UndefinedMethodError+": "+format, args...),
+	}
 }
 
-// Inspect ...
-func (e *UndefinedMethodErrorObject) Inspect() string {
-	return "ArgumentError: " + e.Message
+func initializeArgumentError(format string, args ...interface{}) *Error {
+	return &Error{
+		Class:   ArgumentErrorClass,
+		Message: fmt.Sprintf(ArgumentError+": "+format, args...),
+	}
 }
 
-func (e *UndefinedMethodErrorObject) returnClass() Class {
-	return e.Class
-}
-
-func initializeUndefinedMethodError(format string, args ...interface{}) *UndefinedMethodErrorObject {
-	return &UndefinedMethodErrorObject{Class: UndefinedMethodErrorClass, Message: fmt.Sprintf(format, args...)}
-}
-
-// ArgumentErrorObject ...
-type ArgumentErrorObject struct {
-	Class   *RClass
-	Message string
-}
-
-// Inspect ...
-func (e *ArgumentErrorObject) Inspect() string {
-	return "ArgumentError: " + e.Message
-}
-
-func (e *ArgumentErrorObject) returnClass() Class {
-	return e.Class
-}
-
-func initializeArgumentError(format string, args ...interface{}) *ArgumentErrorObject {
-	return &ArgumentErrorObject{Class: ArgumentErrorClass, Message: fmt.Sprintf(format, args...)}
-}
-
-// TypeErrorObject ...
-type TypeErrorObject struct {
-	Class   *RClass
-	Message string
-}
-
-// Inspect ...
-func (e *TypeErrorObject) Inspect() string {
-	return "TypeError: " + e.Message
-}
-
-func (e *TypeErrorObject) returnClass() Class {
-	return e.Class
-}
-
-func initializeTypeError(format string, args ...interface{}) *TypeErrorObject {
-	return &TypeErrorObject{Class: TypeErrorClass, Message: fmt.Sprintf(format, args...)}
+func initializeTypeError(format string, args ...interface{}) *Error {
+	return &Error{
+		Class:   TypeErrorClass,
+		Message: fmt.Sprintf(TypeError+": "+format, args...),
+	}
 }

--- a/vm/error.go
+++ b/vm/error.go
@@ -1,18 +1,95 @@
 package vm
 
-type ErrorClass struct {
-	*BaseClass
+import (
+	"fmt"
+)
+
+var (
+	// UndefinedMethodErrorClass ...
+	UndefinedMethodErrorClass *RClass
+	// ArgumentErrorClass ...
+	ArgumentErrorClass *RClass
+	// TypeErrorClass ...
+	TypeErrorClass *RClass
+)
+
+func initErrors() {
+	bc := createBaseClass("UndefinedMethodError")
+	UndefinedMethodErrorClass = &RClass{BaseClass: bc}
+	bc = createBaseClass("ArgumentError")
+	ArgumentErrorClass = &RClass{BaseClass: bc}
+	bc = createBaseClass("TypeError")
+	TypeErrorClass = &RClass{BaseClass: bc}
 }
 
+// Error ...
 type Error struct {
-	Class   *ErrorClass
+	Class   *RClass
 	Message string
 }
 
+// Inspect ...
 func (e *Error) Inspect() string {
 	return "ERROR: " + e.Message
 }
 
 func (e *Error) returnClass() Class {
 	return e.Class
+}
+
+// UndefinedMethodErrorObject ...
+type UndefinedMethodErrorObject struct {
+	Class   *RClass
+	Message string
+}
+
+// Inspect ...
+func (e *UndefinedMethodErrorObject) Inspect() string {
+	return "ArgumentError: " + e.Message
+}
+
+func (e *UndefinedMethodErrorObject) returnClass() Class {
+	return e.Class
+}
+
+func initializeUndefinedMethodError(format string, args ...interface{}) *UndefinedMethodErrorObject {
+	return &UndefinedMethodErrorObject{Class: UndefinedMethodErrorClass, Message: fmt.Sprintf(format, args...)}
+}
+
+// ArgumentErrorObject ...
+type ArgumentErrorObject struct {
+	Class   *RClass
+	Message string
+}
+
+// Inspect ...
+func (e *ArgumentErrorObject) Inspect() string {
+	return "ArgumentError: " + e.Message
+}
+
+func (e *ArgumentErrorObject) returnClass() Class {
+	return e.Class
+}
+
+func initializeArgumentError(format string, args ...interface{}) *ArgumentErrorObject {
+	return &ArgumentErrorObject{Class: ArgumentErrorClass, Message: fmt.Sprintf(format, args...)}
+}
+
+// TypeErrorObject ...
+type TypeErrorObject struct {
+	Class   *RClass
+	Message string
+}
+
+// Inspect ...
+func (e *TypeErrorObject) Inspect() string {
+	return "TypeError: " + e.Message
+}
+
+func (e *TypeErrorObject) returnClass() Class {
+	return e.Class
+}
+
+func initializeTypeError(format string, args ...interface{}) *TypeErrorObject {
+	return &TypeErrorObject{Class: TypeErrorClass, Message: fmt.Sprintf(format, args...)}
 }

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -4,32 +4,33 @@ import "testing"
 
 func TestUndefinedMethodError(t *testing.T) {
 	evaluated := testEval(t, "a")
-	_, ok := evaluated.(*UndefinedMethodErrorObject)
+	err, ok := evaluated.(*Error)
 	if !ok {
-		t.Errorf("Expect UndefinedMethodError. got=%T (%+v)", evaluated, evaluated)
+		t.Errorf("Expect Error. got=%T (%+v)", evaluated, evaluated)
 	}
-}
-
-func TestUndefinedMethodErrorStopsProgram(t *testing.T) {
-	evaluated := testEval(t, `a; 1 + 1`)
-	_, ok := evaluated.(*UndefinedMethodErrorObject)
-	if !ok {
-		t.Errorf("Expect UndefinedMethodError. got=%T (%+v)", evaluated, evaluated)
+	if err.Class.ReturnName() != UndefinedMethodError {
+		t.Errorf("Expect %s. got=%T (%+v)", UndefinedMethodError, evaluated, evaluated)
 	}
 }
 
 func TestArgumentError(t *testing.T) {
 	evaluated := testEval(t, "[].count(5,4,3)")
-	_, ok := evaluated.(*ArgumentErrorObject)
+	err, ok := evaluated.(*Error)
 	if !ok {
-		t.Errorf("Expect ArgumentError. got=%T (%+v)", evaluated, evaluated)
+		t.Errorf("Expect Error. got=%T (%+v)", evaluated, evaluated)
+	}
+	if err.Class.ReturnName() != ArgumentError {
+		t.Errorf("Expect %s. got=%T (%+v)", ArgumentError, evaluated, evaluated)
 	}
 }
 
 func TestTypeError(t *testing.T) {
 	evaluated := testEval(t, "10 * \"foo\"")
-	_, ok := evaluated.(*TypeErrorObject)
+	err, ok := evaluated.(*Error)
 	if !ok {
-		t.Errorf("Expect TypeError. got=%T (%+v)", evaluated, evaluated)
+		t.Errorf("Expect Error. got=%T (%+v)", evaluated, evaluated)
+	}
+	if err.Class.ReturnName() != TypeError {
+		t.Errorf("Expect %s. got=%T (%+v)", TypeError, evaluated, evaluated)
 	}
 }

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -1,0 +1,35 @@
+package vm
+
+import "testing"
+
+func TestUndefinedMethodError(t *testing.T) {
+	evaluated := testEval(t, "a")
+	_, ok := evaluated.(*UndefinedMethodErrorObject)
+	if !ok {
+		t.Errorf("Expect UndefinedMethodError. got=%T (%+v)", evaluated, evaluated)
+	}
+}
+
+func TestUndefinedMethodErrorStopsProgram(t *testing.T) {
+	evaluated := testEval(t, `a; 1 + 1`)
+	_, ok := evaluated.(*UndefinedMethodErrorObject)
+	if !ok {
+		t.Errorf("Expect UndefinedMethodError. got=%T (%+v)", evaluated, evaluated)
+	}
+}
+
+func TestArgumentError(t *testing.T) {
+	evaluated := testEval(t, "[].count(5,4,3)")
+	_, ok := evaluated.(*ArgumentErrorObject)
+	if !ok {
+		t.Errorf("Expect ArgumentError. got=%T (%+v)", evaluated, evaluated)
+	}
+}
+
+func TestTypeError(t *testing.T) {
+	evaluated := testEval(t, "10 * \"foo\"")
+	_, ok := evaluated.(*TypeErrorObject)
+	if !ok {
+		t.Errorf("Expect TypeError. got=%T (%+v)", evaluated, evaluated)
+	}
+}

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -323,7 +323,8 @@ var builtInActions = map[operationType]*action{
 			}
 
 			if method == nil {
-				t.returnError("undefined method `" + methodName + "' for " + receiver.Inspect())
+				t.UndefinedMethodError(methodName, receiver)
+				return
 			}
 
 			blockFrame := t.retrieveBlock(cf, args)

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -126,7 +126,7 @@ var builtinIntegerInstanceMethods = []*BuiltInMethodObject{
 				right, ok := args[0].(*IntegerObject)
 
 				if !ok {
-					return initializeTypeError("Expect Integer type. got=%T (%+v)")
+					return initializeTypeError("Expect Integer. got=%T (%+v)", args[0], args[0])
 				}
 
 				rightValue := right.Value

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -126,7 +126,7 @@ var builtinIntegerInstanceMethods = []*BuiltInMethodObject{
 				right, ok := args[0].(*IntegerObject)
 
 				if !ok {
-					return initializeTypeError("Expect Integer. got=%T (%+v)", args[0], args[0])
+					return initializeError(TypeErrorClass, "Expect Integer. got=%T (%+v)", args[0], args[0])
 				}
 
 				rightValue := right.Value

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -126,7 +126,7 @@ var builtinIntegerInstanceMethods = []*BuiltInMethodObject{
 				right, ok := args[0].(*IntegerObject)
 
 				if !ok {
-					return wrongTypeError(integerClass)
+					return initializeTypeError("Expect Integer type. got=%T (%+v)")
 				}
 
 				rightValue := right.Value

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -98,9 +98,6 @@ func TestEvalIntegerFail(t *testing.T) {
 		1 - "m"
 		`, newError("expect argument to be Integer type")},
 		{`
-		1 * "a"
-		`, newError("expect argument to be Integer type")},
-		{`
 		1 ** "p"
 		`, newError("expect argument to be Integer type")},
 		{`

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -95,6 +95,6 @@ func (t *thread) returnError(msg string) {
 }
 
 func (t *thread) UndefinedMethodError(methodName string, receiver Object) {
-	err := initializeUndefinedMethodError("Undefined Method '%+v' for %+v", methodName, receiver.Inspect())
+	err := initializeError(UndefinedMethodErrorClass, "Undefined Method '%+v' for %+v", methodName, receiver.Inspect())
 	t.stack.push(&Pointer{err})
 }

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -47,8 +47,7 @@ func (t *thread) hasError() (string, bool) {
 	var hasError bool
 	var msg string
 	if t.stack.top() != nil {
-		switch err := t.stack.top().Target.(type) {
-		case *UndefinedMethodErrorObject:
+		if err, ok := t.stack.top().Target.(*Error); ok {
 			hasError = true
 			msg = err.Message
 		}

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -36,7 +36,24 @@ func (t *thread) evalCallFrame(cf *callFrame) {
 	for cf.pc < len(cf.instructionSet.instructions) {
 		i := cf.instructionSet.instructions[cf.pc]
 		t.execInstruction(cf, i)
+		if msg, yes := t.hasError(); yes {
+			fmt.Println(msg)
+			return
+		}
 	}
+}
+
+func (t *thread) hasError() (string, bool) {
+	var hasError bool
+	var msg string
+	if t.stack.top() != nil {
+		switch err := t.stack.top().Target.(type) {
+		case *UndefinedMethodErrorObject:
+			hasError = true
+			msg = err.Message
+		}
+	}
+	return msg, hasError
 }
 
 func (t *thread) execInstruction(cf *callFrame, i *instruction) {
@@ -47,7 +64,6 @@ func (t *thread) execInstruction(cf *callFrame, i *instruction) {
 			if stackTrace == 0 {
 				fmt.Printf("Internal Error: %s\n", p)
 			}
-			fmt.Printf("Instruction trace: %d. \"%s\"\n", stackTrace, i.inspect())
 			stackTrace++
 			panic(p)
 		}
@@ -77,4 +93,9 @@ func (t *thread) returnError(msg string) {
 	err := &Error{Message: msg}
 	t.stack.push(&Pointer{err})
 	panic(errorMessage(msg))
+}
+
+func (t *thread) UndefinedMethodError(methodName string, receiver Object) {
+	err := initializeUndefinedMethodError("Undefined Method '%+v' for %+v", methodName, receiver.Inspect())
+	t.stack.push(&Pointer{err})
 }


### PR DESCRIPTION
This PR adds the following error classes:

- UndefinedMethodError
- TypeError
- ArgumentError

Also, in `vm/instructions.go`, a new way of returning error is added. If an error is occurred when running `evalCallFrame`, it will return and stop the thread.

The existing way of `panic` is still there for most cases. If this PR is ok, then I'll start replacing all existing `panic` with this type of error handling.