### PR TITLE
WIP:Method call without parens v2

### DIFF
--- a/parser/expression_parsing.go
+++ b/parser/expression_parsing.go
@@ -60,10 +60,14 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 		return nil
 	}
 	leftExp := prefix()
+	fmt.Println("Token: ",p.curToken.Literal, "  ",p.curToken.Type,"PeekToken: ",p.peekToken.Literal)
 
 	for !p.peekTokenIs(token.Semicolon) && precedence < p.peekPrecedence() && p.peekTokenAtSameLine() {
+		//fmt.Println("Finally^^")
+
 		infix := p.infixParseFns[p.peekToken.Type]
 		if infix == nil {
+			//fmt.Println("QQ")
 			return leftExp
 		}
 		p.nextToken()
@@ -302,9 +306,11 @@ func (p *Parser) parseIfExpression() ast.Expression {
 
 func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 	var exp *ast.CallExpression
+	fmt.Println("where are u??^^")
 
 	if p.curTokenIs(token.LParen) { // call expression doesn't have a receiver foo(x) || foo()
 		// method name is receiver, for example 'foo' of foo(x)
+		fmt.Println("curTokenIs(token.LParen) ")
 
 		m := receiver.(*ast.Identifier).Value
 		// receiver is self
@@ -315,7 +321,8 @@ func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 		// current token is identifier (method name)
 		exp = &ast.CallExpression{Token: p.curToken, Receiver: receiver, Method: m}
 		exp.Arguments = p.parseCallArguments()
-	} else if p.curTokenIs(token.Ident) {
+	} else if p.curTokenIs(token.Ident)||p.curTokenIs(token.Int) {
+		fmt.Println("curTokenIs(here) ")
 
 		m := receiver.(*ast.Identifier).Value
 		// receiver is self
@@ -417,6 +424,7 @@ func (p *Parser) parseCallArguments() []ast.Expression {
 }
 
 func (p *Parser) parseCallArgumentsWithoutParens() []ast.Expression {
+	fmt.Println("%%%%%")
 	args := []ast.Expression{}
 
 	if p.peekTokenIs(token.RParen) {
@@ -424,19 +432,22 @@ func (p *Parser) parseCallArgumentsWithoutParens() []ast.Expression {
 		return args
 	}
 
-	p.nextToken() // start of first expression
+	//p.nextToken() // start of first expression
 	args = append(args, p.parseExpression(LOWEST))
+	fmt.Println("PeekToken: ",p.peekToken.Literal)
+
 
 	for p.peekTokenIs(token.Comma) {
+		fmt.Println("again")
+
 		p.nextToken() // ","
 		p.nextToken() // start of next expression
 		args = append(args, p.parseExpression(LOWEST))
 	}
-
-	if !p.expectPeek(token.RParen) {
+	
+	if p.peekTokenAtSameLine(){
 		return nil
 	}
-
 	return args
 }
 

--- a/parser/expression_parsing.go
+++ b/parser/expression_parsing.go
@@ -305,7 +305,6 @@ func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 
 	if p.curTokenIs(token.LParen) { // call expression doesn't have a receiver foo(x) || foo()
 		// method name is receiver, for example 'foo' of foo(x)
-		fmt.Println("______LParen")
 
 		m := receiver.(*ast.Identifier).Value
 		// receiver is self
@@ -316,8 +315,7 @@ func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 		// current token is identifier (method name)
 		exp = &ast.CallExpression{Token: p.curToken, Receiver: receiver, Method: m}
 		exp.Arguments = p.parseCallArguments()
-	} else if p.curTokenIs(token.Ident){
-		fmt.Println("token.Ident!!!!!!!")
+	} else if p.curTokenIs(token.Ident) {
 
 		m := receiver.(*ast.Identifier).Value
 		// receiver is self
@@ -329,8 +327,7 @@ func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 		exp = &ast.CallExpression{Token: p.curToken, Receiver: receiver, Method: m}
 		exp.Arguments = p.parseCallArgumentsWithoutParens()
 
-	}else if p.curTokenIs(token.Dot) { // call expression has a receiver like: p.foo
-		fmt.Println("______Dot")
+	} else if p.curTokenIs(token.Dot) { // call expression has a receiver like: p.foo
 
 		exp = &ast.CallExpression{Token: p.curToken, Receiver: receiver}
 
@@ -442,7 +439,6 @@ func (p *Parser) parseCallArgumentsWithoutParens() []ast.Expression {
 
 	return args
 }
-
 
 func (p *Parser) parseYieldExpression() ast.Expression {
 	ye := &ast.YieldExpression{Token: p.curToken}

--- a/parser/expression_parsing.go
+++ b/parser/expression_parsing.go
@@ -71,6 +71,7 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	}
 
 	leftExp := prefix()
+	// I use precedence "FIRST" to identify call_without_parens case, this is not an appropriate way but it work in current situation
 
 	if argument[p.peekToken.Type] && precedence == FIRST {
 		infix := p.parseCallExpression
@@ -334,10 +335,10 @@ func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 		// current token is identifier (method name)
 		exp = &ast.CallExpression{Token: p.curToken, Receiver: receiver, Method: m}
 
-		if p.curTokenIs(token.LParen) {
+		if p.curTokenIs(token.LParen) { // foo(x,y,x) || foo(x)
 			exp.Arguments = p.parseCallArguments()
 
-		} else {
+		} else { // foo x,y,z ||  foo x
 			exp.Arguments = p.parseCallArgumentsWithoutParens()
 		}
 

--- a/parser/expression_parsing.go
+++ b/parser/expression_parsing.go
@@ -71,16 +71,13 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	}
 
 	leftExp := prefix()
-	fmt.Println("=>",p.curToken.Literal,"  Type: ",p.curToken.Type, "P: ",precedence,"Pe: " ,p.peekPrecedence(), "peek",p.peekToken.Type)
 
 	if argument[p.peekToken.Type] && precedence == FIRST {
-		fmt.Println("FIRST")
 		infix := p.parseCallExpression
 		p.nextToken()
 		leftExp = infix(leftExp)
 
 	} else {
-		fmt.Println("A")
 
 		for !p.peekTokenIs(token.Semicolon) && precedence < p.peekPrecedence() && p.peekTokenAtSameLine() {
 
@@ -92,7 +89,6 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 			leftExp = infix(leftExp)
 		}
 	}
-	fmt.Println("B")
 
 	return leftExp
 }
@@ -359,18 +355,15 @@ func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 		if p.peekTokenIs(token.LParen) {
 			p.nextToken()
 			exp.Arguments = p.parseCallArguments()
-		}  else if p.peekTokenIs(token.Dot){ // p.foo.bar; || p.foo; || p.foo + 123
+		} else if p.peekTokenIs(token.Dot) { // p.foo.bar; || p.foo; || p.foo + 123
 
 			exp.Arguments = []ast.Expression{}
 
-		} else if argument[p.peekToken.Type] && p.peekTokenAtSameLine()  {
+		} else if argument[p.peekToken.Type] && p.peekTokenAtSameLine() { //p.foo x, y, z || p.foo x
 			p.nextToken()
-			//token.Ident not allow so check peekTokenAtSameLine
 			exp.Arguments = p.parseCallArgumentsWithoutParensDot()
-
 		}
 	}
-
 
 	// Setter method call like: p.foo = x
 	if p.peekTokenIs(token.Assign) {
@@ -445,12 +438,7 @@ func (p *Parser) parseCallArguments() []ast.Expression {
 func (p *Parser) parseCallArgumentsWithoutParensDot() []ast.Expression {
 	args := []ast.Expression{}
 
-	//if !p.peekTokenAtSameLine() {
-	//	//p.nextToken() // ')'
-	//	return args
-	//}
-
-	args = append(args, p.parseExpression(FIRST))
+	args = append(args, p.parseExpression(LOWEST))
 
 	for p.peekTokenIs(token.Comma) {
 		p.nextToken() // ","
@@ -463,7 +451,6 @@ func (p *Parser) parseCallArgumentsWithoutParensDot() []ast.Expression {
 	}
 	return args
 }
-
 
 func (p *Parser) parseCallArgumentsWithoutParens() []ast.Expression {
 	args := []ast.Expression{}

--- a/parser/expression_parsing.go
+++ b/parser/expression_parsing.go
@@ -305,6 +305,8 @@ func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 
 	if p.curTokenIs(token.LParen) { // call expression doesn't have a receiver foo(x) || foo()
 		// method name is receiver, for example 'foo' of foo(x)
+		fmt.Println("______LParen")
+
 		m := receiver.(*ast.Identifier).Value
 		// receiver is self
 		selfTok := token.Token{Type: token.Self, Literal: "self", Line: p.curToken.Line}
@@ -315,6 +317,8 @@ func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 		exp = &ast.CallExpression{Token: p.curToken, Receiver: receiver, Method: m}
 		exp.Arguments = p.parseCallArguments()
 	} else if p.curTokenIs(token.Ident){
+		fmt.Println("token.Ident!!!!!!!")
+
 		m := receiver.(*ast.Identifier).Value
 		// receiver is self
 		selfTok := token.Token{Type: token.Self, Literal: "self", Line: p.curToken.Line}
@@ -326,6 +330,8 @@ func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 		exp.Arguments = p.parseCallArgumentsWithoutParens()
 
 	}else if p.curTokenIs(token.Dot) { // call expression has a receiver like: p.foo
+		fmt.Println("______Dot")
+
 		exp = &ast.CallExpression{Token: p.curToken, Receiver: receiver}
 
 		// check if method name is identifier

--- a/parser/expression_parsing.go
+++ b/parser/expression_parsing.go
@@ -8,6 +8,15 @@ import (
 	"github.com/goby-lang/goby/token"
 )
 
+var argument = map[token.Type]bool{
+	token.Int:              true,
+	token.String:           true,
+	token.True:             true,
+	token.False:            true,
+	token.InstanceVariable: true,
+	token.Ident:            true,
+}
+
 var precedence = map[token.Type]int{
 	token.Eq:                 EQUALS,
 	token.NotEq:              EQUALS,
@@ -65,7 +74,8 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	for !p.peekTokenIs(token.Semicolon) && precedence < p.peekPrecedence() && p.peekTokenAtSameLine() {
 
 		infix := p.infixParseFns[p.peekToken.Type]
-		if (p.peekTokenIs(token.Int) || p.peekTokenIs(token.Ident) || p.peekTokenIs(token.InstanceVariable)) && precedence == 0 { // method call without paren case
+
+		if  argument[p.peekToken.Type] && precedence == 0 { // method call without paren case
 			infix = p.parseCallExpression
 		}
 

--- a/parser/expression_parsing.go
+++ b/parser/expression_parsing.go
@@ -59,14 +59,14 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 		p.noPrefixParseFnError(p.curToken.Type)
 		return nil
 	}
-	leftExp := prefix()
-	fmt.Println("precedence=> ", precedence)
 
+	leftExp := prefix()
 
 	for !p.peekTokenIs(token.Semicolon) && precedence < p.peekPrecedence() && p.peekTokenAtSameLine() {
 
 		infix := p.infixParseFns[p.peekToken.Type]
 		if p.peekTokenIs(token.Int) && precedence == 0 {
+			// method call without paren case
 			infix = p.parseCallExpression
 		}
 
@@ -322,9 +322,7 @@ func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 		// current token is identifier (method name)
 		exp = &ast.CallExpression{Token: p.curToken, Receiver: receiver, Method: m}
 		exp.Arguments = p.parseCallArguments()
-	} else if p.curTokenIs(token.Ident)||p.curTokenIs(token.Int) {
-
-		fmt.Println("Good")
+	} else if p.curTokenIs(token.Ident) || p.curTokenIs(token.Int) {
 
 		m := receiver.(*ast.Identifier).Value
 		// receiver is self
@@ -441,7 +439,7 @@ func (p *Parser) parseCallArgumentsWithoutParens() []ast.Expression {
 		args = append(args, p.parseExpression(LOWEST))
 	}
 
-	if p.peekTokenAtSameLine(){
+	if p.peekTokenAtSameLine() {
 		return nil
 	}
 	return args

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -85,7 +85,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.Dot, p.parseCallExpression)
 	p.registerInfix(token.LParen, p.parseCallExpression)
 	p.registerInfix(token.Ident, p.parseCallExpression)
-	p.registerInfix(token.Int, p.parseCallExpression)
+	//p.registerInfix(token.Int, p.parseCallExpression)
 
 	p.registerInfix(token.LBracket, p.parseArrayIndexExpression)
 	p.registerInfix(token.Incr, p.parsePostfixExpression)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -84,6 +84,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.COMP, p.parseInfixExpression)
 	p.registerInfix(token.Dot, p.parseCallExpression)
 	p.registerInfix(token.LParen, p.parseCallExpression)
+	p.registerInfix(token.Ident, p.parseCallExpression)
 	p.registerInfix(token.LBracket, p.parseArrayIndexExpression)
 	p.registerInfix(token.Incr, p.parsePostfixExpression)
 	p.registerInfix(token.Decr, p.parsePostfixExpression)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -84,7 +84,6 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.COMP, p.parseInfixExpression)
 	p.registerInfix(token.Dot, p.parseCallExpression)
 	p.registerInfix(token.LParen, p.parseCallExpression)
-	p.registerInfix(token.Ident, p.parseCallExpression)
 	p.registerInfix(token.LBracket, p.parseArrayIndexExpression)
 	p.registerInfix(token.Incr, p.parsePostfixExpression)
 	p.registerInfix(token.Decr, p.parsePostfixExpression)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -85,8 +85,6 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.Dot, p.parseCallExpression)
 	p.registerInfix(token.LParen, p.parseCallExpression)
 	p.registerInfix(token.Ident, p.parseCallExpression)
-	//p.registerInfix(token.Int, p.parseCallExpression)
-
 	p.registerInfix(token.LBracket, p.parseArrayIndexExpression)
 	p.registerInfix(token.Incr, p.parsePostfixExpression)
 	p.registerInfix(token.Decr, p.parsePostfixExpression)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -85,6 +85,8 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.Dot, p.parseCallExpression)
 	p.registerInfix(token.LParen, p.parseCallExpression)
 	p.registerInfix(token.Ident, p.parseCallExpression)
+	p.registerInfix(token.Int, p.parseCallExpression)
+
 	p.registerInfix(token.LBracket, p.parseArrayIndexExpression)
 	p.registerInfix(token.Incr, p.parsePostfixExpression)
 	p.registerInfix(token.Decr, p.parsePostfixExpression)

--- a/parser/statement_parsing.go
+++ b/parser/statement_parsing.go
@@ -200,7 +200,7 @@ func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 	stmt := &ast.ExpressionStatement{Token: p.curToken}
 
 	precedence := 1
-	if p.curTokenIs(token.Ident){
+	if p.curTokenIs(token.Ident) {
 		precedence = 0
 	}
 	stmt.Expression = p.parseExpression(precedence)
@@ -225,7 +225,6 @@ func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 			p.errors = append(p.errors, syntaxError("end", "EOF"))
 			return bs
 		}
-		//fmt.Println("parseStatement, Token:", p.curToken.Type)
 		stmt := p.parseStatement()
 		if stmt != nil {
 			bs.Statements = append(bs.Statements, stmt)

--- a/parser/statement_parsing.go
+++ b/parser/statement_parsing.go
@@ -72,9 +72,7 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 			p.nextToken()
 			stmt.Parameters = p.parseParameters()
 
-		} else if  p.peekTokenIs(token.Ident) {
-
-
+		} else if p.peekTokenIs(token.Ident) {// def foo x, next token is x and at same line
 			stmt.Parameters = p.parseParametersNoParen()
 		}
 
@@ -198,11 +196,13 @@ func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 	stmt := &ast.ExpressionStatement{Token: p.curToken}
 
-	precedence := 1
 	if p.curTokenIs(token.Ident) {
-		precedence = 0
+		// I use precedence to identify call_without_parens case, this is not an appropriate way but it work in current situation
+		stmt.Expression = p.parseExpression(FIRST)
+	} else {
+		stmt.Expression = p.parseExpression(LOWEST)
 	}
-	stmt.Expression = p.parseExpression(precedence)
+
 	if p.peekTokenIs(token.Semicolon) {
 		p.nextToken()
 	}

--- a/parser/statement_parsing.go
+++ b/parser/statement_parsing.go
@@ -34,7 +34,7 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 	stmt := &ast.DefStatement{Token: p.curToken}
 
 	p.nextToken()
-
+	fmt.Println("curToken", p.curToken.Literal, ",  Type ",  p.curToken.Type)
 	switch p.curToken.Type {
 	case token.Ident:
 		if p.peekTokenIs(token.Dot) {
@@ -45,7 +45,10 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 			}
 			stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 		} else {
+
 			stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+			fmt.Println("stmt.Name ", stmt.Name)
+
 		}
 	case token.Self:
 		stmt.Receiver = &ast.SelfExpression{Token: p.curToken}
@@ -64,17 +67,22 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 		p.nextToken()
 	}
 	// def foo
-	if p.peekTokenAtSameLine() && !p.peekTokenIs(token.Comment) { // def foo(), next token is ( and at same line
 
-		if !p.expectPeek(token.LParen) {
-			return nil
+	if p.peekTokenAtSameLine() { // def foo(), next token is ( and at same line
+		if p.peekTokenIs(token.LParen) {
+			if !p.expectPeek(token.LParen) {
+				return nil
+			}
+			stmt.Parameters = p.parseParameters()
+		} else if  p.peekTokenIs(token.Ident) {
+
+			stmt.Parameters = p.parseParametersNoParen()
 		}
-
-		stmt.Parameters = p.parseParameters()
-
+		
 	} else {
 		stmt.Parameters = []*ast.Identifier{}
 	}
+
 
 	stmt.BlockStatement = p.parseBlockStatement()
 
@@ -131,6 +139,8 @@ func (p *Parser) parseModuleStatement() *ast.ModuleStatement {
 }
 
 func (p *Parser) parseParameters() []*ast.Identifier {
+	fmt.Println("______parseParameters")
+
 	identifiers := []*ast.Identifier{}
 
 	if p.peekTokenIs(token.RParen) {
@@ -139,9 +149,9 @@ func (p *Parser) parseParameters() []*ast.Identifier {
 	} // empty params
 
 	p.nextToken()
-
 	ident := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 	identifiers = append(identifiers, ident)
+	//fmt.Println("ident=> ", ident)
 
 	for p.peekTokenIs(token.Comma) {
 		p.nextToken()
@@ -153,6 +163,33 @@ func (p *Parser) parseParameters() []*ast.Identifier {
 	if !p.expectPeek(token.RParen) {
 		return nil
 	}
+
+	return identifiers
+}
+
+func (p *Parser) parseParametersNoParen() []*ast.Identifier {
+	fmt.Println("______parseParametersNoParen")
+	identifiers := []*ast.Identifier{}
+
+	p.nextToken()
+
+	ident := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+	//fmt.Println("ident=> ", ident)
+	identifiers = append(identifiers, ident)
+
+	for p.peekTokenIs(token.Comma) {
+		p.nextToken()
+		p.nextToken()
+		identifier := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+		identifiers = append(identifiers, identifier)
+	}
+
+	//if !p.expectPeek(token.RParen) {
+	//	return nil
+	//}
+	//p.nextToken()
+	//p.nextToken()
+
 
 	return identifiers
 }
@@ -183,6 +220,8 @@ func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 }
 
 func (p *Parser) parseBlockStatement() *ast.BlockStatement {
+	fmt.Println("_____Here??")
+
 	// curToken is {
 	bs := &ast.BlockStatement{Token: p.curToken}
 	bs.Statements = []ast.Statement{}
@@ -195,6 +234,7 @@ func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 			p.errors = append(p.errors, syntaxError("end", "EOF"))
 			return bs
 		}
+		fmt.Println("curToke=>",p.curToken.Literal)
 
 		stmt := p.parseStatement()
 		if stmt != nil {

--- a/parser/statement_parsing.go
+++ b/parser/statement_parsing.go
@@ -34,7 +34,6 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 	stmt := &ast.DefStatement{Token: p.curToken}
 
 	p.nextToken()
-	fmt.Println("curToken", p.curToken.Literal, ",  Type ",  p.curToken.Type)
 	switch p.curToken.Type {
 	case token.Ident:
 		if p.peekTokenIs(token.Dot) {
@@ -47,7 +46,6 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 		} else {
 
 			stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
-			fmt.Println("stmt.Name ", stmt.Name)
 
 		}
 	case token.Self:
@@ -74,15 +72,15 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 				return nil
 			}
 			stmt.Parameters = p.parseParameters()
+
 		} else if  p.peekTokenIs(token.Ident) {
 
 			stmt.Parameters = p.parseParametersNoParen()
 		}
-		
+
 	} else {
 		stmt.Parameters = []*ast.Identifier{}
 	}
-
 
 	stmt.BlockStatement = p.parseBlockStatement()
 
@@ -139,7 +137,6 @@ func (p *Parser) parseModuleStatement() *ast.ModuleStatement {
 }
 
 func (p *Parser) parseParameters() []*ast.Identifier {
-	fmt.Println("______parseParameters")
 
 	identifiers := []*ast.Identifier{}
 
@@ -151,7 +148,6 @@ func (p *Parser) parseParameters() []*ast.Identifier {
 	p.nextToken()
 	ident := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 	identifiers = append(identifiers, ident)
-	//fmt.Println("ident=> ", ident)
 
 	for p.peekTokenIs(token.Comma) {
 		p.nextToken()
@@ -168,13 +164,11 @@ func (p *Parser) parseParameters() []*ast.Identifier {
 }
 
 func (p *Parser) parseParametersNoParen() []*ast.Identifier {
-	fmt.Println("______parseParametersNoParen")
 	identifiers := []*ast.Identifier{}
 
 	p.nextToken()
 
 	ident := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
-	//fmt.Println("ident=> ", ident)
 	identifiers = append(identifiers, ident)
 
 	for p.peekTokenIs(token.Comma) {
@@ -183,13 +177,6 @@ func (p *Parser) parseParametersNoParen() []*ast.Identifier {
 		identifier := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 		identifiers = append(identifiers, identifier)
 	}
-
-	//if !p.expectPeek(token.RParen) {
-	//	return nil
-	//}
-	//p.nextToken()
-	//p.nextToken()
-
 
 	return identifiers
 }
@@ -220,7 +207,6 @@ func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 }
 
 func (p *Parser) parseBlockStatement() *ast.BlockStatement {
-	fmt.Println("_____Here??")
 
 	// curToken is {
 	bs := &ast.BlockStatement{Token: p.curToken}
@@ -234,7 +220,6 @@ func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 			p.errors = append(p.errors, syntaxError("end", "EOF"))
 			return bs
 		}
-		fmt.Println("curToke=>",p.curToken.Literal)
 
 		stmt := p.parseStatement()
 		if stmt != nil {

--- a/parser/statement_parsing.go
+++ b/parser/statement_parsing.go
@@ -42,7 +42,8 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 			if !p.expectPeek(token.Ident) {
 				return nil
 			}
-			stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+			stmt.Name =
+				&ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 		} else {
 
 			stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
@@ -68,9 +69,7 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 
 	if p.peekTokenAtSameLine() { // def foo(), next token is ( and at same line
 		if p.peekTokenIs(token.LParen) {
-			if !p.expectPeek(token.LParen) {
-				return nil
-			}
+			p.nextToken()
 			stmt.Parameters = p.parseParameters()
 
 		} else if  p.peekTokenIs(token.Ident) {

--- a/parser/statement_parsing.go
+++ b/parser/statement_parsing.go
@@ -199,8 +199,11 @@ func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 	stmt := &ast.ExpressionStatement{Token: p.curToken}
 
-	stmt.Expression = p.parseExpression(0)
-	//fmt.Println("L=> ", 0)
+	precedence := 1
+	if p.curTokenIs(token.Ident){
+		precedence = 0
+	}
+	stmt.Expression = p.parseExpression(precedence)
 	if p.peekTokenIs(token.Semicolon) {
 		p.nextToken()
 	}
@@ -222,7 +225,7 @@ func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 			p.errors = append(p.errors, syntaxError("end", "EOF"))
 			return bs
 		}
-
+		//fmt.Println("parseStatement, Token:", p.curToken.Type)
 		stmt := p.parseStatement()
 		if stmt != nil {
 			bs.Statements = append(bs.Statements, stmt)

--- a/parser/statement_parsing.go
+++ b/parser/statement_parsing.go
@@ -75,6 +75,7 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 
 		} else if  p.peekTokenIs(token.Ident) {
 
+
 			stmt.Parameters = p.parseParametersNoParen()
 		}
 
@@ -198,7 +199,8 @@ func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 	stmt := &ast.ExpressionStatement{Token: p.curToken}
 
-	stmt.Expression = p.parseExpression(LOWEST)
+	stmt.Expression = p.parseExpression(0)
+	//fmt.Println("L=> ", 0)
 	if p.peekTokenIs(token.Semicolon) {
 		p.nextToken()
 	}

--- a/parser/statement_parsing.go
+++ b/parser/statement_parsing.go
@@ -72,7 +72,7 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 			p.nextToken()
 			stmt.Parameters = p.parseParameters()
 
-		} else if p.peekTokenIs(token.Ident) {// def foo x, next token is x and at same line
+		} else if p.peekTokenIs(token.Ident) { // def foo x, next token is x and at same line
 			stmt.Parameters = p.parseParametersNoParen()
 		}
 

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -202,43 +202,6 @@ func TestMethodCall(t *testing.T) {
 	}
 }
 
-func TestMethodCallWithoutParens(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected int
-	}{
-		{
-			`
-			class Foo
-			  def set_x(x)
-			    @x = x
-			  end
-
-			  def foo
-			    set_x(10)
-			    a = 10
-			    @x + a
-			  end
-			end
-
-			f = Foo.new
-			f.foo
-			`,
-			20,
-		},
-	}
-
-	for _, tt := range tests {
-		evaluated := testEval(t, tt.input)
-
-		if isError(evaluated) {
-			t.Fatalf("got Error: %s", evaluated.(*Error).Message)
-		}
-
-		testIntegerObject(t, evaluated, tt.expected)
-	}
-}
-
 
 func TestClassMethodEvaluation(t *testing.T) {
 	tests := []struct {
@@ -881,3 +844,60 @@ func TestMethodCallWithNestedBlock(t *testing.T) {
 		testIntegerObject(t, evaluated, tt.expected)
 	}
 }
+
+func TestMethodCallWithoutParens(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{
+			`
+			class Foo
+			  def set_x(x0)
+			    @x = x0
+			  end
+
+			  def foo
+			    set_x(10)
+			    a = 10
+			    @x + a
+			  end
+			end
+
+			f = Foo.new
+			f.foo
+			`,
+			20,
+		},
+		{
+			`
+			class Foo
+			  def set_x x1
+			    @x = x1
+			  end
+
+			  def foo
+			    set_x(10)
+			    a = 10
+			    @x + a
+			  end
+			end
+
+			f = Foo.new
+			f.foo
+			`,
+			20,
+		},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(t, tt.input)
+
+		if isError(evaluated) {
+			t.Fatalf("got Error: %s", evaluated.(*Error).Message)
+		}
+
+		testIntegerObject(t, evaluated, tt.expected)
+	}
+}
+

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -202,6 +202,44 @@ func TestMethodCall(t *testing.T) {
 	}
 }
 
+func TestMethodCallWithoutParens(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{
+			`
+			class Foo
+			  def set_x(x)
+			    @x = x
+			  end
+
+			  def foo
+			    set_x(10)
+			    a = 10
+			    @x + a
+			  end
+			end
+
+			f = Foo.new
+			f.foo
+			`,
+			20,
+		},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(t, tt.input)
+
+		if isError(evaluated) {
+			t.Fatalf("got Error: %s", evaluated.(*Error).Message)
+		}
+
+		testIntegerObject(t, evaluated, tt.expected)
+	}
+}
+
+
 func TestClassMethodEvaluation(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -325,6 +363,8 @@ func TestClassMethodEvaluation(t *testing.T) {
 		}
 	}
 }
+
+
 
 func TestSelfExpressionEvaluation(t *testing.T) {
 	tests := []struct {

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -855,7 +855,7 @@ func TestMethodCallWithoutParens(t *testing.T) {
 		//	  end
 		//
 		//	  def foo
-		//	    set_x(10)
+		//	    set_x 10
 		//	    a = 10
 		//	    @x + a
 		//	  end
@@ -875,7 +875,7 @@ func TestMethodCallWithoutParens(t *testing.T) {
 			  end
 
 			  def foo
-			    set_x 10,11,12
+			    set_x 10,11
 			    a = 10
 			    @x + a +@y
 			  end

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -915,21 +915,21 @@ func TestMethodCallWithoutParens(t *testing.T) {
 		{
 			`
 			class Foo
+			  attr_reader("x", "y")
+
 			  def set_x x1
 			    @x1 = x1
 			  end
 
 			  def set_y y1, y2, y3
-			    @y3 = y3
-			    @y1 = y1
-			    @y2 = y2
+			    @y = y1 + y2 + y3
 			  end
 
 			  def foo
-			    set_x 10,20
+			    set_x 10
 			    set_y 1,2,3
 			    set_y 3,4,5
-			    @x1 + @y1 + @y2 + @y3
+			    @x1 + @y
 			  end
 			end
 
@@ -940,30 +940,45 @@ func TestMethodCallWithoutParens(t *testing.T) {
 		},
 		{
 			`
+
 			class Foo
+   			  attr_reader("y")
+
+			  def set_y y1, y2, y3
+			    @y = y1 + y2 + y3
+			  end
+
+			end
+
+			f = Foo.new
+			f.set_y 3,4,5
+
+			f.y
+			`,
+			12,
+		},
+		{
+			`
+			class Foo
+			  attr_reader("x", "y")
+
 			  def set_x x1
-			    @x1 = x1
+			    @x = x1
 			  end
 
 			  def set_y y1, y2, y3
-			    @y3 = y3
-			    @y1 = y1
-			    @y2 = y2
-			  end
-
-			  def foo
-			    b = 3
-			    set_x 10
-			    set_y b,4,@x1
-			    @x1 + @y1 + @y2 + @y3
+			    @y = y1 + y2 + y3
 			  end
 			end
 
 			f = Foo.new
-			f.foo
+			f.set_x 1
+			f.set_y 4,5,6
+			f.x + f.y
 			`,
-			27,
+			16,
 		},
+
 		{
 			`
 			class Foo
@@ -975,12 +990,11 @@ func TestMethodCallWithoutParens(t *testing.T) {
 
 			  def set_y y1, y2, y3
 			    @y = y1 + y2 + y3
-			    #set_x 1,2,3
 			  end
 			end
 
 			f = Foo.new
-			f.set_x (1,2,3)
+			f.set_x 1,2,3
 			f.set_y 4,5,6
 			f.x + f.y
 			`,

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -938,6 +938,32 @@ func TestMethodCallWithoutParens(t *testing.T) {
 			`,
 			22,
 		},
+		{
+			`
+			class Foo
+			  def set_x x1
+			    @x1 = x1
+			  end
+
+			  def set_y y1, y2, y3
+			    @y3 = y3
+			    @y1 = y1
+			    @y2 = y2
+			  end
+
+			  def foo
+			    b = 3
+			    set_x 10
+			    set_y b,4,@x1
+			    @x1 + @y1 + @y2 + @y3
+			  end
+			end
+
+			f = Foo.new
+			f.foo
+			`,
+			27,
+		},
 	}
 
 	for _, tt := range tests {

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -202,7 +202,6 @@ func TestMethodCall(t *testing.T) {
 	}
 }
 
-
 func TestClassMethodEvaluation(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -326,8 +325,6 @@ func TestClassMethodEvaluation(t *testing.T) {
 		}
 	}
 }
-
-
 
 func TestSelfExpressionEvaluation(t *testing.T) {
 	tests := []struct {
@@ -853,7 +850,7 @@ func TestMethodCallWithoutParens(t *testing.T) {
 		{
 			`
 			class Foo
-			  def set_x(x0)
+			  def set_x x0
 			    @x = x0
 			  end
 
@@ -872,21 +869,22 @@ func TestMethodCallWithoutParens(t *testing.T) {
 		{
 			`
 			class Foo
-			  def set_x x1
+			  def set_x x1, x2, x3
 			    @x = x1
+			    @y = x2
 			  end
 
 			  def foo
-			    set_x(10)
+			    set_x(10,11,12)
 			    a = 10
-			    @x + a
+			    @x + a +@y
 			  end
 			end
 
 			f = Foo.new
 			f.foo
 			`,
-			20,
+			31,
 		},
 	}
 
@@ -900,4 +898,3 @@ func TestMethodCallWithoutParens(t *testing.T) {
 		testIntegerObject(t, evaluated, tt.expected)
 	}
 }
-

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -847,25 +847,25 @@ func TestMethodCallWithoutParens(t *testing.T) {
 		input    string
 		expected int
 	}{
-		{
-			`
-			class Foo
-			  def set_x x0
-			    @x = x0
-			  end
-
-			  def foo
-			    set_x(10)
-			    a = 10
-			    @x + a
-			  end
-			end
-
-			f = Foo.new
-			f.foo
-			`,
-			20,
-		},
+		//{
+		//	`
+		//	class Foo
+		//	  def set_x x0
+		//	    @x = x0
+		//	  end
+		//
+		//	  def foo
+		//	    set_x(10)
+		//	    a = 10
+		//	    @x + a
+		//	  end
+		//	end
+		//
+		//	f = Foo.new
+		//	f.foo
+		//	`,
+		//	20,
+		//},
 		{
 			`
 			class Foo
@@ -875,7 +875,7 @@ func TestMethodCallWithoutParens(t *testing.T) {
 			  end
 
 			  def foo
-			    set_x(10,11,12)
+			    set_x 10,11,12
 			    a = 10
 			    @x + a +@y
 			  end

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -847,25 +847,25 @@ func TestMethodCallWithoutParens(t *testing.T) {
 		input    string
 		expected int
 	}{
-		//{
-		//	`
-		//	class Foo
-		//	  def set_x x0
-		//	    @x = x0
-		//	  end
-		//
-		//	  def foo
-		//	    set_x 10
-		//	    a = 10
-		//	    @x + a
-		//	  end
-		//	end
-		//
-		//	f = Foo.new
-		//	f.foo
-		//	`,
-		//	20,
-		//},
+		{
+			`
+			class Foo
+			  def set_x x0
+			    @x = x0
+			  end
+
+			  def foo
+			    set_x 10
+			    a = 10
+			    @x + a
+			  end
+			end
+
+			f = Foo.new
+			f.foo
+			`,
+			20,
+		},
 		{
 			`
 			class Foo
@@ -885,6 +885,58 @@ func TestMethodCallWithoutParens(t *testing.T) {
 			f.foo
 			`,
 			31,
+		},
+		{
+			`
+			class Foo
+			  def set_x x1, x2, x3
+			    @x1 = x1
+			    @x2 = x2
+			  end
+
+			  def set_y y1, y2, y3
+			    @y3 = y3
+			    @y1 = y1
+			  end
+
+			  def foo
+			    set_x 15,17
+			    set_y 3,4,5
+			    set_x (10,11)
+			    @x1 + @x2 + @y3
+			  end
+			end
+
+			f = Foo.new
+			f.foo
+			`,
+			26,
+		},
+		{
+			`
+			class Foo
+			  def set_x x1
+			    @x1 = x1
+			  end
+
+			  def set_y y1, y2, y3
+			    @y3 = y3
+			    @y1 = y1
+			    @y2 = y2
+			  end
+
+			  def foo
+			    set_x 10,20
+			    set_y 1,2,3
+			    set_y 3,4,5
+			    @x1 + @y1 + @y2 + @y3
+			  end
+			end
+
+			f = Foo.new
+			f.foo
+			`,
+			22,
 		},
 	}
 

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -964,6 +964,28 @@ func TestMethodCallWithoutParens(t *testing.T) {
 			`,
 			27,
 		},
+		{
+			`
+			class Foo
+			  attr_reader("x", "y")
+
+			  def set_x x1, x2, x3
+			    @x = x1 + x2 + x3
+			  end
+
+			  def set_y y1, y2, y3
+			    @y = y1 + y2 + y3
+			    #set_x 1,2,3
+			  end
+			end
+
+			f = Foo.new
+			f.set_x (1,2,3)
+			f.set_y 4,5,6
+			f.x + f.y
+			`,
+			21,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Support function definition without parens.
- Support method call without parens.
- Support parameter of method call in type Ident, Int, InstanceVariable, String, Boolean
Now we can write goby like this!
`       



	  def set_x x1
	    @x = x1
	  end
	
	  def set_y y1, y2, y3
	    @y = y1 + y2 + y3
	  end
	
	  f = Foo.new
	  f.set_x 1
	  f.set_y 4,5,6
	  f.x + f.y

`

If you find some code is not appropriate just leave a message and let me know~
