### PR TITLE
[Retry] Add API documents to Class

### DIFF
--- a/samples/to_json.gb
+++ b/samples/to_json.gb
@@ -1,0 +1,2 @@
+h = { a: 1, b: [1, "2", [4, 5, nil], { foo: "bar" }]}.to_json
+puts(h) #=> {"a":1,"b":[1, "2", [4, 5, null], {"foo":"bar"}]}

--- a/vm/array.go
+++ b/vm/array.go
@@ -39,6 +39,20 @@ func (a *ArrayObject) Inspect() string {
 	return out.String()
 }
 
+func (a *ArrayObject) toJSON() string {
+	var out bytes.Buffer
+	elements := []string{}
+	for _, e := range a.Elements {
+		elements = append(elements, e.toJSON())
+	}
+
+	out.WriteString("[")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString("]")
+
+	return out.String()
+}
+
 // returnClass returns current object's class, which is RArray
 func (a *ArrayObject) returnClass() Class {
 	return a.Class

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -30,6 +30,10 @@ func (b *BooleanObject) Inspect() string {
 	return fmt.Sprintf("%t", b.Value)
 }
 
+func (b *BooleanObject) toJSON() string {
+	return b.Inspect()
+}
+
 // returnClass returns boolean object's class, which is RBool
 func (b *BooleanObject) returnClass() Class {
 	return b.Class

--- a/vm/class.go
+++ b/vm/class.go
@@ -108,6 +108,10 @@ func (c *BaseClass) Inspect() string {
 	return "<Class:" + c.Name + ">"
 }
 
+func (c *BaseClass) toJSON() string {
+	return c.Inspect()
+}
+
 func (c *BaseClass) setBuiltInMethods(methodList []*BuiltInMethodObject, classMethods bool) {
 	for _, m := range methodList {
 		c.Methods.set(m.Name, m)

--- a/vm/class.go
+++ b/vm/class.go
@@ -315,11 +315,8 @@ var builtinCommonInstanceMethods = []*BuiltInMethodObject{
 		// Currently, only the following embedded Goby libraries are targeted:
 		//
 		// - "file"
-		//
 		// - "net/http"
-		//
 		// - "net/simple_server"
-		//
 		// - "uri"
 		//
 		// ```ruby

--- a/vm/error.go
+++ b/vm/error.go
@@ -42,6 +42,10 @@ func (e *Error) Inspect() string {
 	return "ERROR: " + e.Message
 }
 
+func (e *Error) toJSON() string {
+	return e.Inspect()
+}
+
 func (e *Error) returnClass() Class {
 	return e.Class
 }

--- a/vm/file.go
+++ b/vm/file.go
@@ -30,6 +30,10 @@ func (f *FileObject) Inspect() string {
 	return "<File: " + f.File.Name() + ">"
 }
 
+func (f *FileObject) toJSON() string {
+	return f.Inspect()
+}
+
 // returnClass returns current object's class, which is RArray
 func (f *FileObject) returnClass() Class {
 	return f.Class

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -48,7 +48,7 @@ func initializeHash(pairs map[string]Object) *HashObject {
 	return &HashObject{Pairs: pairs, Class: hashClass}
 }
 
-func generateJson(t *thread, key string, v Object) string {
+func generateJSONFromPair(t *thread, key string, v Object) string {
 	var data string
 	var value string
 	var out bytes.Buffer
@@ -83,7 +83,7 @@ func (h *HashObject) generateJSON(t *thread) string {
 	out.WriteString("{")
 
 	for key, value := range pairs {
-		values = append(values, generateJson(t, key, value))
+		values = append(values, generateJSONFromPair(t, key, value))
 	}
 
 	out.WriteString(strings.Join(values, ","))

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -48,7 +48,7 @@ func initializeHash(pairs map[string]Object) *HashObject {
 	return &HashObject{Pairs: pairs, Class: hashClass}
 }
 
-func generateJson(key string, v Object) string {
+func generateJson(t *thread, key string, v Object) string {
 	var data string
 	var value string
 	var out bytes.Buffer
@@ -62,6 +62,12 @@ func generateJson(key string, v Object) string {
 		value = "\"" + v.Value + "\""
 	case *IntegerObject:
 		value = v.Inspect()
+	case *BooleanObject:
+		value = v.Inspect()
+	case *NullObject:
+		value = "null"
+	default:
+		t.returnError(fmt.Sprintf("Can't convert %T object into json.", v))
 	}
 	out.WriteString(value)
 
@@ -80,7 +86,7 @@ var builtinHashInstanceMethods = []*BuiltInMethodObject{
 				out.WriteString("{")
 
 				for key, value := range pairs {
-					values = append(values, generateJson(key, value))
+					values = append(values, generateJson(t, key, value))
 				}
 
 				out.WriteString(strings.Join(values, ","))

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -48,7 +48,47 @@ func initializeHash(pairs map[string]Object) *HashObject {
 	return &HashObject{Pairs: pairs, Class: hashClass}
 }
 
+func generateJson(key string, v Object) string {
+	var data string
+	var value string
+	var out bytes.Buffer
+
+	out.WriteString(data)
+	out.WriteString("\"" + key + "\"")
+	out.WriteString(":")
+
+	switch v := v.(type) {
+	case *StringObject:
+		value = "\"" + v.Value + "\""
+	case *IntegerObject:
+		value = v.Inspect()
+	}
+	out.WriteString(value)
+
+	return out.String()
+}
+
 var builtinHashInstanceMethods = []*BuiltInMethodObject{
+	{
+		Name: "to_json",
+		Fn: func(receiver Object) builtinMethodBody {
+			return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				var out bytes.Buffer
+				var values []string
+
+				pairs := receiver.(*HashObject).Pairs
+				out.WriteString("{")
+
+				for key, value := range pairs {
+					values = append(values, generateJson(key, value))
+				}
+
+				out.WriteString(strings.Join(values, ","))
+				out.WriteString("}")
+				return initializeString(out.String())
+			}
+		},
+	},
 	{
 		Name: "[]",
 		Fn: func(receiver Object) builtinMethodBody {

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -48,42 +48,26 @@ func initializeHash(pairs map[string]Object) *HashObject {
 	return &HashObject{Pairs: pairs, Class: hashClass}
 }
 
-func generateJSONFromPair(t *thread, key string, v Object) string {
+func generateJSONFromPair(key string, v Object) string {
 	var data string
-	var value string
 	var out bytes.Buffer
 
 	out.WriteString(data)
 	out.WriteString("\"" + key + "\"")
 	out.WriteString(":")
-
-	switch v := v.(type) {
-	case *StringObject:
-		value = "\"" + v.Value + "\""
-	case *IntegerObject:
-		value = v.Inspect()
-	case *BooleanObject:
-		value = v.Inspect()
-	case *NullObject:
-		value = "null"
-	case *HashObject:
-		value = v.generateJSON(t)
-	default:
-		t.returnError(fmt.Sprintf("Can't convert %T object into json.", v))
-	}
-	out.WriteString(value)
+	out.WriteString(v.toJSON())
 
 	return out.String()
 }
 
-func (h *HashObject) generateJSON(t *thread) string {
+func (h *HashObject) toJSON() string {
 	var out bytes.Buffer
 	var values []string
 	pairs := h.Pairs
 	out.WriteString("{")
 
 	for key, value := range pairs {
-		values = append(values, generateJSONFromPair(t, key, value))
+		values = append(values, generateJSONFromPair(key, value))
 	}
 
 	out.WriteString(strings.Join(values, ","))
@@ -97,7 +81,7 @@ var builtinHashInstanceMethods = []*BuiltInMethodObject{
 		Fn: func(receiver Object) builtinMethodBody {
 			return func(t *thread, args []Object, blockFrame *callFrame) Object {
 				r := receiver.(*HashObject)
-				return initializeString(r.generateJSON(t))
+				return initializeString(r.toJSON())
 			}
 		},
 	},

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -2,8 +2,8 @@ package vm
 
 import (
 	"encoding/json"
-	"testing"
 	"reflect"
+	"testing"
 )
 
 func TestHashToJSON(t *testing.T) {
@@ -12,13 +12,49 @@ func TestHashToJSON(t *testing.T) {
 		expected interface{}
 	}{
 		{`
+		{}.to_json
+		`, struct{}{}},
+		{`
 		{ a: 1, b: 2 }.to_json
 		`, struct {
 			A int `json:"a"`
 			B int `json:"b"`
 		}{
-			A: 1,
-			B: 2,
+			1,
+			2,
+		}},
+		{`
+		{ foo: "bar", b: 2 }.to_json
+		`, struct {
+			Foo string `json:"foo"`
+			B   int    `json:"b"`
+		}{
+			"bar",
+			2,
+		}},
+		{`
+		{ foo: "bar", b: 2, boolean: true }.to_json
+		`, struct {
+			Foo     string `json:"foo"`
+			B       int    `json:"b"`
+			Boolean bool   `json:"boolean"`
+		}{
+			"bar",
+			2,
+			true,
+		}},
+		{`
+		{ foo: "bar", b: 2, boolean: true, nothing: nil }.to_json
+		`, struct {
+			Foo     string `json:"foo"`
+			B       int    `json:"b"`
+			Boolean bool   `json:"boolean"`
+			Nothing interface{} `json:"nothing"`
+		}{
+			"bar",
+			2,
+			true,
+			nil,
 		}},
 	}
 

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -6,6 +6,43 @@ import (
 	"testing"
 )
 
+func TestHashToJSONWithArray(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`
+		{ a: 1, b: [1, "2", true]}.to_json
+		`, struct {
+			A int           `json:"a"`
+			B []interface{} `json:"b"`
+		}{
+			A: 1,
+			B: []interface{}{1, "2", true},
+		}},
+		{`
+		{ a: 1, b: [1, "2", [4, 5, nil], { foo: "bar" }]}.to_json
+		`, struct {
+			A int           `json:"a"`
+			B []interface{} `json:"b"`
+		}{
+			A: 1,
+			B: []interface{}{
+				1, "2", []interface{}{4, 5, nil}, struct {
+					Foo string `json:"foo"`
+				}{
+					"bar",
+				},
+			},
+		}},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(t, tt.input)
+		compareJSONResult(t, evaluated, tt.expected)
+	}
+}
+
 func TestHashToJSONWithNestedHash(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -29,6 +29,10 @@ func (i *IntegerObject) Inspect() string {
 	return strconv.Itoa(i.Value)
 }
 
+func (i *IntegerObject) toJSON() string {
+	return i.Inspect()
+}
+
 func (i *IntegerObject) returnClass() Class {
 	return i.Class
 }

--- a/vm/method.go
+++ b/vm/method.go
@@ -38,6 +38,10 @@ func (m *MethodObject) Inspect() string {
 	return out.String()
 }
 
+func (m *MethodObject) toJSON() string {
+	return m.Inspect()
+}
+
 func (m *MethodObject) returnClass() Class {
 	return m.class
 }
@@ -53,7 +57,11 @@ type BuiltInMethodObject struct {
 
 // Inspect just returns built in method's name.
 func (bim *BuiltInMethodObject) Inspect() string {
-	return bim.Name
+	return "<BuiltInMethod: " + bim.Name + ">"
+}
+
+func (bim *BuiltInMethodObject) toJSON() string {
+	return bim.Inspect()
 }
 
 func (bim *BuiltInMethodObject) returnClass() Class {

--- a/vm/null.go
+++ b/vm/null.go
@@ -21,6 +21,10 @@ func (n *NullObject) Inspect() string {
 	return ""
 }
 
+func (n *NullObject) toJSON() string {
+	return "null"
+}
+
 func (n *NullObject) returnClass() Class {
 	return n.Class
 }

--- a/vm/object.go
+++ b/vm/object.go
@@ -27,6 +27,7 @@ func initMainObj() {
 type Object interface {
 	returnClass() Class
 	Inspect() string
+	toJSON() string
 }
 
 // Pointer is used to point to an object. Variables should hold pointer instead of holding a object directly.
@@ -48,6 +49,10 @@ type RObject struct {
 // Inspect tells which class it belongs to.
 func (ro *RObject) Inspect() string {
 	return "<Instance of: " + ro.Class.Name + ">"
+}
+
+func (ro *RObject) toJSON() string {
+	return ro.Inspect()
 }
 
 // returnClass will return object's class

--- a/vm/string.go
+++ b/vm/string.go
@@ -27,6 +27,10 @@ func (s *StringObject) Inspect() string {
 	return s.Value
 }
 
+func (s *StringObject) toJSON() string {
+	return "\"" + s.Value + "\""
+}
+
 func (s *StringObject) returnClass() Class {
 	if s.Class == nil {
 		panic(fmt.Sprintf("String %s doesn't have class.", s.Inspect()))


### PR DESCRIPTION
This is the fix for wrong rebasing on #155. Sorry. 
See https://github.com/goby-lang/goby/pull/155 for the review history.

Note that I left the following blank lines because they need just for generating HTML on API doc: they would be shown as `-point -point -point -point` on HTML if no blank lines are added.

```diff
+		// - "file"
+		//
+		// - "net/http"
+		//
+		// - "net/simple_server"
+		//
+		// - "uri"
```