### PR TITLE
Remove parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,37 +80,6 @@ It will have Ruby's syntax (I'll try to support all common syntaxes) but without
     
 **(You can open an issue for any feature request)**
 
-### Something different from Ruby
-
-#### Method call syntax
-For now, all method call needs to use parentheses to wrap their arguments. Including methods like `require`, `include` which we normally won't do this.
-
-It'll look like:
-
-```ruby
-require("foo")
-
-class Bar
-  include(Foo)
-end
-```
-
-There's two reason for this:
-
-##### I want to make Goby's syntax more consistent than Ruby
-In Ruby you can write most of things in many different ways, and that can cause some confusion so we need style guide(s) to tell programmers write code consistently.
-
-But in some programming languages like go, the syntax is very limited which in sometimes is very verbose, but this also makes program more easy to understand and maintain.
-
-##### This requires a parser generator
-
-Since our parser is handcrafted, supporting this feature would be hard and can easily cause bugs on some edge cases.
-
-Although we definitely will replace current parser with a parser generator, this is not our top priority now.
-
-
-**If you have any thought on this, please join our discussion in [this issue](https://github.com/goby-lang/goby/issues/84). We would love to hear some user's feedback 😁**
-
 ## Install
 
 

--- a/parser/base_helper.go
+++ b/parser/base_helper.go
@@ -10,7 +10,7 @@ func (p *Parser) peekPrecedence() int {
 		return p
 	}
 
-	return LOWEST
+	return NORMAL
 }
 
 func (p *Parser) curPrecedence() int {
@@ -18,7 +18,7 @@ func (p *Parser) curPrecedence() int {
 		return p
 	}
 
-	return LOWEST
+	return NORMAL
 }
 
 func (p *Parser) nextToken() {

--- a/parser/expression_parsing.go
+++ b/parser/expression_parsing.go
@@ -20,11 +20,11 @@ var argument = map[token.Type]bool{
 var precedence = map[token.Type]int{
 	token.Eq:                 EQUALS,
 	token.NotEq:              EQUALS,
-	token.LT:                 LESSGREATER,
-	token.LTE:                LESSGREATER,
-	token.GT:                 LESSGREATER,
-	token.GTE:                LESSGREATER,
-	token.COMP:               LESSGREATER,
+	token.LT:                 COMPARE,
+	token.LTE:                COMPARE,
+	token.GT:                 COMPARE,
+	token.GTE:                COMPARE,
+	token.COMP:               COMPARE,
 	token.And:                LOGIC,
 	token.Or:                 LOGIC,
 	token.Plus:               SUM,
@@ -45,11 +45,11 @@ var precedence = map[token.Type]int{
 // Constants for denoting precedence
 const (
 	_ int = iota
-	FIRST
 	LOWEST
+	NORMAL
 	LOGIC
 	EQUALS
-	LESSGREATER
+	COMPARE
 	ASSIGN
 	SUM
 	PRODUCT
@@ -71,9 +71,9 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	}
 
 	leftExp := prefix()
-	// I use precedence "FIRST" to identify call_without_parens case, this is not an appropriate way but it work in current situation
+	// I use precedence "LOWEST" to identify call_without_parens case, this is not an appropriate way but it work in current situation
 
-	if argument[p.peekToken.Type] && precedence == FIRST {
+	if argument[p.peekToken.Type] && precedence == LOWEST {
 		infix := p.parseCallExpression
 		p.nextToken()
 		leftExp = infix(leftExp)
@@ -207,7 +207,7 @@ func (p *Parser) parseHashPair(pairs map[string]ast.Expression) {
 	}
 
 	p.nextToken()
-	value = p.parseExpression(LOWEST)
+	value = p.parseExpression(NORMAL)
 	pairs[key] = value
 }
 
@@ -226,7 +226,7 @@ func (p *Parser) parseArrayIndexExpression(left ast.Expression) ast.Expression {
 
 	p.nextToken()
 
-	callExpression.Arguments = []ast.Expression{p.parseExpression(LOWEST)}
+	callExpression.Arguments = []ast.Expression{p.parseExpression(NORMAL)}
 
 	if !p.expectPeek(token.RBracket) {
 		return nil
@@ -236,7 +236,7 @@ func (p *Parser) parseArrayIndexExpression(left ast.Expression) ast.Expression {
 	if p.peekTokenIs(token.Assign) {
 		p.nextToken()
 		p.nextToken()
-		assignValue := p.parseExpression(LOWEST)
+		assignValue := p.parseExpression(NORMAL)
 		callExpression.Method = "[]="
 		callExpression.Arguments = append(callExpression.Arguments, assignValue)
 	}
@@ -253,12 +253,12 @@ func (p *Parser) parseArrayElements() []ast.Expression {
 	}
 
 	p.nextToken() // start of first expression
-	elems = append(elems, p.parseExpression(LOWEST))
+	elems = append(elems, p.parseExpression(NORMAL))
 
 	for p.peekTokenIs(token.Comma) {
 		p.nextToken() // ","
 		p.nextToken() // start of next expression
-		elems = append(elems, p.parseExpression(LOWEST))
+		elems = append(elems, p.parseExpression(NORMAL))
 	}
 
 	if !p.expectPeek(token.RBracket) {
@@ -298,7 +298,7 @@ func (p *Parser) parseInfixExpression(left ast.Expression) ast.Expression {
 func (p *Parser) parseGroupedExpression() ast.Expression {
 	p.nextToken()
 
-	exp := p.parseExpression(LOWEST)
+	exp := p.parseExpression(NORMAL)
 
 	if !p.expectPeek(token.RParen) {
 		return nil
@@ -310,7 +310,7 @@ func (p *Parser) parseGroupedExpression() ast.Expression {
 func (p *Parser) parseIfExpression() ast.Expression {
 	ie := &ast.IfExpression{Token: p.curToken}
 	p.nextToken()
-	ie.Condition = p.parseExpression(LOWEST)
+	ie.Condition = p.parseExpression(NORMAL)
 	ie.Consequence = p.parseBlockStatement()
 
 	// curToken is now ELSE or RBRACE
@@ -371,7 +371,7 @@ func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 		exp.Method = exp.Method + "="
 		p.nextToken()
 		p.nextToken()
-		exp.Arguments = append(exp.Arguments, p.parseExpression(LOWEST))
+		exp.Arguments = append(exp.Arguments, p.parseExpression(NORMAL))
 	}
 
 	// Parse block
@@ -421,12 +421,12 @@ func (p *Parser) parseCallArguments() []ast.Expression {
 	}
 
 	p.nextToken() // start of first expression
-	args = append(args, p.parseExpression(LOWEST))
+	args = append(args, p.parseExpression(NORMAL))
 
 	for p.peekTokenIs(token.Comma) {
 		p.nextToken() // ","
 		p.nextToken() // start of next expression
-		args = append(args, p.parseExpression(LOWEST))
+		args = append(args, p.parseExpression(NORMAL))
 	}
 
 	if !p.expectPeek(token.RParen) {
@@ -439,12 +439,12 @@ func (p *Parser) parseCallArguments() []ast.Expression {
 func (p *Parser) parseCallArgumentsWithoutParensDot() []ast.Expression {
 	args := []ast.Expression{}
 
-	args = append(args, p.parseExpression(LOWEST))
+	args = append(args, p.parseExpression(NORMAL))
 
 	for p.peekTokenIs(token.Comma) {
 		p.nextToken() // ","
 		p.nextToken() // start of next expression
-		args = append(args, p.parseExpression(LOWEST))
+		args = append(args, p.parseExpression(NORMAL))
 	}
 
 	if p.peekTokenAtSameLine() {
@@ -456,12 +456,12 @@ func (p *Parser) parseCallArgumentsWithoutParensDot() []ast.Expression {
 func (p *Parser) parseCallArgumentsWithoutParens() []ast.Expression {
 	args := []ast.Expression{}
 
-	args = append(args, p.parseExpression(LOWEST))
+	args = append(args, p.parseExpression(NORMAL))
 
 	for p.peekTokenIs(token.Comma) {
 		p.nextToken() // ","
 		p.nextToken() // start of next expression
-		args = append(args, p.parseExpression(LOWEST))
+		args = append(args, p.parseExpression(NORMAL))
 	}
 
 	if p.peekTokenAtSameLine() {

--- a/parser/expression_parsing.go
+++ b/parser/expression_parsing.go
@@ -8,13 +8,15 @@ import (
 	"github.com/goby-lang/goby/token"
 )
 
-var argument = map[token.Type]bool{
+var arguments = map[token.Type]bool{
 	token.Int:              true,
 	token.String:           true,
 	token.True:             true,
 	token.False:            true,
+	token.Null:             true,
 	token.InstanceVariable: true,
 	token.Ident:            true,
+	token.Constant:         true,
 }
 
 var precedence = map[token.Type]int{
@@ -73,7 +75,7 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	leftExp := prefix()
 	// I use precedence "LOWEST" to identify call_without_parens case, this is not an appropriate way but it work in current situation
 
-	if argument[p.peekToken.Type] && precedence == LOWEST {
+	if arguments[p.peekToken.Type] && precedence == LOWEST {
 		infix := p.parseCallExpression
 		p.nextToken()
 		leftExp = infix(leftExp)
@@ -324,7 +326,7 @@ func (p *Parser) parseIfExpression() ast.Expression {
 func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 	var exp *ast.CallExpression
 
-	if p.curTokenIs(token.LParen) || argument[p.curToken.Type] {
+	if p.curTokenIs(token.LParen) || arguments[p.curToken.Type] {
 
 		m := receiver.(*ast.Identifier).Value
 		// receiver is self
@@ -360,7 +362,7 @@ func (p *Parser) parseCallExpression(receiver ast.Expression) ast.Expression {
 
 			exp.Arguments = []ast.Expression{}
 
-		} else if argument[p.peekToken.Type] && p.peekTokenAtSameLine() { //p.foo x, y, z || p.foo x
+		} else if arguments[p.peekToken.Type] && p.peekTokenAtSameLine() { //p.foo x, y, z || p.foo x
 			p.nextToken()
 			exp.Arguments = p.parseCallArgumentsWithoutParensDot()
 		}

--- a/parser/statement_parsing.go
+++ b/parser/statement_parsing.go
@@ -98,7 +98,7 @@ func (p *Parser) parseClassStatement() *ast.ClassStatement {
 	if p.peekTokenIs(token.LT) {
 		p.nextToken() // <
 		p.nextToken() // Inherited class like 'Bar'
-		stmt.SuperClass = p.parseExpression(LOWEST)
+		stmt.SuperClass = p.parseExpression(NORMAL)
 
 		switch exp := stmt.SuperClass.(type) {
 		case *ast.InfixExpression:
@@ -184,7 +184,7 @@ func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 
 	p.nextToken()
 
-	stmt.ReturnValue = p.parseExpression(LOWEST)
+	stmt.ReturnValue = p.parseExpression(NORMAL)
 
 	if p.peekTokenIs(token.Semicolon) {
 		p.nextToken()
@@ -198,9 +198,9 @@ func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 
 	if p.curTokenIs(token.Ident) {
 		// I use precedence to identify call_without_parens case, this is not an appropriate way but it work in current situation
-		stmt.Expression = p.parseExpression(FIRST)
-	} else {
 		stmt.Expression = p.parseExpression(LOWEST)
+	} else {
+		stmt.Expression = p.parseExpression(NORMAL)
 	}
 
 	if p.peekTokenIs(token.Semicolon) {
@@ -240,7 +240,7 @@ func (p *Parser) parseWhileStatement() *ast.WhileStatement {
 	p.nextToken()
 	// Prevent expression's method call to consume while's block as argument.
 	p.acceptBlock = false
-	ws.Condition = p.parseExpression(LOWEST)
+	ws.Condition = p.parseExpression(NORMAL)
 	p.acceptBlock = true
 	p.nextToken()
 

--- a/samples/blocking_server.gb
+++ b/samples/blocking_server.gb
@@ -1,6 +1,6 @@
 # Run: ab -n 10000 -c 100 http://localhost:3000/
 
-require("net/simple_server")
+require "net/simple_server"
 
 server = Net::SimpleServer.new("3000")
 

--- a/samples/file_lib/file.gb
+++ b/samples/file_lib/file.gb
@@ -1,4 +1,4 @@
-require("file")
+require "file"
 
 puts(File.extname("test.gb"))
 puts(File.split("/home/goby/test.sh"))

--- a/samples/http.gb
+++ b/samples/http.gb
@@ -1,4 +1,4 @@
-require("net/http")
+require "net/http"
 
 puts(Net::HTTP.get("http://google.com"))
 

--- a/samples/module.gb
+++ b/samples/module.gb
@@ -15,7 +15,7 @@ class Baz
 end
 
 class Bar < Baz
-  include(Foo)
+  include Foo
 end
 
 b = Bar.new

--- a/samples/server.gb
+++ b/samples/server.gb
@@ -1,4 +1,4 @@
-require("net/simple_server")
+require "net/simple_server"
 
 server = Net::SimpleServer.new("3000")
 

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -325,7 +325,7 @@ func TestNamespace(t *testing.T) {
 
 func TestRequireSuccess(t *testing.T) {
 	input := `
-	require("file")
+	require "file"
 
 	File.extname("foo.rb")
 	`
@@ -341,7 +341,7 @@ func TestRequireSuccess(t *testing.T) {
 
 func TestRequireFail(t *testing.T) {
 	input := `
-	require("bar")
+	require "bar"
 	`
 	expected := `Can't require "bar"`
 

--- a/vm/file_test.go
+++ b/vm/file_test.go
@@ -10,7 +10,7 @@ func TestFileDeletion(t *testing.T) {
 		expected interface{}
 	}{
 		{`
-		require("file")
+		require "file"
 
 		File.open("/tmp/out1.txt", "w", 0755)
 		File.open("/tmp/out2.txt", "w", 0755)
@@ -19,7 +19,7 @@ func TestFileDeletion(t *testing.T) {
 		File.delete("/tmp/out1.txt", "/tmp/out2.txt", "/tmp/out3.txt")
 		`, 3},
 		{`
-		require("file")
+		require "file"
 
 		File.open("/tmp/out.txt", "w", 0755)
 		File.delete("/tmp/out.txt")
@@ -39,7 +39,7 @@ func TestFileWrite(t *testing.T) {
 		expected interface{}
 	}{
 		{`
-		require("file")
+		require "file"
 
 		l = 0
 		File.open("/tmp/out.txt", "w", 0755) do |f|
@@ -49,7 +49,7 @@ func TestFileWrite(t *testing.T) {
 		l
 		`, 5},
 		{`
-		require("file")
+		require "file"
 
 		File.open("/tmp/out.txt", "w", 0755) do |f|
 		  f.write("Goby is awesome!!!")
@@ -58,13 +58,13 @@ func TestFileWrite(t *testing.T) {
 		File.new("/tmp/out.txt").read
 		`, "Goby is awesome!!!"},
 		{`
-		require("file")
+		require "file"
 
 		File.open("/tmp/out.txt", "w", 0755)
 		File.new("/tmp/out.txt").size
 		`, 0},
 		{`
-		require("file")
+		require "file"
 
 		File.open("/tmp/out.txt", "w", 0755)
 		File.exist("/tmp/out.txt")
@@ -84,31 +84,31 @@ func TestFileObject(t *testing.T) {
 		expected interface{}
 	}{
 		{`
-		require("file")
+		require "file"
 
 		f = File.new("../test_fixtures/file_test/size.gb")
 		f.name
 		`, "../test_fixtures/file_test/size.gb"},
 		{`
-		require("file")
+		require "file"
 
 		f = File.new("../test_fixtures/file_test/size.gb")
 		f.size
 		`, 22},
 		{`
-		require("file")
+		require "file"
 
 		f = File.new("../test_fixtures/file_test/size.gb")
 		f.close
 		`, nil},
 		{`
-		require("file")
+		require "file"
 
 		f = File.new("../test_fixtures/file_test/size.gb")
 		f.read
 		`, "this file's size is\n22"},
 		{`
-		require("file")
+		require "file"
 
 		file = ""
 		File.open("../test_fixtures/file_test/size.gb", "r", 0755) do |f|
@@ -130,11 +130,11 @@ func TestExtnameMethod(t *testing.T) {
 		expected string
 	}{
 		{`
-		require("file")
+		require "file"
 		File.extname("loop.gb")
 		`, ".gb"},
 		{`
-		require("file")
+		require "file"
 		File.extname("text.txt")
 		`, ".txt"},
 	}
@@ -151,7 +151,7 @@ func TestBasenameMethod(t *testing.T) {
 		expected string
 	}{
 		{`
-		require("file")
+		require "file"
 		File.basename("/home/goby/plugin/test.gb")
 		`, "test.gb"},
 	}
@@ -168,7 +168,7 @@ func TestSplitMethod(t *testing.T) {
 		expected *ArrayObject
 	}{
 		{`
-		require("file")
+		require "file"
 		File.split("/home/goby/plugin/test.gb")
 		`, initializeArray([]Object{initializeString("/home/goby/plugin/"), initializeString("test.gb")})},
 	}
@@ -185,15 +185,15 @@ func TestJoinMethod(t *testing.T) {
 		expected string
 	}{
 		{`
-		require("file")
+		require "file"
 		File.join("test1", "test2", "test3")
 		`, "test1/test2/test3"},
 		{`
-		require("file")
+		require "file"
 		File.join("goby", "plugin")
 		`, "goby/plugin"},
 		{`
-		require("file")
+		require "file"
 		File.join("plugin")
 		`, "plugin"},
 	}
@@ -206,7 +206,7 @@ func TestJoinMethod(t *testing.T) {
 
 func TestSizeMethod(t *testing.T) {
 	input := `
-	require("file")
+	require "file"
 
 	File.size("../test_fixtures/file_test/size.gb")
 	`

--- a/vm/http_test.go
+++ b/vm/http_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestHTTPResponse(t *testing.T) {
 	script := `
-	require("net/http")
+	require "net/http"
 
 	res = Net::HTTP::Response.new
 
@@ -32,7 +32,7 @@ func TestNormalGet(t *testing.T) {
 	defer ts.Close()
 
 	testScript := fmt.Sprintf(`
-require("net/http")
+require "net/http"
 
 Net::HTTP.get("%s")
 `, ts.URL)
@@ -55,7 +55,7 @@ func TestNormalGetWithPath(t *testing.T) {
 	defer ts.Close()
 
 	testScript := fmt.Sprintf(`
-require("net/http")
+require "net/http"
 
 Net::HTTP.get("%s", "path")
 `, ts.URL)

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -133,7 +133,7 @@ func TestModuleStatement(t *testing.T) {
 		end
 
 		class Foo
-		  include(Bar)
+		  include Bar
 		end
 
 		Foo.new.bar
@@ -156,7 +156,7 @@ func TestModuleStatement(t *testing.T) {
 			end
 
 			class Bar < Baz
-			  include(Foo)
+			  include Foo
 			end
 
 			b = Bar.new

--- a/vm/uri_test.go
+++ b/vm/uri_test.go
@@ -9,73 +9,73 @@ func TestURIParsing(t *testing.T) {
 	}{
 		// Scheme
 		{`
-		require("uri")
+		require "uri"
 
 		u = URI.parse("http://example.com")
 		u.scheme
 		`, "http"},
 		{`
-		require("uri")
+		require "uri"
 
 		u = URI.parse("https://example.com")
 		u.scheme
 		`, "https"},
 		// Host
 		{`
-		require("uri")
+		require "uri"
 
 		u = URI.parse("http://example.com")
 		u.host
 		`, "example.com"},
 		// Port
 		{`
-		require("uri")
+		require "uri"
 
 		u = URI.parse("http://example.com")
 		u.port
 		`, 80},
 		{`
-		require("uri")
+		require "uri"
 
 		u = URI.parse("https://example.com")
 		u.port
 		`, 443},
 		// Path
 		{`
-		require("uri")
+		require "uri"
 
 		u = URI.parse("https://example.com/posts/1")
 		u.path
 		`, "/posts/1"},
 		{`
-		require("uri")
+		require "uri"
 
 		u = URI.parse("https://example.com")
 		u.path
 		`, "/"},
 		// Query
 		{`
-		require("uri")
+		require "uri"
 
 		u = URI.parse("https://example.com?foo=bar&a=b")
 		u.query
 		`, "foo=bar&a=b"},
 		{`
-		require("uri")
+		require "uri"
 
 		u = URI.parse("https://example.com")
 		u.query
 		`, nil},
 		// User
 		{`
-		require("uri")
+		require "uri"
 
 		u = URI.parse("https://example.com?foo=bar&a=b")
 		u.user
 		`, nil},
 		// Password
 		{`
-		require("uri")
+		require "uri"
 
 		u = URI.parse("https://example.com")
 		u.password


### PR DESCRIPTION
Thanks to @shes50103 we can call methods without wrapping parens on arguments. So this PR is to remove unusual paren wrappings (like `require("foo")` or `include(Bar)` in test cases and sample files.