### PR TITLE
Hash to json

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ It will have Ruby's syntax (I'll try to support all common syntaxes) but without
     - String
     - Boolean
     - nil
-    - Hash
+    - Hash (with built in `to_json` method)
     - Array
 - Flow control
     - If statement

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -77,6 +77,14 @@ func (h *HashObject) toJSON() string {
 
 var builtinHashInstanceMethods = []*BuiltInMethodObject{
 	{
+		// Returns json that is corresponding to the hash.
+		// Basically just like Hash#to_json in Rails but currently doesn't support options.
+		//
+		// ```Ruby
+		// h = { a: 1, b: [1, "2", [4, 5, nil], { foo: "bar" }]}.to_json
+		// puts(h) #=> {"a":1,"b":[1, "2", [4, 5, null], {"foo":"bar"}]}
+		// ```
+		// @return [String]
 		Name: "to_json",
 		Fn: func(receiver Object) builtinMethodBody {
 			return func(t *thread, args []Object, blockFrame *callFrame) Object {


### PR DESCRIPTION
Just like `Hash#to_json` in Rails, example:
```ruby
h = { a: 1, b: [1, "2", [4, 5, nil], { foo: "bar" }]}.to_json
puts(h) #=> {"a":1,"b":[1, "2", [4, 5, null], {"foo":"bar"}]}
```