### PR TITLE
Symbol

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -129,6 +129,7 @@ func (l *Lexer) NextToken() token.Token {
 		l.FSM.Event("method")
 	case ':':
 		if l.FSM.Is("nosymbol") {
+			//e.g. {test: abc} || {test: :abc} || {test: 50}
 
 			tok = newToken(token.Colon, l.ch, l.line)
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -128,7 +128,13 @@ func (l *Lexer) NextToken() token.Token {
 		if l.peekChar() == ':' {
 			l.readChar()
 			tok = token.Token{Type: token.ResolutionOperator, Literal: "::", Line: l.line}
+		} else if isLetter(l.peekChar()) {
+			tok.Literal = l.readSymbol()
+			tok.Type = token.String
+			tok.Line = l.line
+			return tok
 		} else {
+
 			tok = newToken(token.Colon, l.ch, l.line)
 		}
 	case '|':
@@ -268,6 +274,25 @@ func (l *Lexer) readString(ch byte) string {
 	l.readChar()                           // currently at string's last letter
 	result := l.input[position:l.position] // get full string
 	l.readChar()                           // move to string's later quote
+	return result
+}
+
+
+func (l *Lexer) readSymbol() string {
+	l.readChar()
+
+	position := l.position // currently at string's first letter
+
+	for !(l.peekChar() == ' ' || l.peekChar() == '\n' || l.peekChar() == '\r' || l.peekChar() == '\t') {
+		l.readChar()
+
+		if l.peekChar() == 0 {
+			panic("Unterminated string meets end of file")
+		}
+	}
+
+	l.readChar()                           // currently at string's last letter
+	result := l.input[position:l.position] // get full string
 	return result
 }
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -253,7 +253,8 @@ func (l *Lexer) resetNosymbol() {
 	//if l.ch != ':' &&
 	fmt.Println("resetNosymbol=>",l.FSM.Current())
 
-	if !l.FSM.Is("method")  {
+	if !l.FSM.Is("method") && l.ch != ':'
+	{
 			l.FSM.Event("initialize")
 
 	}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -3,7 +3,6 @@ package lexer
 import (
 	"github.com/goby-lang/goby/token"
 	"github.com/looplab/fsm"
-	"fmt"
 )
 
 // Lexer is used for tokenizing programs
@@ -25,7 +24,7 @@ func New(input string) *Lexer {
 		fsm.Events{
 			{Name: "nosymbol", Src: []string{"initial"}, Dst: "nosymbol"},
 			{Name: "method", Src: []string{"initial"}, Dst: "method"},
-			{Name: "initialize", Src: []string{"method", "initial","nosymbol"}, Dst: "initial"},
+			{Name: "initialize", Src: []string{"method", "initial", "nosymbol"}, Dst: "initial"},
 		},
 		fsm.Callbacks{},
 	)
@@ -36,8 +35,9 @@ func New(input string) *Lexer {
 func (l *Lexer) NextToken() token.Token {
 
 	var tok token.Token
-	l.skipWhitespace()
 	l.resetNosymbol()
+
+	l.skipWhitespace()
 	switch l.ch {
 	case '"', byte('\''):
 		tok.Literal = l.readString(l.ch)
@@ -128,15 +128,16 @@ func (l *Lexer) NextToken() token.Token {
 		tok = newToken(token.Dot, l.ch, l.line)
 		l.FSM.Event("method")
 	case ':':
-		if l.FSM.Is("nosymbol"){
+		if l.FSM.Is("nosymbol") {
+
 			tok = newToken(token.Colon, l.ch, l.line)
 
 		} else {
-			if  l.peekChar() == ':'{
+			if l.peekChar() == ':' {
 				l.readChar()
 				tok = token.Token{Type: token.ResolutionOperator, Literal: "::", Line: l.line}
 
-			} else if isLetter(l.peekChar()){
+			} else if isLetter(l.peekChar()) {
 				tok.Literal = l.readSymbol()
 				tok.Type = token.String
 				tok.Line = l.line
@@ -144,24 +145,8 @@ func (l *Lexer) NextToken() token.Token {
 
 			} else {
 				tok = newToken(token.Colon, l.ch, l.line)
-
-
 			}
 		}
-
-		//if l.peekChar() == ':' {
-		//	l.readChar()
-		//	tok = token.Token{Type: token.ResolutionOperator, Literal: "::", Line: l.line}
-		//} else if isLetter(l.peekChar()) && l.FSM.Is("initial") {
-		//	//fmt.Println("a=>",l.FSM.Current())
-		//	tok.Literal = l.readSymbol()
-		//	tok.Type = token.String
-		//	tok.Line = l.line
-		//	return tok
-		//} else {
-		//	//fmt.Println("b=>",l.FSM.Current())
-		//	tok = newToken(token.Colon, l.ch, l.line)
-		//}
 	case '|':
 		if l.peekChar() == '|' {
 			l.readChar()
@@ -213,7 +198,6 @@ func (l *Lexer) NextToken() token.Token {
 				tok.Line = l.line
 			}
 			if tok.Type == token.Ident {
-				fmt.Println("=>",l.FSM.Current())
 				l.FSM.Event("nosymbol")
 			}
 			return tok
@@ -250,12 +234,9 @@ func (l *Lexer) skipWhitespace() {
 }
 
 func (l *Lexer) resetNosymbol() {
-	//if l.ch != ':' &&
-	fmt.Println("resetNosymbol=>",l.FSM.Current())
 
-	if !l.FSM.Is("method") && l.ch != ':'
-	{
-			l.FSM.Event("initialize")
+	if !l.FSM.Is("method") && l.ch != ':' {
+		l.FSM.Event("initialize")
 
 	}
 
@@ -318,13 +299,12 @@ func (l *Lexer) readString(ch byte) string {
 	return result
 }
 
-
 func (l *Lexer) readSymbol() string {
 	l.readChar()
 
 	position := l.position // currently at string's first letter
 
-	for !(l.peekChar() == ' ' || l.peekChar() == '\n' || l.peekChar() == '\r' || l.peekChar() == '\t'|| l.peekChar() == ',') {
+	for !(l.peekChar() == ' ' || l.peekChar() == '\n' || l.peekChar() == '\r' || l.peekChar() == '\t' || l.peekChar() == ',') {
 		l.readChar()
 
 		if l.peekChar() == 0 {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -99,11 +99,11 @@ func TestNextToken(t *testing.T) {
 
 	next
 	:apple
-	{ test: "abc" }
+	{ test:"abc" }
 	{ test: :abc }
-	{ test: 50 }
+	{ test:50 }
 	{ test: abc }
-	{ test: abc }
+	{ test:abc }
 	`
 
 	tests := []struct {
@@ -394,7 +394,7 @@ func TestNextToken(t *testing.T) {
 
 		}
 		if tok.Line != tt.expectedLine {
-			t.Fatalf("tests[%d] - line number wrong. expected=%d, got=%d got=%q", i, tt.expectedLine, tok.Line,  tok.Literal)
+			t.Fatalf("tests[%d] - line number wrong. expected=%d, got=%d got=%q", i, tt.expectedLine, tok.Line, tok.Literal)
 		}
 	}
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -103,6 +103,7 @@ func TestNextToken(t *testing.T) {
 	{ test: :abc }
 	{ test: 50 }
 	{ test: abc }
+	{ test: abc }
 	`
 
 	tests := []struct {
@@ -372,7 +373,13 @@ func TestNextToken(t *testing.T) {
 		{token.Ident, "abc", 96},
 		{token.RBrace, "}", 96},
 
-		{token.EOF, "", 97},
+		{token.LBrace, "{", 97},
+		{token.Ident, "test", 97},
+		{token.Colon, ":", 97},
+		{token.Ident, "abc", 97},
+		{token.RBrace, "}", 97},
+
+		{token.EOF, "", 98},
 	}
 	l := New(input)
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -98,6 +98,11 @@ func TestNextToken(t *testing.T) {
 	''
 
 	next
+	:apple
+	{ test: "abc" }
+	{ test: :abc }
+	{ test: 50 }
+	{ test: abc }
 	`
 
 	tests := []struct {
@@ -341,7 +346,33 @@ func TestNextToken(t *testing.T) {
 		{token.String, "", 89},
 
 		{token.Next, "next", 91},
-		{token.EOF, "", 92},
+		{token.String, "apple", 92},
+
+		{token.LBrace, "{", 93},
+		{token.Ident, "test", 93},
+		{token.Colon, ":", 93},
+		{token.String, "abc", 93},
+		{token.RBrace, "}", 93},
+
+		{token.LBrace, "{", 94},
+		{token.Ident, "test", 94},
+		{token.Colon, ":", 94},
+		{token.String, "abc", 94},
+		{token.RBrace, "}", 94},
+
+		{token.LBrace, "{", 95},
+		{token.Ident, "test", 95},
+		{token.Colon, ":", 95},
+		{token.Int, "50", 95},
+		{token.RBrace, "}", 95},
+
+		{token.LBrace, "{", 96},
+		{token.Ident, "test", 96},
+		{token.Colon, ":", 96},
+		{token.Ident, "abc", 96},
+		{token.RBrace, "}", 96},
+
+		{token.EOF, "", 97},
 	}
 	l := New(input)
 
@@ -356,7 +387,7 @@ func TestNextToken(t *testing.T) {
 
 		}
 		if tok.Line != tt.expectedLine {
-			t.Fatalf("tests[%d] - line number wrong. expected=%d, got=%d", i, tt.expectedLine, tok.Line)
+			t.Fatalf("tests[%d] - line number wrong. expected=%d, got=%d got=%q", i, tt.expectedLine, tok.Line,  tok.Literal)
 		}
 	}
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -394,7 +394,7 @@ func TestNextToken(t *testing.T) {
 
 		}
 		if tok.Line != tt.expectedLine {
-			t.Fatalf("tests[%d] - line number wrong. expected=%d, got=%d got=%q", i, tt.expectedLine, tok.Line, tok.Literal)
+			t.Fatalf("tests[%d] - line number wrong. expected=%d, got=%d", i, tt.expectedLine, tok.Line)
 		}
 	}
 }

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -989,7 +989,7 @@ func TestMethodCallWithoutParens(t *testing.T) {
 		{
 			`
 			class Foo
-			  attr_reader("x", "y")
+			  attr_reader :x, :y
 
 			  def set_x x1, x2, x3
 			    @x = x1 + x2 + x3


### PR DESCRIPTION
- Support Symbol token in lexer
- Identify ":" is a mark of symbol or just a Colon

Following is support syntax:

```
:apple
{ test:"abc" }
{ test: :abc }
{ test: 50 }
{ test: abc }
{ test:abc }
```
Not  support this syntax:
```
{ test::abc }
```
Now you can write Goby like this
```
attr_reader :x, :y
```