### PR TITLE
Add sleep to test.sh to avoid 'connection refused' error on apache bench

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
+SLEEP=0.5
+
 set -e
 echo "" > coverage.txt
 
+rm -f profile.out
 for d in $(go list ./... | grep -v vendor); do
     go test -race -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
@@ -16,6 +19,7 @@ done
 # TODO: Write a test for this specific case
 go install .
 goby test_fixtures/server.gb & PID=$!
+echo "Sleeping $SLEEP sec for waiting server.gb being ready..."; sleep $SLEEP
 
 ab -n 3000 -c 100 http://localhost:3000/
 

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,6 @@ SLEEP=0.5
 set -e
 echo "" > coverage.txt
 
-rm -f profile.out
 for d in $(go list ./... | grep -v vendor); do
     go test -race -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
@@ -19,7 +18,7 @@ done
 # TODO: Write a test for this specific case
 go install .
 goby test_fixtures/server.gb & PID=$!
-echo "Sleeping $SLEEP sec for waiting server.gb being ready..."; sleep $SLEEP
+echo "Sleeping for $SLEEP sec to wait server.gb being ready..."; sleep $SLEEP
 
 ab -n 3000 -c 100 http://localhost:3000/
 


### PR DESCRIPTION
Just to avoid the following error that occurs occasionally on local `make test`:

> Benchmarking localhost (be patient)
apr_socket_recv: Connection refused (61)
make: *** [test] Error 61
2017/06/18 18:34:16 SimpleServer start listening on port: 3000
^C2017/06/18 18:34:31 SimpleServer gracefully stopped