### PR TITLE
Add `$GOBY_ROOT` instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ It will have Ruby's syntax (I'll try to support all common syntaxes) but without
 
 ## Install
 
+## Setup `$GOBY_ROOT`
+
+Goby requires environment variable `$GOBY_ROOT` for installing libraries. Add the following line to your shell config file, either `~/.bashrc`, `~/.bash_profile`, or `~/.zshrc` if you're using zsh.
+
+```
+export GOBY_ROOT=/usr/local/goby
+```
+
+You can set any path as your `$GOBY_ROOT`.
+
+The most common messages you'll see if you do not set `$GOBY_ROOT` are 'library not found'. For example:
+
+```ruby
+require 'net/http' 
+# => Internal Error: open lib/net/http/response.gb: no such file or directory
+```
 
 ### From Source
 
@@ -98,6 +114,8 @@ It will have Ruby's syntax (I'll try to support all common syntaxes) but without
 ```
 $ go get github.com/goby-lang/goby
 ```
+
+5. Run `goby -v` to verify.
 
 ### Via homebrew
 

--- a/goby.go
+++ b/goby.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version stores current Goby version
-const Version string = "0.0.1"
+const Version string = "0.0.6"
 
 func main() {
 	compileOptionPtr := flag.Bool("c", false, "Compile to bytecode")


### PR DESCRIPTION
I've moved instruction to [wiki](https://github.com/goby-lang/goby/wiki/Installation) since this section is getting longer. I also update the version number to align with the version on brew.