### PR TITLE
Refactor vm

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -83,12 +83,12 @@ func (a *ArrayObject) shift() Object {
 	return value
 }
 
-// initializeArray returns an array that contains given objects
-func initializeArray(elements []Object) *ArrayObject {
+// initArrayObject returns an array that contains given objects
+func initArrayObject(elements []Object) *ArrayObject {
 	return &ArrayObject{Elements: elements, Class: arrayClass}
 }
 
-func initArray() {
+func initArrayClass() {
 	bc := &BaseClass{Name: "Array", ClassMethods: newEnvironment(), Methods: newEnvironment(), Class: classClass, pseudoSuperClass: objectClass, superClass: objectClass}
 	ac := &RArray{BaseClass: bc}
 	ac.setBuiltInMethods(builtinArrayInstanceMethods, false)
@@ -327,7 +327,7 @@ var builtinArrayInstanceMethods = []*BuiltInMethodObject{
 					elements[i] = result.Target
 				}
 
-				return initializeArray(elements)
+				return initArrayObject(elements)
 			}
 		},
 	},
@@ -360,7 +360,7 @@ var builtinArrayInstanceMethods = []*BuiltInMethodObject{
 					}
 				}
 
-				return initializeArray(elements)
+				return initArrayObject(elements)
 			}
 		},
 	},
@@ -463,7 +463,7 @@ var builtinArrayInstanceMethods = []*BuiltInMethodObject{
 				var count int
 
 				if len(args) > 1 {
-					return initializeError(ArgumentErrorClass, "Expect 1 argument, got=%v", len(args))
+					return initErrorObject(ArgumentErrorClass, "Expect 1 argument, got=%v", len(args))
 				}
 
 				if blockFrame != nil {
@@ -526,7 +526,7 @@ var builtinArrayInstanceMethods = []*BuiltInMethodObject{
 		Fn: func(receiver Object) builtinMethodBody {
 			return func(t *thread, args []Object, blockFrame *callFrame) Object {
 				arr := receiver.(*ArrayObject)
-				rotArr := initializeArray(arr.Elements)
+				rotArr := initArrayObject(arr.Elements)
 
 				rotate := 1
 
@@ -563,7 +563,7 @@ var builtinArrayInstanceMethods = []*BuiltInMethodObject{
 					return newError("Expect index argument to be Integer. got=%T", args[0])
 				}
 
-				return initializeArray(arr.Elements[:arg.Value])
+				return initArrayObject(arr.Elements[:arg.Value])
 			}
 		},
 	},
@@ -584,7 +584,7 @@ var builtinArrayInstanceMethods = []*BuiltInMethodObject{
 				}
 
 				l := len(arr.Elements)
-				return initializeArray(arr.Elements[l-arg.Value : l])
+				return initArrayObject(arr.Elements[l-arg.Value : l])
 			}
 		},
 	},

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -54,8 +54,8 @@ func TestPushMethod(t *testing.T) {
 }
 
 func TestShiftMethod(t *testing.T) {
-	array := initializeArray([]Object{initilaizeInteger(1), initilaizeInteger(2), initilaizeInteger(3), initilaizeInteger(4)})
-	second := initializeArray([]Object{initilaizeInteger(2), initilaizeInteger(3), initilaizeInteger(4)})
+	array := initArrayObject([]Object{initilaizeInteger(1), initilaizeInteger(2), initilaizeInteger(3), initilaizeInteger(4)})
+	second := initArrayObject([]Object{initilaizeInteger(2), initilaizeInteger(3), initilaizeInteger(4)})
 
 	m := getBuiltInMethod(t, array, "shift")
 	first := m(nil, nil, nil)
@@ -241,19 +241,19 @@ func TestMapMethod(t *testing.T) {
 		a.map do |i|
 			i + 3
 		end
-		`, initializeArray([]Object{initilaizeInteger(4), initilaizeInteger(5), initilaizeInteger(10)})},
+		`, initArrayObject([]Object{initilaizeInteger(4), initilaizeInteger(5), initilaizeInteger(10)})},
 		{`
 		a = [true, false, true, false, true ]
 		a.map do |i|
 			!i
 		end
-		`, initializeArray([]Object{FALSE, TRUE, FALSE, TRUE, FALSE})},
+		`, initArrayObject([]Object{FALSE, TRUE, FALSE, TRUE, FALSE})},
 		{`
 		a = ["1", "sss", "qwe"]
 		a.map do |i|
 			i + "1"
 		end
-		`, initializeArray([]Object{initializeString("11"), initializeString("sss1"), initializeString("qwe1")})},
+		`, initArrayObject([]Object{initStringObject("11"), initStringObject("sss1"), initStringObject("qwe1")})},
 	}
 
 	for _, tt := range tests {
@@ -272,19 +272,19 @@ func TestSelectMethod(t *testing.T) {
 		a.select do |i|
 			i > 3
 		end
-		`, initializeArray([]Object{initilaizeInteger(4), initilaizeInteger(5)})},
+		`, initArrayObject([]Object{initilaizeInteger(4), initilaizeInteger(5)})},
 		{`
 		a = [true, false, true, false, true ]
 		a.select do |i|
 			i
 		end
-		`, initializeArray([]Object{TRUE, TRUE, TRUE})},
+		`, initArrayObject([]Object{TRUE, TRUE, TRUE})},
 		{`
 		a = ["test", "not2", "3", "test", "5"]
 		a.select do |i|
 			i == "test"
 		end
-		`, initializeArray([]Object{initializeString("test"), initializeString("test")})},
+		`, initArrayObject([]Object{initStringObject("test"), initStringObject("test")})},
 	}
 
 	for _, tt := range tests {
@@ -301,11 +301,11 @@ func TestClearMethod(t *testing.T) {
 		{`
 		a = [1, 2, 3]
 		a.clear
-		`, initializeArray([]Object{})},
+		`, initArrayObject([]Object{})},
 		{`
 		a = []
 		a.clear
-		`, initializeArray([]Object{})},
+		`, initArrayObject([]Object{})},
 	}
 
 	for _, tt := range tests {
@@ -322,15 +322,15 @@ func TestConcatMethod(t *testing.T) {
 		{`
 		a = [1, 2]
 		a.concat([3], [4])
-		`, initializeArray([]Object{initilaizeInteger(1), initilaizeInteger(2), initilaizeInteger(3), initilaizeInteger(4)})},
+		`, initArrayObject([]Object{initilaizeInteger(1), initilaizeInteger(2), initilaizeInteger(3), initilaizeInteger(4)})},
 		{`
 		a = []
 		a.concat([1], [2], ["a", "b"], [3], [4])
-		`, initializeArray([]Object{initilaizeInteger(1), initilaizeInteger(2), initializeString("a"), initializeString("b"), initilaizeInteger(3), initilaizeInteger(4)})},
+		`, initArrayObject([]Object{initilaizeInteger(1), initilaizeInteger(2), initStringObject("a"), initStringObject("b"), initilaizeInteger(3), initilaizeInteger(4)})},
 		{`
 		a = [1, 2]
 		a.concat()
-		`, initializeArray([]Object{initilaizeInteger(1), initilaizeInteger(2)})},
+		`, initArrayObject([]Object{initilaizeInteger(1), initilaizeInteger(2)})},
 	}
 
 	for _, tt := range tests {
@@ -440,11 +440,11 @@ func TestRotateMethod(t *testing.T) {
 		{`
 		a = [1, 2]
 		a.rotate
-		`, initializeArray([]Object{initilaizeInteger(2), initilaizeInteger(1)})},
+		`, initArrayObject([]Object{initilaizeInteger(2), initilaizeInteger(1)})},
 		{`
 		a = [1, 2, 3, 4]
 		a.rotate(2)
-		`, initializeArray([]Object{initilaizeInteger(3), initilaizeInteger(4), initilaizeInteger(1), initilaizeInteger(2)})},
+		`, initArrayObject([]Object{initilaizeInteger(3), initilaizeInteger(4), initilaizeInteger(1), initilaizeInteger(2)})},
 	}
 
 	for _, tt := range tests {
@@ -499,11 +499,11 @@ func TestFirstMethod(t *testing.T) {
 		{`
 		a = [3, 4, 5, 1, 6]
 		a.first(2)
-		`, initializeArray([]Object{initilaizeInteger(3), initilaizeInteger(4)})},
+		`, initArrayObject([]Object{initilaizeInteger(3), initilaizeInteger(4)})},
 		{`
 		a = ["a", "b", "d", "q"]
 		a.first(2)
-		`, initializeArray([]Object{initializeString("a"), initializeString("b")})},
+		`, initArrayObject([]Object{initStringObject("a"), initStringObject("b")})},
 	}
 
 	for _, tt := range testsArray {
@@ -543,7 +543,7 @@ func TestLastMethod(t *testing.T) {
 		{`
 		a = [1, 2, "a", 2, "b"]
 		a.last
-		`, initializeString("b")},
+		`, initStringObject("b")},
 	}
 
 	for _, tt := range tests {
@@ -558,11 +558,11 @@ func TestLastMethod(t *testing.T) {
 		{`
 		a = [3, 4, 5, 1, 6]
 		a.last(3)
-		`, initializeArray([]Object{initilaizeInteger(5), initilaizeInteger(1), initilaizeInteger(6)})},
+		`, initArrayObject([]Object{initilaizeInteger(5), initilaizeInteger(1), initilaizeInteger(6)})},
 		{`
 		a = ["a", "b", "d", "q"]
 		a.last(2)
-		`, initializeArray([]Object{initializeString("d"), initializeString("q")})},
+		`, initArrayObject([]Object{initStringObject("d"), initStringObject("q")})},
 	}
 
 	for _, tt := range testsArray {
@@ -600,5 +600,5 @@ func generateArray(length int) *ArrayObject {
 		int := initilaizeInteger(i)
 		elements = append(elements, int)
 	}
-	return initializeArray(elements)
+	return initArrayObject(elements)
 }

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -175,7 +175,7 @@ var builtinBooleanInstanceMethods = []*BuiltInMethodObject{
 	},
 }
 
-func initBool() {
+func initBoolClass() {
 	bc := &BaseClass{Name: "Boolean", Methods: newEnvironment(), ClassMethods: newEnvironment(), Class: classClass, pseudoSuperClass: objectClass, superClass: objectClass}
 	b := &RBool{BaseClass: bc}
 	b.setBuiltInMethods(builtinBooleanInstanceMethods, false)

--- a/vm/class.go
+++ b/vm/class.go
@@ -481,7 +481,7 @@ var builtinCommonInstanceMethods = []*BuiltInMethodObject{
 		Name: "to_s",
 		Fn: func(receiver Object) builtinMethodBody {
 			return func(t *thread, args []Object, blockFrame *callFrame) Object {
-				return initializeString(receiver.toString())
+				return initStringObject(receiver.toString())
 			}
 		},
 	},
@@ -775,7 +775,7 @@ var builtinClassClassMethods = []*BuiltInMethodObject{
 			return func(t *thread, args []Object, blockFrame *callFrame) Object {
 
 				name := receiver.(Class).ReturnName()
-				nameString := initializeString(name)
+				nameString := initStringObject(name)
 				return nameString
 			}
 		},

--- a/vm/error.go
+++ b/vm/error.go
@@ -56,7 +56,7 @@ func (e *Error) returnClass() Class {
 	return e.Class
 }
 
-func initializeError(errorType *RClass, format string, args ...interface{}) *Error {
+func initErrorObject(errorType *RClass, format string, args ...interface{}) *Error {
 	return &Error{
 		Class:   errorType,
 		Message: fmt.Sprintf(errorType.Name+": "+format, args...),

--- a/vm/file.go
+++ b/vm/file.go
@@ -136,7 +136,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					filename := args[0].(*StringObject).Value
-					return initializeString(filepath.Ext(filename))
+					return initStringObject(filepath.Ext(filename))
 				}
 			},
 		},
@@ -207,7 +207,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					filename := args[0].(*StringObject).Value
-					return initializeString(filepath.Base(filename))
+					return initStringObject(filepath.Base(filename))
 				}
 			},
 		},
@@ -227,7 +227,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 						elements = append(elements, next)
 					}
 
-					return initializeString(filepath.Join(elements...))
+					return initStringObject(filepath.Join(elements...))
 				}
 			},
 		},
@@ -245,10 +245,10 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 					filename := args[0].(*StringObject).Value
 					dir, file := filepath.Split(filename)
 
-					dirObject := initializeString(dir)
-					fileObject := initializeString(file)
+					dirObject := initStringObject(dir)
+					fileObject := initStringObject(file)
 
-					return initializeArray([]Object{dirObject, fileObject})
+					return initArrayObject([]Object{dirObject, fileObject})
 				}
 			},
 		},
@@ -279,7 +279,7 @@ func builtinFileInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					name := receiver.(*FileObject).File.Name()
-					return initializeString(name)
+					return initStringObject(name)
 				}
 			},
 		},
@@ -315,7 +315,7 @@ func builtinFileInstanceMethods() []*BuiltInMethodObject {
 						t.returnError(err.Error())
 					}
 
-					return initializeString(string(data))
+					return initStringObject(string(data))
 				}
 			},
 		},

--- a/vm/file_test.go
+++ b/vm/file_test.go
@@ -170,7 +170,7 @@ func TestSplitMethod(t *testing.T) {
 		{`
 		require "file"
 		File.split("/home/goby/plugin/test.gb")
-		`, initializeArray([]Object{initializeString("/home/goby/plugin/"), initializeString("test.gb")})},
+		`, initArrayObject([]Object{initStringObject("/home/goby/plugin/"), initStringObject("test.gb")})},
 	}
 
 	for _, tt := range tests {

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -44,7 +44,7 @@ func (h *HashObject) length() int {
 	return len(h.Pairs)
 }
 
-func initializeHash(pairs map[string]Object) *HashObject {
+func initHashObject(pairs map[string]Object) *HashObject {
 	return &HashObject{Pairs: pairs, Class: hashClass}
 }
 
@@ -89,7 +89,7 @@ var builtinHashInstanceMethods = []*BuiltInMethodObject{
 		Fn: func(receiver Object) builtinMethodBody {
 			return func(t *thread, args []Object, blockFrame *callFrame) Object {
 				r := receiver.(*HashObject)
-				return initializeString(r.toJSON())
+				return initStringObject(r.toJSON())
 			}
 		},
 	},
@@ -167,7 +167,7 @@ var builtinHashInstanceMethods = []*BuiltInMethodObject{
 	},
 }
 
-func initHash() {
+func initHashClass() {
 	bc := &BaseClass{Name: "Hash", ClassMethods: newEnvironment(), Methods: newEnvironment(), Class: classClass, pseudoSuperClass: objectClass, superClass: objectClass}
 	hc := &RHash{BaseClass: bc}
 	hc.setBuiltInMethods(builtinHashInstanceMethods, false)

--- a/vm/http.go
+++ b/vm/http.go
@@ -78,7 +78,7 @@ var builtinHTTPClassMethods = []*BuiltInMethodObject{
 					t.returnError(err.Error())
 				}
 
-				return initializeString(string(content))
+				return initStringObject(string(content))
 			}
 		},
 	},

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -135,7 +135,7 @@ var builtInActions = map[operationType]*action{
 				elems = append([]Object{v.Target}, elems...)
 			}
 
-			arr := initializeArray(elems)
+			arr := initArrayObject(elems)
 			t.stack.push(&Pointer{arr})
 		},
 	},
@@ -151,7 +151,7 @@ var builtInActions = map[operationType]*action{
 				pairs[k.Target.(*StringObject).Value] = v.Target
 			}
 
-			hash := initializeHash(pairs)
+			hash := initHashObject(pairs)
 			t.stack.push(&Pointer{hash})
 		},
 	},
@@ -382,7 +382,7 @@ func initializeObjectFromInstruction(value interface{}) Object {
 		case "false":
 			return FALSE
 		default:
-			return initializeString(v)
+			return initStringObject(v)
 		}
 	}
 

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -130,7 +130,7 @@ var builtinIntegerInstanceMethods = []*BuiltInMethodObject{
 				right, ok := args[0].(*IntegerObject)
 
 				if !ok {
-					return initializeError(TypeErrorClass, "Expect Integer. got=%T (%+v)", args[0], args[0])
+					return initErrorObject(TypeErrorClass, "Expect Integer. got=%T (%+v)", args[0], args[0])
 				}
 
 				rightValue := right.Value
@@ -439,7 +439,7 @@ var builtinIntegerInstanceMethods = []*BuiltInMethodObject{
 
 				int := receiver.(*IntegerObject)
 
-				return initializeString(strconv.Itoa(int.Value))
+				return initStringObject(strconv.Itoa(int.Value))
 			}
 		},
 	},
@@ -565,7 +565,7 @@ var builtinIntegerInstanceMethods = []*BuiltInMethodObject{
 	},
 }
 
-func initInteger() {
+func initIntegerClass() {
 	bc := &BaseClass{Name: "Integer", Methods: newEnvironment(), ClassMethods: newEnvironment(), Class: classClass, pseudoSuperClass: objectClass, superClass: objectClass}
 	ic := &RInteger{BaseClass: bc}
 	ic.setBuiltInMethods(builtinIntegerInstanceMethods, false)

--- a/vm/method.go
+++ b/vm/method.go
@@ -7,7 +7,7 @@ import (
 
 var methodClass *RMethod
 
-func init() {
+func initMethodClass() {
 	methods := newEnvironment()
 
 	bc := &BaseClass{Name: "Method", Methods: methods, ClassMethods: newEnvironment(), Class: classClass, pseudoSuperClass: objectClass, superClass: objectClass}

--- a/vm/null.go
+++ b/vm/null.go
@@ -29,7 +29,7 @@ func (n *NullObject) returnClass() Class {
 	return n.Class
 }
 
-func initNull() {
+func initNullClass() {
 	baseClass := &BaseClass{Name: "Null", Methods: newEnvironment(), ClassMethods: newEnvironment(), Class: classClass, pseudoSuperClass: objectClass}
 	nc := &RNull{BaseClass: baseClass}
 	nc.setBuiltInMethods(builtInNullInstanceMethods, false)

--- a/vm/object.go
+++ b/vm/object.go
@@ -8,14 +8,15 @@ var mainObj *RObject
 
 func init() {
 	initTopLevelClasses()
-	initNull()
-	initBool()
-	initInteger()
-	initString()
-	initArray()
-	initHash()
+	initNullClass()
+	initBoolClass()
+	initIntegerClass()
+	initStringClass()
+	initArrayClass()
+	initHashClass()
 	initializeChannelClass()
 	initErrorClasses()
+	initMethodClass()
 	initMainObj()
 }
 

--- a/vm/simple_server.go
+++ b/vm/simple_server.go
@@ -181,7 +181,7 @@ func setupResponse(w http.ResponseWriter, req *http.Request, res *RObject) {
 func initObject(v interface{}) Object {
 	switch v := v.(type) {
 	case string:
-		return initializeString(v)
+		return initStringObject(v)
 	case int:
 		return initilaizeInteger(v)
 	case bool:

--- a/vm/string.go
+++ b/vm/string.go
@@ -48,7 +48,7 @@ var (
 	mutex       = &sync.Mutex{}
 )
 
-func initializeString(value string) *StringObject {
+func initStringObject(value string) *StringObject {
 	if len(value) < 50 {
 		mutex.Lock()
 
@@ -290,7 +290,7 @@ var builtinStringInstanceMethods = []*BuiltInMethodObject{
 				rest := string(str[1:])
 				result := strings.ToUpper(start) + strings.ToLower(rest)
 
-				return initializeString(result)
+				return initStringObject(result)
 			}
 		},
 	},
@@ -307,7 +307,7 @@ var builtinStringInstanceMethods = []*BuiltInMethodObject{
 
 				str := receiver.(*StringObject).Value
 
-				return initializeString(strings.ToUpper(str))
+				return initStringObject(strings.ToUpper(str))
 			}
 		},
 	},
@@ -324,7 +324,7 @@ var builtinStringInstanceMethods = []*BuiltInMethodObject{
 
 				str := receiver.(*StringObject).Value
 
-				return initializeString(strings.ToLower(str))
+				return initStringObject(strings.ToLower(str))
 			}
 		},
 	},
@@ -381,7 +381,7 @@ var builtinStringInstanceMethods = []*BuiltInMethodObject{
 					revert += string(str[i])
 				}
 
-				return initializeString(revert)
+				return initStringObject(revert)
 			}
 		},
 	},
@@ -398,7 +398,7 @@ var builtinStringInstanceMethods = []*BuiltInMethodObject{
 
 				str := receiver.(*StringObject).Value
 
-				return initializeString(str)
+				return initStringObject(str)
 			}
 		},
 	},
@@ -442,7 +442,7 @@ var builtinStringInstanceMethods = []*BuiltInMethodObject{
 	},
 }
 
-func initString() {
+func initStringClass() {
 	bc := &BaseClass{Name: "String", Methods: newEnvironment(), ClassMethods: newEnvironment(), Class: classClass, pseudoSuperClass: objectClass, superClass: objectClass}
 	sc := &RString{BaseClass: bc}
 	sc.setBuiltInMethods(builtinStringInstanceMethods, false)

--- a/vm/string.go
+++ b/vm/string.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 	"unicode"
 )
 
@@ -43,29 +42,7 @@ func (s *StringObject) equal(e *StringObject) bool {
 	return s.Value == e.Value
 }
 
-var (
-	stringTable = make(map[string]*StringObject)
-	mutex       = &sync.Mutex{}
-)
-
 func initStringObject(value string) *StringObject {
-	if len(value) < 50 {
-		mutex.Lock()
-
-		defer mutex.Unlock()
-		addr, ok := stringTable[value]
-
-		if !ok {
-			s := &StringObject{Value: value, Class: stringClass}
-
-			stringTable[value] = s
-
-			return s
-		}
-
-		return addr
-	}
-
 	return &StringObject{Value: value, Class: stringClass}
 }
 

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -162,10 +162,10 @@ func (t *thread) returnError(msg string) {
 }
 
 func (t *thread) UndefinedMethodError(methodName string, receiver Object) {
-	err := initializeError(UndefinedMethodErrorClass, "Undefined Method '%+v' for %+v", methodName, receiver.toString())
+	err := initErrorObject(UndefinedMethodErrorClass, "Undefined Method '%+v' for %+v", methodName, receiver.toString())
 	t.stack.push(&Pointer{err})
 }
 
 func (t *thread) UnsupportedMethodError(methodName string, receiver Object) *Error {
-	return initializeError(UnsupportedMethodClass, "Unsupported Method %s for %+v", methodName, receiver.toString())
+	return initErrorObject(UnsupportedMethodClass, "Unsupported Method %s for %+v", methodName, receiver.toString())
 }

--- a/vm/uri.go
+++ b/vm/uri.go
@@ -16,13 +16,13 @@ func initializeURIClass(vm *VM) {
 	uri.setBuiltInMethods(builtinURIClassMethods, true)
 
 	attrs := []Object{
-		initializeString("host"),
-		initializeString("path"),
-		initializeString("port"),
-		initializeString("query"),
-		initializeString("scheme"),
-		initializeString("user"),
-		initializeString("password"),
+		initStringObject("host"),
+		initStringObject("path"),
+		initStringObject("port"),
+		initStringObject("query"),
+		initStringObject("scheme"),
+		initStringObject("user"),
+		initStringObject("password"),
 	}
 
 	http.setAttrReader(attrs)
@@ -57,14 +57,14 @@ var builtinURIClassMethods = []*BuiltInMethodObject{
 					"@user":     NULL,
 					"@password": NULL,
 					"@query":    NULL,
-					"@path":     initializeString("/"),
+					"@path":     initStringObject("/"),
 				}
 
 				// Scheme
-				uriAttrs["@scheme"] = initializeString(u.Scheme)
+				uriAttrs["@scheme"] = initStringObject(u.Scheme)
 
 				// Host
-				uriAttrs["@host"] = initializeString(u.Host)
+				uriAttrs["@host"] = initStringObject(u.Host)
 
 				// Port
 				if len(u.Port()) == 0 {
@@ -86,22 +86,22 @@ var builtinURIClassMethods = []*BuiltInMethodObject{
 
 				// Path
 				if len(u.Path) != 0 {
-					uriAttrs["@path"] = initializeString(u.Path)
+					uriAttrs["@path"] = initStringObject(u.Path)
 				}
 
 				// Query
 				if len(u.RawQuery) != 0 {
-					uriAttrs["@query"] = initializeString(u.RawQuery)
+					uriAttrs["@query"] = initStringObject(u.RawQuery)
 				}
 
 				// User
 				if u.User != nil {
 					if len(u.User.Username()) != 0 {
-						uriAttrs["@user"] = initializeString(u.User.Username())
+						uriAttrs["@user"] = initStringObject(u.User.Username())
 					}
 
 					if p, ok := u.User.Password(); ok {
-						uriAttrs["@password"] = initializeString(p)
+						uriAttrs["@password"] = initStringObject(p)
 					}
 				}
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -12,6 +12,8 @@ import (
 
 var stackTrace int
 
+var mutex = &sync.Mutex{}
+
 type isIndexTable struct {
 	Data map[string]int
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -147,7 +147,7 @@ func (vm *VM) initConstants() {
 	args := []Object{}
 
 	for _, arg := range vm.args {
-		args = append(args, initializeString(arg))
+		args = append(args, initStringObject(arg))
 	}
 
 	for _, c := range builtInClasses {
@@ -155,7 +155,7 @@ func (vm *VM) initConstants() {
 		constants[c.ReturnName()] = p
 	}
 
-	constants["ARGV"] = &Pointer{Target: initializeArray(args)}
+	constants["ARGV"] = &Pointer{Target: initArrayObject(args)}
 	objectClass.constants = constants
 	vm.constants["Object"] = &Pointer{objectClass}
 }


### PR DESCRIPTION
Mainly renaming function names to make their purpose more clear, like:
- `initArray()` to `initArrayClass()`
- `initializeArray()` to `initArrayObject()`

I also remove the string's cache table since we don't really need it yet and the implementation is very naive and caused many issues.