### PR TITLE
Implement #225 Part 2

### DIFF
--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -135,20 +135,22 @@ func (g *Generator) compileIfExpression(is *InstructionSet, exp *ast.IfExpressio
 	g.compileExpression(is, exp.Condition, scope, table)
 
 	anchor1 := &anchor{}
+	anchor2 := &anchor{}
+
 	is.define(BranchUnless, anchor1)
 
 	g.compileCodeBlock(is, exp.Consequence, scope, table)
 
 	anchor1.line = is.count + 1
 
+	is.define(Jump, anchor2)
+
 	if exp.Alternative == nil {
-		anchor1.line--
+		// jump over the `putnil` in false case
+		anchor2.line = anchor1.line + 1
 		is.define(PutNull)
 		return
 	}
-
-	anchor2 := &anchor{}
-	is.define(Jump, anchor2)
 
 	g.compileCodeBlock(is, exp.Alternative, scope, table)
 

--- a/compiler/bytecode/expression_generation_test.go
+++ b/compiler/bytecode/expression_generation_test.go
@@ -56,14 +56,15 @@ func TestConditionWithoutAlternativeCompilation(t *testing.T) {
 4 getlocal 0 0
 5 getlocal 0 1
 6 send > 1
-7 branchunless 10
+7 branchunless 11
 8 putobject 10
 9 setlocal 0 2
-10 putnil
-11 getlocal 0 2
-12 putobject 1
-13 send + 1
-14 leave
+10 jump 12
+11 putnil
+12 getlocal 0 2
+13 putobject 1
+14 send + 1
+15 leave
 `
 
 	bytecode := compileToBytecode(input)

--- a/compiler/bytecode/statement_generation_test.go
+++ b/compiler/bytecode/statement_generation_test.go
@@ -69,10 +69,10 @@ func TestNextStatement(t *testing.T) {
 1 setlocal 0 0
 2 putobject 0
 3 setlocal 0 1
-4 jump 22
+4 jump 23
 5 putnil
 6 pop
-7 jump 22
+7 jump 23
 8 getlocal 0 0
 9 putobject 1
 10 send + 1
@@ -80,20 +80,21 @@ func TestNextStatement(t *testing.T) {
 12 getlocal 0 0
 13 putobject 5
 14 send == 1
-15 branchunless 17
-16 jump 22
-17 putnil
-18 getlocal 0 1
-19 putobject 1
-20 send + 1
-21 setlocal 0 1
-22 getlocal 0 0
-23 putobject 10
-24 send < 1
-25 branchif 8
-26 putnil
-27 pop
-28 leave
+15 branchunless 18
+16 jump 23
+17 jump 19
+18 putnil
+19 getlocal 0 1
+20 putobject 1
+21 send + 1
+22 setlocal 0 1
+23 getlocal 0 0
+24 putobject 10
+25 send < 1
+26 branchif 8
+27 putnil
+28 pop
+29 leave
 `
 
 	bytecode := compileToBytecode(input)

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -11,6 +11,7 @@ func TestArrayEvaluation(t *testing.T) {
 
 	vm := initTestVM()
 	evaluated := vm.testEval(t, input)
+	vm.checkCFP(t, 0, 0)
 
 	arr, ok := evaluated.(*ArrayObject)
 	if !ok {
@@ -50,6 +51,7 @@ func TestArrayLengthMethod(t *testing.T) {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
 	}
 }
 
@@ -79,6 +81,7 @@ func TestArrayPopMethod(t *testing.T) {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
 	}
 }
 
@@ -119,6 +122,7 @@ func TestArrayPushMethod(t *testing.T) {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
 	}
 }
 
@@ -148,6 +152,7 @@ func TestArrayShiftMethod(t *testing.T) {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
 	}
 }
 
@@ -162,16 +167,20 @@ func TestArrayShiftMethodFail(t *testing.T) {
 		`, newError("Expect 0 argument. got=4")},
 	}
 
-	for _, tt := range testsFail {
+	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
+
 		err, ok := evaluated.(*Error)
+
 		if !ok {
 			t.Errorf("Expect error. got=%T (%+v)", err, err)
 		}
 		if err.Message != tt.expected.Message {
 			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
 		}
+
+		v.checkCFP(t, i, 1)
 	}
 }
 
@@ -280,6 +289,7 @@ func TestArrayIndex(t *testing.T) {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
 	}
 }
 
@@ -301,6 +311,7 @@ func TestArrayEachMethod(t *testing.T) {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
 	}
 }
 
@@ -322,6 +333,7 @@ func TestArrayEachIndexMethod(t *testing.T) {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
 	}
 }
 
@@ -354,6 +366,7 @@ func TestArrayMapMethod(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -386,6 +399,7 @@ func TestArraySelectMethod(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -408,6 +422,7 @@ func TestArrayClearMethod(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -434,6 +449,7 @@ func TestArrayConcatMethod(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -452,7 +468,7 @@ func TestArrayConcatMethodFail(t *testing.T) {
 		`, newError("Expect argument to be Array. got=*vm.StringObject")},
 	}
 
-	for _, tt := range testsFail {
+	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		err, ok := evaluated.(*Error)
@@ -462,6 +478,8 @@ func TestArrayConcatMethodFail(t *testing.T) {
 		if err.Message != tt.expected.Message {
 			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
 		}
+
+		v.checkCFP(t, i, 1)
 	}
 }
 
@@ -508,6 +526,7 @@ func TestArrayCountMethod(t *testing.T) {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
 	}
 }
 
@@ -522,7 +541,7 @@ func TestArrayCountMethodFail(t *testing.T) {
 		`, newError("Expect one argument. got=2")},
 	}
 
-	for _, tt := range testsFail {
+	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 
@@ -530,6 +549,8 @@ func TestArrayCountMethodFail(t *testing.T) {
 		if !ok || err.Class.ReturnName() != ArgumentError {
 			t.Errorf("Expect ArgumentError. got=%T (%+v)", err, err)
 		}
+
+		v.checkCFP(t, i, 1)
 	}
 }
 
@@ -552,6 +573,7 @@ func TestArrayRotateMethod(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -566,7 +588,7 @@ func TestArrayRotateMethodFail(t *testing.T) {
 		`, newError("Expect index argument to be Integer. got=*vm.StringObject")},
 	}
 
-	for _, tt := range testsFail {
+	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		err, ok := evaluated.(*Error)
@@ -576,6 +598,8 @@ func TestArrayRotateMethodFail(t *testing.T) {
 		if err.Message != tt.expected.Message {
 			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
 		}
+
+		v.checkCFP(t, i, 1)
 	}
 }
 
@@ -594,6 +618,7 @@ func TestArrayFirstMethod(t *testing.T) {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
 	}
 
 	testsArray := []struct {
@@ -614,6 +639,7 @@ func TestArrayFirstMethod(t *testing.T) {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
 	}
 }
 
@@ -628,7 +654,7 @@ func TestArrayFirstMethodFail(t *testing.T) {
 		`, newError("Expect index argument to be Integer. got=*vm.StringObject")},
 	}
 
-	for _, tt := range testsFail {
+	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		err, ok := evaluated.(*Error)
@@ -638,6 +664,7 @@ func TestArrayFirstMethodFail(t *testing.T) {
 		if err.Message != tt.expected.Message {
 			t.Errorf("Expect error message \"%s\". got=\"%s\"", err.Message, tt.expected.Message)
 		}
+		v.checkCFP(t, i, 1)
 	}
 }
 
@@ -660,6 +687,7 @@ func TestArrayLastMethod(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -674,7 +702,7 @@ func TestArrayLastMethodFail(t *testing.T) {
 		`, newError("Expect index argument to be Integer. got=*vm.StringObject")},
 	}
 
-	for _, tt := range testsFail {
+	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
 		err, ok := evaluated.(*Error)
@@ -684,5 +712,6 @@ func TestArrayLastMethodFail(t *testing.T) {
 		if err.Message != tt.expected.Message {
 			t.Errorf("Expect error message \"%s\". got=\"%s\"", err.Message, tt.expected.Message)
 		}
+		v.checkCFP(t, i, 1)
 	}
 }

--- a/vm/boolean_test.go
+++ b/vm/boolean_test.go
@@ -15,6 +15,7 @@ func TestEvalBooleanExpression(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -64,6 +65,7 @@ func TestEvalInfixBooleanExpression(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 

--- a/vm/channel_and_thread_test.go
+++ b/vm/channel_and_thread_test.go
@@ -40,6 +40,7 @@ func TestObjectMutationInThread(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -133,5 +134,6 @@ func TestObjectDeliveryBetweenThread(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }

--- a/vm/class.go
+++ b/vm/class.go
@@ -520,6 +520,10 @@ func builtinCommonInstanceMethods() []*BuiltInMethodObject {
 						newT.builtInMethodYield(blockFrame, args...)
 					}()
 
+					// We need to pop this frame from main thread manually,
+					// because the block's 'leave' instruction is running on other process
+					t.callFrameStack.pop()
+
 					return NULL
 				}
 			},

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -33,7 +33,7 @@ func TestUndefinedMethodError(t *testing.T) {
 		`, "UndefinedMethodError: Undefined Method 'bar=' for <Instance of: Foo>"},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		err, ok := evaluated.(*Error)
@@ -49,6 +49,8 @@ func TestUndefinedMethodError(t *testing.T) {
 		if err.Message != tt.errorMsg {
 			t.Errorf("Expected error message: %s\nGot: %s\n", tt.errorMsg, err.Message)
 		}
+
+		vm.checkCFP(t, i, 1)
 	}
 }
 
@@ -94,6 +96,8 @@ func TestArgumentError(t *testing.T) {
 	if err.Class.ReturnName() != ArgumentError {
 		t.Errorf("Expect %s. got=%T (%+v)", ArgumentError, evaluated, evaluated)
 	}
+
+	vm.checkCFP(t, 0, 1)
 }
 
 func TestTypeError(t *testing.T) {
@@ -106,4 +110,5 @@ func TestTypeError(t *testing.T) {
 	if err.Class.ReturnName() != TypeError {
 		t.Errorf("Expect %s. got=%T (%+v)", TypeError, evaluated, evaluated)
 	}
+	vm.checkCFP(t, 0, 1)
 }

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -27,6 +27,7 @@ func TestComment(t *testing.T) {
 	vm := initTestVM()
 	evaluated := vm.testEval(t, input)
 	testIntegerObject(t, 0, evaluated, 1)
+	vm.checkCFP(t, 0, 0)
 }
 
 func TestMethodCall(t *testing.T) {
@@ -178,6 +179,7 @@ func TestMethodCall(t *testing.T) {
 		}
 
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -218,6 +220,7 @@ func TestMethodCallWithDefaultArgValue(t *testing.T) {
 		}
 
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -357,6 +360,7 @@ func TestMethodCallWithBlockArgument(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -461,6 +465,7 @@ func TestMethodCallWithNestedBlock(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -662,6 +667,7 @@ func TestMethodCallWithoutParens(t *testing.T) {
 		}
 
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -777,6 +783,7 @@ func TestClassMethodCall(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -822,6 +829,8 @@ func TestInstanceMethodCall(t *testing.T) {
 	if result.Value != 110 {
 		t.Errorf("expect result to be 110. got=%d", result.Value)
 	}
+
+	vm.checkCFP(t, 0, 0)
 }
 
 func TestPostfixMethodCall(t *testing.T) {
@@ -850,6 +859,7 @@ func TestPostfixMethodCall(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -870,6 +880,7 @@ func TestBangPrefixMethodCall(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -888,6 +899,7 @@ func TestMinusPrefixMethodCall(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -953,6 +965,7 @@ func TestSelfExpressionEvaluation(t *testing.T) {
 		}
 
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -1024,6 +1037,7 @@ func TestInstanceVariableEvaluation(t *testing.T) {
 		}
 
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -1072,7 +1086,10 @@ func TestIfExpressionEvaluation(t *testing.T) {
 			`,
 			true,
 		},
-		{"if true; 10 end", 10},
+		{`
+		if true
+		   10
+		end`, 10},
 		{"if false; 10 end", nil},
 		{"if 1; 10; end", 10},
 		{"if 1 < 2; 10 end", 10},
@@ -1092,15 +1109,8 @@ func TestIfExpressionEvaluation(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
-
-		switch tt.expected.(type) {
-		case int64:
-			testIntegerObject(t, i, evaluated, tt.expected.(int))
-		case bool:
-			testBooleanObject(t, i, evaluated, tt.expected.(bool))
-		case nil:
-			testNullObject(t, i, evaluated)
-		}
+		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -1121,4 +1131,5 @@ func TestClassInheritance(t *testing.T) {
 	evaluated := vm.testEval(t, input)
 
 	testStringObject(t, 0, evaluated, "Bar")
+	vm.checkCFP(t, 0, 0)
 }

--- a/vm/file_test.go
+++ b/vm/file_test.go
@@ -31,6 +31,7 @@ func TestFileDeletion(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -76,6 +77,7 @@ func TestFileWrite(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -124,6 +126,7 @@ func TestFileObject(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -146,6 +149,7 @@ func TestExtnameMethod(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -164,6 +168,7 @@ func TestBasenameMethod(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -182,6 +187,7 @@ func TestSplitMethod(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -208,6 +214,7 @@ func TestJoinMethod(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -221,6 +228,7 @@ func TestSizeMethod(t *testing.T) {
 	vm := initTestVM()
 	evaluated := vm.testEval(t, input)
 	checkExpected(t, 0, evaluated, 22)
+	vm.checkCFP(t, 0, 0)
 }
 
 //@TODO add test for chmod form a847c8b41f29657b380c1731ec36a660dbf49bc4

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -37,10 +37,11 @@ func TestHashToJSONWithArray(t *testing.T) {
 		}},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		compareJSONResult(t, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -85,10 +86,11 @@ func TestHashToJSONWithNestedHash(t *testing.T) {
 		}},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		compareJSONResult(t, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -144,10 +146,11 @@ func TestHashToJSONWithBasicTypes(t *testing.T) {
 		}},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		compareJSONResult(t, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -168,6 +171,7 @@ func TestHashLength(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -194,6 +198,8 @@ func TestEvalHashExpression(t *testing.T) {
 			testBooleanObject(t, 0, value, true)
 		}
 	}
+
+	vm.checkCFP(t, 0, 0)
 }
 
 func TestEvalHashAccess(t *testing.T) {
@@ -250,6 +256,7 @@ func TestEvalHashAccess(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 

--- a/vm/http_test.go
+++ b/vm/http_test.go
@@ -22,6 +22,7 @@ func TestHTTPResponse(t *testing.T) {
 	vm := initTestVM()
 	evaluated := vm.testEval(t, input)
 	checkExpected(t, 0, evaluated, "test")
+	vm.checkCFP(t, 0, 0)
 }
 
 func TestNormalGet(t *testing.T) {
@@ -41,6 +42,7 @@ Net::HTTP.get("%s")
 	vm := initTestVM()
 	evaluated := vm.testEval(t, testScript)
 	checkExpected(t, 0, evaluated, expected)
+	vm.checkCFP(t, 0, 0)
 }
 
 func TestNormalGetWithPath(t *testing.T) {
@@ -65,4 +67,5 @@ Net::HTTP.get("%s", "path")
 	vm := initTestVM()
 	evaluated := vm.testEval(t, testScript)
 	checkExpected(t, 0, evaluated, expected)
+	vm.checkCFP(t, 0, 0)
 }

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -69,6 +69,7 @@ func TestEvalInteger(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -118,7 +119,7 @@ func TestEvalIntegerFail(t *testing.T) {
 		`, newError("Can't yield without a block")},
 	}
 
-	for _, tt := range testsFail {
+	for i, tt := range testsFail {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		err, ok := evaluated.(*Error)
@@ -128,5 +129,6 @@ func TestEvalIntegerFail(t *testing.T) {
 		if err.Message != tt.expected.Message {
 			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
 		}
+		vm.checkCFP(t, i, 1)
 	}
 }

--- a/vm/null_test.go
+++ b/vm/null_test.go
@@ -8,6 +8,7 @@ func TestEvalNil(t *testing.T) {
 	vm := initTestVM()
 	evaluated := vm.testEval(t, input)
 	checkExpected(t, 0, evaluated, nil)
+	vm.checkCFP(t, 0, 0)
 }
 
 func TestBangPrefix(t *testing.T) {
@@ -19,4 +20,5 @@ func TestBangPrefix(t *testing.T) {
 	vm := initTestVM()
 	evaluated := vm.testEval(t, input)
 	checkExpected(t, 0, evaluated, true)
+	vm.checkCFP(t, 0, 0)
 }

--- a/vm/range.go
+++ b/vm/range.go
@@ -271,10 +271,19 @@ func builtInRangeInstanceMethods() []*BuiltInMethodObject {
 						return newError("Step can't be negative")
 					}
 
-					for i := ran.Start; i <= ran.End; i += stepValue {
-						obj := t.vm.initIntegerObject(i)
-						t.builtInMethodYield(blockFrame, obj)
+					// range end must greater or equal than range start to execute the block
+					if ran.End >= ran.Start {
+						for i := ran.Start; i <= ran.End; i += stepValue {
+							obj := t.vm.initIntegerObject(i)
+							t.builtInMethodYield(blockFrame, obj)
+						}
+
+						return ran
 					}
+
+					// if block is not used, it should be popped
+					t.callFrameStack.pop()
+
 					return ran
 				}
 			},

--- a/vm/range_test.go
+++ b/vm/range_test.go
@@ -58,6 +58,7 @@ func TestEachThroughRange(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -90,6 +91,7 @@ func TestRangeToArray(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -116,6 +118,7 @@ func TestRangeToString(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -154,6 +157,7 @@ func TestFirstAndLast(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -180,6 +184,7 @@ func TestSize(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -238,6 +243,7 @@ func TestStepThroughRange(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -285,5 +291,6 @@ func TestInclude(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }

--- a/vm/simple_server_test.go
+++ b/vm/simple_server_test.go
@@ -23,6 +23,7 @@ func TestServerInitialization(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -28,6 +28,7 @@ func TestReturnStatementEvaluation(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -77,6 +78,8 @@ func TestDefStatement(t *testing.T) {
 			t.Errorf("expect method %s to have %d parameters. got=%d", method.Name, len(expectedMethod.params), method.argc)
 		}
 	}
+
+	vm.checkCFP(t, 0, 0)
 }
 
 func TestModuleStatement(t *testing.T) {
@@ -139,6 +142,7 @@ func TestModuleStatement(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -181,6 +185,7 @@ func TestWhileStatement(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -229,5 +234,6 @@ func TestNextStatement(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -17,6 +17,7 @@ func TestEvalStringExpression(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -36,6 +37,7 @@ func TestStringConversion(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -60,6 +62,7 @@ func TestStringComparison(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -79,6 +82,7 @@ func TestStringOperation(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -100,6 +104,7 @@ func TestCapitalizingString(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -117,6 +122,7 @@ func TestUpcasingString(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -134,6 +140,7 @@ func TestDowncasingString(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -151,6 +158,7 @@ func TestSizeAndLengthOfString(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -169,6 +177,7 @@ func TestReversingString(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -185,6 +194,7 @@ func TestIncludingString(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }
 
@@ -200,5 +210,6 @@ func TestChainingStringMethods(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }

--- a/vm/uri_test.go
+++ b/vm/uri_test.go
@@ -86,5 +86,6 @@ func TestURIParsing(t *testing.T) {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
 	}
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -140,7 +140,9 @@ func (vm *VM) InitForREPL() {
 	vm.SetClassISIndexTable("")
 	vm.SetMethodISIndexTable("")
 	vm.replMode = true
-	cf := newCallFrame(&instructionSet{})
+
+	// REPL should maintain a base call frame so that the whole program won't exit
+	cf := newCallFrame(&instructionSet{name: "REPL base"})
 	cf.self = vm.mainObj
 	vm.mainThread.callFrameStack.push(cf)
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -92,7 +92,7 @@ func (v *VM) testEval(t *testing.T, input string) Object {
 
 func (v *VM) checkCFP(t *testing.T, index, expectedCFP int) {
 	if v.mainThread.cfp != expectedCFP {
-		t.Fatalf("Expect main thread's cfp to be %d. got: %d", expectedCFP, v.mainThread.cfp)
+		t.Fatalf("At case %d expect main thread's cfp to be %d. got: %d", index, expectedCFP, v.mainThread.cfp)
 	}
 }
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -56,7 +56,7 @@ foo
 	}
 
 	for i, test := range tests {
-		v := New("./", []string{})
+		v := initTestVM()
 		v.InitForREPL()
 
 		for _, input := range test.inputs {
@@ -71,6 +71,8 @@ foo
 
 		evaluated := v.GetExecResult()
 		checkExpected(t, i, evaluated, test.expected)
+		// Because REPL should maintain a base call frame so that the whole program won't exit
+		v.checkCFP(t, i, 1)
 	}
 }
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -90,7 +90,7 @@ func (v *VM) testEval(t *testing.T, input string) Object {
 	return v.mainThread.stack.top().Target
 }
 
-func (v *VM) inspectCFP(t *testing.T, index, expectedCFP int) {
+func (v *VM) checkCFP(t *testing.T, index, expectedCFP int) {
 	if v.mainThread.cfp != expectedCFP {
 		t.Fatalf("Expect main thread's cfp to be %d. got: %d", expectedCFP, v.mainThread.cfp)
 	}


### PR DESCRIPTION
This PR applies vm's CFP check to all test cases and closes #225 

When normal program's execution ends, the cfp should be 0.
But if the program has error the cfp should stop changing because the program is stopped.