### PR TITLE
Refactor: arrange the order of functions in built-in classes for consistency

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -13,69 +13,6 @@ type ArrayObject struct {
 	Elements []Object
 }
 
-// toString returns detailed info of a array include elements it contains
-func (a *ArrayObject) toString() string {
-	var out bytes.Buffer
-
-	elements := []string{}
-	for _, e := range a.Elements {
-		elements = append(elements, e.toString())
-	}
-
-	out.WriteString("[")
-	out.WriteString(strings.Join(elements, ", "))
-	out.WriteString("]")
-
-	return out.String()
-}
-
-func (a *ArrayObject) toJSON() string {
-	var out bytes.Buffer
-	elements := []string{}
-	for _, e := range a.Elements {
-		elements = append(elements, e.toJSON())
-	}
-
-	out.WriteString("[")
-	out.WriteString(strings.Join(elements, ", "))
-	out.WriteString("]")
-
-	return out.String()
-}
-
-// length returns the length of array's elements
-func (a *ArrayObject) length() int {
-	return len(a.Elements)
-}
-
-// pop removes the last element in the array and returns it
-func (a *ArrayObject) pop() Object {
-	if len(a.Elements) < 1 {
-		return NULL
-	}
-
-	value := a.Elements[len(a.Elements)-1]
-	a.Elements = a.Elements[:len(a.Elements)-1]
-	return value
-}
-
-// push appends given object into array and returns the array object
-func (a *ArrayObject) push(objs []Object) *ArrayObject {
-	a.Elements = append(a.Elements, objs...)
-	return a
-}
-
-// shift removes the first element in the array and returns it
-func (a *ArrayObject) shift() Object {
-	if len(a.Elements) < 1 {
-		return NULL
-	}
-
-	value := a.Elements[0]
-	a.Elements = a.Elements[1:]
-	return value
-}
-
 func (vm *VM) initArrayObject(elements []Object) *ArrayObject {
 	return &ArrayObject{Elements: elements, baseObj: &baseObj{class: vm.topLevelClass(arrayClass)}}
 }
@@ -620,4 +557,70 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 			},
 		},
 	}
+}
+
+// Polymorphic helper functions -----------------------------------------
+
+// toString returns detailed info of array's elements.
+func (a *ArrayObject) toString() string {
+	var out bytes.Buffer
+
+	elements := []string{}
+	for _, e := range a.Elements {
+		elements = append(elements, e.toString())
+	}
+
+	out.WriteString("[")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString("]")
+
+	return out.String()
+}
+
+// toJSON converts the receiver into JSON string.
+func (a *ArrayObject) toJSON() string {
+	var out bytes.Buffer
+	elements := []string{}
+	for _, e := range a.Elements {
+		elements = append(elements, e.toJSON())
+	}
+
+	out.WriteString("[")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString("]")
+
+	return out.String()
+}
+
+// length returns the length of array's elements
+func (a *ArrayObject) length() int {
+	return len(a.Elements)
+}
+
+// pop removes the last element in the array and returns it
+func (a *ArrayObject) pop() Object {
+	if len(a.Elements) < 1 {
+		return NULL
+	}
+
+	value := a.Elements[len(a.Elements)-1]
+	a.Elements = a.Elements[:len(a.Elements)-1]
+	return value
+}
+
+// push appends given object into array and returns the array object
+func (a *ArrayObject) push(objs []Object) *ArrayObject {
+	a.Elements = append(a.Elements, objs...)
+	return a
+}
+
+// shift removes the first element in the array and returns it
+func (a *ArrayObject) shift() Object {
+	if len(a.Elements) < 1 {
+		return NULL
+	}
+
+	value := a.Elements[0]
+	a.Elements = a.Elements[1:]
+	return value
 }

--- a/vm/array.go
+++ b/vm/array.go
@@ -14,7 +14,10 @@ type ArrayObject struct {
 }
 
 func (vm *VM) initArrayObject(elements []Object) *ArrayObject {
-	return &ArrayObject{Elements: elements, baseObj: &baseObj{class: vm.topLevelClass(arrayClass)}}
+	return &ArrayObject{
+		baseObj:  &baseObj{class: vm.topLevelClass(arrayClass)},
+		Elements: elements,
+	}
 }
 
 func (vm *VM) initArrayClass() *RClass {

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -19,17 +19,15 @@ type BooleanObject struct {
 	Value bool
 }
 
-// toString returns boolean object's value, which is either true or false.
-func (b *BooleanObject) toString() string {
-	return fmt.Sprintf("%t", b.Value)
-}
+func (vm *VM) initBoolClass() *RClass {
+	b := vm.initializeClass(booleanClass, false)
+	b.setBuiltInMethods(builtinBooleanInstanceMethods(), false)
+	b.setBuiltInMethods(builtInBooleanClassMethods(), true)
 
-func (b *BooleanObject) toJSON() string {
-	return b.toString()
-}
+	TRUE = &BooleanObject{Value: true, baseObj: &baseObj{class: b}}
+	FALSE = &BooleanObject{Value: false, baseObj: &baseObj{class: b}}
 
-func (b *BooleanObject) equal(e *BooleanObject) bool {
-	return b.Value == e.Value
+	return b
 }
 
 func builtInBooleanClassMethods() []*BuiltInMethodObject {
@@ -179,13 +177,18 @@ func builtinBooleanInstanceMethods() []*BuiltInMethodObject {
 	}
 }
 
-func (vm *VM) initBoolClass() *RClass {
-	b := vm.initializeClass(booleanClass, false)
-	b.setBuiltInMethods(builtinBooleanInstanceMethods(), false)
-	b.setBuiltInMethods(builtInBooleanClassMethods(), true)
+// Polymorphic helper functions -----------------------------------------
 
-	TRUE = &BooleanObject{Value: true, baseObj: &baseObj{class: b}}
-	FALSE = &BooleanObject{Value: false, baseObj: &baseObj{class: b}}
+// toString returns boolean object's value, which is either true or false.
+func (b *BooleanObject) toString() string {
+	return fmt.Sprintf("%t", b.Value)
+}
 
-	return b
+// toJSON converts the receiver into JSON string.
+func (b *BooleanObject) toJSON() string {
+	return b.toString()
+}
+
+func (b *BooleanObject) equal(e *BooleanObject) bool {
+	return b.Value == e.Value
 }

--- a/vm/class.go
+++ b/vm/class.go
@@ -73,31 +73,6 @@ func initObjectClass(c *RClass) *RClass {
 	return objectClass
 }
 
-// initializeClass is a common function for vm, which initializes and returns
-// a class instance with given class name.
-func (vm *VM) initializeClass(name string, isModule bool) *RClass {
-	class := vm.createRClass(name)
-	class.isModule = isModule
-
-	return class
-}
-
-func (vm *VM) createRClass(className string) *RClass {
-	objectClass := vm.objectClass
-	classClass := vm.topLevelClass(classClass)
-
-	return &RClass{
-		Name:             className,
-		Methods:          newEnvironment(),
-		ClassMethods:     newEnvironment(),
-		pseudoSuperClass: objectClass,
-		superClass:       objectClass,
-		constants:        make(map[string]*Pointer),
-		isModule:         false,
-		baseObj:          &baseObj{class: classClass, InstanceVariables: newEnvironment()},
-	}
-}
-
 func builtinCommonInstanceMethods() []*BuiltInMethodObject {
 	return []*BuiltInMethodObject{
 		{
@@ -634,6 +609,33 @@ func builtinClassClassMethods() []*BuiltInMethodObject {
 				}
 			},
 		},
+	}
+}
+
+// Common internal helper functions -------------------------------------
+
+// initializeClass is a common function for vm, which initializes and returns
+// a class instance with given class name.
+func (vm *VM) initializeClass(name string, isModule bool) *RClass {
+	class := vm.createRClass(name)
+	class.isModule = isModule
+
+	return class
+}
+
+func (vm *VM) createRClass(className string) *RClass {
+	objectClass := vm.objectClass
+	classClass := vm.topLevelClass(classClass)
+
+	return &RClass{
+		Name:             className,
+		Methods:          newEnvironment(),
+		ClassMethods:     newEnvironment(),
+		pseudoSuperClass: objectClass,
+		superClass:       objectClass,
+		constants:        make(map[string]*Pointer),
+		isModule:         false,
+		baseObj:          &baseObj{class: classClass, InstanceVariables: newEnvironment()},
 	}
 }
 

--- a/vm/class.go
+++ b/vm/class.go
@@ -73,7 +73,8 @@ func initObjectClass(c *RClass) *RClass {
 	return objectClass
 }
 
-// initializeClass initializes and returns a class instance with given class name
+// initializeClass is a common function for vm, which initializes and returns
+// a class instance with given class name.
 func (vm *VM) initializeClass(name string, isModule bool) *RClass {
 	class := vm.createRClass(name)
 	class.isModule = isModule
@@ -95,190 +96,6 @@ func (vm *VM) createRClass(className string) *RClass {
 		isModule:         false,
 		baseObj:          &baseObj{class: classClass, InstanceVariables: newEnvironment()},
 	}
-}
-
-// toString returns the basic inspected result (which is class name) of current class
-// TODO: Singleton class's inspect() should also mark if it's a singleton class explicitly.
-func (c *RClass) toString() string {
-	if c.isModule {
-		return "<Module:" + c.Name + ">"
-	}
-	return "<Class:" + c.Name + ">"
-}
-
-func (c *RClass) toJSON() string {
-	return c.toString()
-}
-
-func (c *RClass) setBuiltInMethods(methodList []*BuiltInMethodObject, classMethods bool) {
-	for _, m := range methodList {
-		c.Methods.set(m.Name, m)
-	}
-
-	if classMethods {
-		for _, m := range methodList {
-			c.ClassMethods.set(m.Name, m)
-		}
-	}
-}
-
-func (c *RClass) lookupClassMethod(methodName string) Object {
-	method, ok := c.ClassMethods.get(methodName)
-
-	if !ok {
-		if c.superClass != nil {
-			return c.superClass.lookupClassMethod(methodName)
-		}
-		if c.class != nil {
-			return c.class.lookupClassMethod(methodName)
-		}
-		return nil
-	}
-
-	return method
-}
-
-func (c *RClass) lookupInstanceMethod(methodName string) Object {
-	method, ok := c.Methods.get(methodName)
-
-	if !ok {
-		if c.superClass != nil {
-			return c.superClass.lookupInstanceMethod(methodName)
-		}
-
-		if c.class != nil {
-			return c.class.lookupInstanceMethod(methodName)
-		}
-
-		return nil
-	}
-
-	return method
-}
-
-func (c *RClass) lookupConstant(constName string, findInScope bool) *Pointer {
-	constant, ok := c.constants[constName]
-
-	if !ok {
-		if findInScope && c.scope != nil {
-			return c.scope.lookupConstant(constName, true)
-		}
-
-		if c.superClass != nil {
-			return c.superClass.lookupConstant(constName, false)
-		}
-
-		return nil
-	}
-
-	return constant
-}
-
-func (c *RClass) setClassConstant(constant *RClass) {
-	c.constants[constant.Name] = &Pointer{constant}
-}
-
-func (c *RClass) getClassConstant(constName string) (class *RClass) {
-	t := c.constants[constName].Target
-	class, ok := t.(*RClass)
-
-	if ok {
-		return
-	}
-
-	panic(constName + " is not a class.")
-}
-
-func (c *RClass) alreadyInherit(constant *RClass) bool {
-	if c.superClass == constant {
-		return true
-	}
-
-	if c.superClass.Name == objectClass {
-		return false
-	}
-
-	return c.superClass.alreadyInherit(constant)
-}
-
-// ReturnName returns the name of the class
-func (c *RClass) ReturnName() string {
-	return c.Name
-}
-
-func (c *RClass) returnSuperClass() *RClass {
-	return c.pseudoSuperClass
-}
-
-func (c *RClass) initializeInstance() *RObject {
-	instance := &RObject{baseObj: &baseObj{class: c, InstanceVariables: newEnvironment()}}
-
-	return instance
-}
-
-func (c *RClass) setAttrWriter(args interface{}) {
-
-	switch args := args.(type) {
-	case []Object:
-		for _, attr := range args {
-			attrName := attr.(*StringObject).Value
-			c.Methods.set(attrName+"=", generateAttrWriteMethod(attrName))
-		}
-	case []string:
-		for _, attrName := range args {
-			c.Methods.set(attrName+"=", generateAttrWriteMethod(attrName))
-		}
-	}
-
-}
-
-func (c *RClass) setAttrReader(args interface{}) {
-	switch args := args.(type) {
-	case []Object:
-		for _, attr := range args {
-			attrName := attr.(*StringObject).Value
-			c.Methods.set(attrName, generateAttrReadMethod(attrName))
-		}
-	case []string:
-		for _, attrName := range args {
-			c.Methods.set(attrName, generateAttrReadMethod(attrName))
-		}
-	}
-
-}
-
-func generateAttrWriteMethod(attrName string) *BuiltInMethodObject {
-	return &BuiltInMethodObject{
-		Name: attrName + "=",
-		Fn: func(receiver Object) builtinMethodBody {
-			return func(t *thread, args []Object, blockFrame *callFrame) Object {
-				v := receiver.(*RObject).InstanceVariables.set("@"+attrName, args[0])
-				return v
-			}
-		},
-	}
-}
-
-func generateAttrReadMethod(attrName string) *BuiltInMethodObject {
-	return &BuiltInMethodObject{
-		Name: attrName,
-		Fn: func(receiver Object) builtinMethodBody {
-			return func(t *thread, args []Object, blockFrame *callFrame) Object {
-				v, ok := receiver.(*RObject).InstanceVariables.get("@" + attrName)
-
-				if ok {
-					return v
-				}
-
-				return NULL
-			}
-		},
-	}
-}
-
-func (c *RClass) setAttrAccessor(args interface{}) {
-	c.setAttrReader(args)
-	c.setAttrWriter(args)
 }
 
 func builtinCommonInstanceMethods() []*BuiltInMethodObject {
@@ -818,4 +635,192 @@ func builtinClassClassMethods() []*BuiltInMethodObject {
 			},
 		},
 	}
+}
+
+// Polymorphic helper functions -----------------------------------------
+
+// toString returns the basic inspected result (which is class name) of current class
+// TODO: Singleton class's inspect() should also mark if it's a singleton class explicitly.
+func (c *RClass) toString() string {
+	if c.isModule {
+		return "<Module:" + c.Name + ">"
+	}
+	return "<Class:" + c.Name + ">"
+}
+
+func (c *RClass) toJSON() string {
+	return c.toString()
+}
+
+func (c *RClass) setBuiltInMethods(methodList []*BuiltInMethodObject, classMethods bool) {
+	for _, m := range methodList {
+		c.Methods.set(m.Name, m)
+	}
+
+	if classMethods {
+		for _, m := range methodList {
+			c.ClassMethods.set(m.Name, m)
+		}
+	}
+}
+
+func (c *RClass) lookupClassMethod(methodName string) Object {
+	method, ok := c.ClassMethods.get(methodName)
+
+	if !ok {
+		if c.superClass != nil {
+			return c.superClass.lookupClassMethod(methodName)
+		}
+		if c.class != nil {
+			return c.class.lookupClassMethod(methodName)
+		}
+		return nil
+	}
+
+	return method
+}
+
+func (c *RClass) lookupInstanceMethod(methodName string) Object {
+	method, ok := c.Methods.get(methodName)
+
+	if !ok {
+		if c.superClass != nil {
+			return c.superClass.lookupInstanceMethod(methodName)
+		}
+
+		if c.class != nil {
+			return c.class.lookupInstanceMethod(methodName)
+		}
+
+		return nil
+	}
+
+	return method
+}
+
+func (c *RClass) lookupConstant(constName string, findInScope bool) *Pointer {
+	constant, ok := c.constants[constName]
+
+	if !ok {
+		if findInScope && c.scope != nil {
+			return c.scope.lookupConstant(constName, true)
+		}
+
+		if c.superClass != nil {
+			return c.superClass.lookupConstant(constName, false)
+		}
+
+		return nil
+	}
+
+	return constant
+}
+
+func (c *RClass) setClassConstant(constant *RClass) {
+	c.constants[constant.Name] = &Pointer{constant}
+}
+
+func (c *RClass) getClassConstant(constName string) (class *RClass) {
+	t := c.constants[constName].Target
+	class, ok := t.(*RClass)
+
+	if ok {
+		return
+	}
+
+	panic(constName + " is not a class.")
+}
+
+func (c *RClass) alreadyInherit(constant *RClass) bool {
+	if c.superClass == constant {
+		return true
+	}
+
+	if c.superClass.Name == objectClass {
+		return false
+	}
+
+	return c.superClass.alreadyInherit(constant)
+}
+
+// ReturnName returns the name of the class
+func (c *RClass) ReturnName() string {
+	return c.Name
+}
+
+func (c *RClass) returnSuperClass() *RClass {
+	return c.pseudoSuperClass
+}
+
+func (c *RClass) initializeInstance() *RObject {
+	instance := &RObject{baseObj: &baseObj{class: c, InstanceVariables: newEnvironment()}}
+
+	return instance
+}
+
+func (c *RClass) setAttrWriter(args interface{}) {
+
+	switch args := args.(type) {
+	case []Object:
+		for _, attr := range args {
+			attrName := attr.(*StringObject).Value
+			c.Methods.set(attrName+"=", generateAttrWriteMethod(attrName))
+		}
+	case []string:
+		for _, attrName := range args {
+			c.Methods.set(attrName+"=", generateAttrWriteMethod(attrName))
+		}
+	}
+
+}
+
+func (c *RClass) setAttrReader(args interface{}) {
+	switch args := args.(type) {
+	case []Object:
+		for _, attr := range args {
+			attrName := attr.(*StringObject).Value
+			c.Methods.set(attrName, generateAttrReadMethod(attrName))
+		}
+	case []string:
+		for _, attrName := range args {
+			c.Methods.set(attrName, generateAttrReadMethod(attrName))
+		}
+	}
+
+}
+
+// Other helper functions -----------------------------------------------
+
+func generateAttrWriteMethod(attrName string) *BuiltInMethodObject {
+	return &BuiltInMethodObject{
+		Name: attrName + "=",
+		Fn: func(receiver Object) builtinMethodBody {
+			return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				v := receiver.(*RObject).InstanceVariables.set("@"+attrName, args[0])
+				return v
+			}
+		},
+	}
+}
+
+func generateAttrReadMethod(attrName string) *BuiltInMethodObject {
+	return &BuiltInMethodObject{
+		Name: attrName,
+		Fn: func(receiver Object) builtinMethodBody {
+			return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				v, ok := receiver.(*RObject).InstanceVariables.get("@" + attrName)
+
+				if ok {
+					return v
+				}
+
+				return NULL
+			}
+		},
+	}
+}
+
+func (c *RClass) setAttrAccessor(args interface{}) {
+	c.setAttrReader(args)
+	c.setAttrWriter(args)
 }

--- a/vm/error.go
+++ b/vm/error.go
@@ -35,6 +35,19 @@ const (
 	UnsupportedMethodError = "UnsupportedMethodError"
 )
 
+// Error ...
+type Error struct {
+	*baseObj
+	Message string
+}
+
+func initErrorObject(errorType *RClass, format string, args ...interface{}) *Error {
+	return &Error{
+		baseObj: &baseObj{class: errorType},
+		Message: fmt.Sprintf(errorType.Name+": "+format, args...),
+	}
+}
+
 func (vm *VM) initErrorClasses() {
 	ArgumentErrorClass = vm.initializeClass(ArgumentError, false)
 	InternalErrorClass = vm.initializeClass(InternalError, false)
@@ -44,24 +57,14 @@ func (vm *VM) initErrorClasses() {
 	UnsupportedMethodClass = vm.initializeClass(UnsupportedMethodError, false)
 }
 
-// Error ...
-type Error struct {
-	*baseObj
-	Message string
-}
+// Polymorphic helper functions -----------------------------------------
 
-// toString ...
+// toString converts error messages into string.
 func (e *Error) toString() string {
 	return "ERROR: " + e.Message
 }
 
+// toJSON converts the receiver into JSON string.
 func (e *Error) toJSON() string {
 	return e.toString()
-}
-
-func initErrorObject(errorType *RClass, format string, args ...interface{}) *Error {
-	return &Error{
-		baseObj: &baseObj{class: errorType},
-		Message: fmt.Sprintf(errorType.Name+": "+format, args...),
-	}
 }

--- a/vm/file.go
+++ b/vm/file.go
@@ -7,13 +7,11 @@ import (
 	"syscall"
 )
 
-func initializeFileClass(vm *VM) {
-	fc := vm.initializeClass("File", false)
-	fc.setBuiltInMethods(builtinFileClassMethods(), true)
-	fc.setBuiltInMethods(builtinFileInstanceMethods(), false)
-	vm.objectClass.setClassConstant(fc)
-
-	vm.execGobyLib("file.gb")
+var fileModeTable = map[string]int{
+	"r":  syscall.O_RDONLY,
+	"r+": syscall.O_RDWR,
+	"w":  syscall.O_WRONLY,
+	"w+": syscall.O_RDWR,
 }
 
 // FileObject is a special type that contains file pointer so we can keep track on target file.
@@ -22,20 +20,13 @@ type FileObject struct {
 	File *os.File
 }
 
-// toString returns detailed infoof a array include elements it contains
-func (f *FileObject) toString() string {
-	return "<File: " + f.File.Name() + ">"
-}
+func initFileClass(vm *VM) {
+	fc := vm.initializeClass("File", false)
+	fc.setBuiltInMethods(builtinFileClassMethods(), true)
+	fc.setBuiltInMethods(builtinFileInstanceMethods(), false)
+	vm.objectClass.setClassConstant(fc)
 
-func (f *FileObject) toJSON() string {
-	return f.toString()
-}
-
-var fileModeTable = map[string]int{
-	"r":  syscall.O_RDONLY,
-	"r+": syscall.O_RDWR,
-	"w":  syscall.O_WRONLY,
-	"w+": syscall.O_RDWR,
+	vm.execGobyLib("file.gb")
 }
 
 // Only initialize file related methods after it's being required.
@@ -340,4 +331,16 @@ func builtinFileInstanceMethods() []*BuiltInMethodObject {
 			},
 		},
 	}
+}
+
+// Polymorphic helper functions -----------------------------------------
+
+// toString returns detailed infoof a array include elements it contains
+func (f *FileObject) toString() string {
+	return "<File: " + f.File.Name() + ">"
+}
+
+// toJSON converts the receiver into JSON string.
+func (f *FileObject) toJSON() string {
+	return f.toString()
 }

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -39,54 +39,28 @@ type HashObject struct {
 	Pairs map[string]Object
 }
 
-func (h *HashObject) toString() string {
-	var out bytes.Buffer
-	var pairs []string
-
-	for key, value := range h.Pairs {
-		pairs = append(pairs, fmt.Sprintf("%s: %s", key, value.toString()))
-	}
-
-	out.WriteString("{ ")
-	out.WriteString(strings.Join(pairs, ", "))
-	out.WriteString(" }")
-
-	return out.String()
-}
-
-func (h *HashObject) length() int {
-	return len(h.Pairs)
-}
-
 func (vm *VM) initHashObject(pairs map[string]Object) *HashObject {
 	return &HashObject{Pairs: pairs, baseObj: &baseObj{class: vm.topLevelClass(hashClass)}}
 }
 
-func generateJSONFromPair(key string, v Object) string {
-	var data string
-	var out bytes.Buffer
-
-	out.WriteString(data)
-	out.WriteString("\"" + key + "\"")
-	out.WriteString(":")
-	out.WriteString(v.toJSON())
-
-	return out.String()
+func (vm *VM) initHashClass() *RClass {
+	hc := vm.initializeClass(hashClass, false)
+	hc.setBuiltInMethods(builtinHashInstanceMethods(), false)
+	hc.setBuiltInMethods(builtInHashClassMethods(), true)
+	return hc
 }
 
-func (h *HashObject) toJSON() string {
-	var out bytes.Buffer
-	var values []string
-	pairs := h.Pairs
-	out.WriteString("{")
-
-	for key, value := range pairs {
-		values = append(values, generateJSONFromPair(key, value))
+func builtInHashClassMethods() []*BuiltInMethodObject {
+	return []*BuiltInMethodObject{
+		{
+			Name: "new",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					return t.UnsupportedMethodError("#new", receiver)
+				}
+			},
+		},
 	}
-
-	out.WriteString(strings.Join(values, ","))
-	out.WriteString("}")
-	return out.String()
 }
 
 func builtinHashInstanceMethods() []*BuiltInMethodObject {
@@ -216,22 +190,54 @@ func builtinHashInstanceMethods() []*BuiltInMethodObject {
 	}
 }
 
-func builtInHashClassMethods() []*BuiltInMethodObject {
-	return []*BuiltInMethodObject{
-		{
-			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					return t.UnsupportedMethodError("#new", receiver)
-				}
-			},
-		},
+// Polymorphic helper functions -----------------------------------------
+
+// toString converts the receiver into string.
+func (h *HashObject) toString() string {
+	var out bytes.Buffer
+	var pairs []string
+
+	for key, value := range h.Pairs {
+		pairs = append(pairs, fmt.Sprintf("%s: %s", key, value.toString()))
 	}
+
+	out.WriteString("{ ")
+	out.WriteString(strings.Join(pairs, ", "))
+	out.WriteString(" }")
+
+	return out.String()
 }
 
-func (vm *VM) initHashClass() *RClass {
-	hc := vm.initializeClass(hashClass, false)
-	hc.setBuiltInMethods(builtinHashInstanceMethods(), false)
-	hc.setBuiltInMethods(builtInHashClassMethods(), true)
-	return hc
+// toJSON converts the receiver into JSON string.
+func (h *HashObject) toJSON() string {
+	var out bytes.Buffer
+	var values []string
+	pairs := h.Pairs
+	out.WriteString("{")
+
+	for key, value := range pairs {
+		values = append(values, generateJSONFromPair(key, value))
+	}
+
+	out.WriteString(strings.Join(values, ","))
+	out.WriteString("}")
+	return out.String()
+}
+
+func (h *HashObject) length() int {
+	return len(h.Pairs)
+}
+
+// Other helper functions ----------------------------------------------
+
+func generateJSONFromPair(key string, v Object) string {
+	var data string
+	var out bytes.Buffer
+
+	out.WriteString(data)
+	out.WriteString("\"" + key + "\"")
+	out.WriteString(":")
+	out.WriteString(v.toJSON())
+
+	return out.String()
 }

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -40,7 +40,10 @@ type HashObject struct {
 }
 
 func (vm *VM) initHashObject(pairs map[string]Object) *HashObject {
-	return &HashObject{Pairs: pairs, baseObj: &baseObj{class: vm.topLevelClass(hashClass)}}
+	return &HashObject{
+		baseObj: &baseObj{class: vm.topLevelClass(hashClass)},
+		Pairs:   pairs,
+	}
 }
 
 func (vm *VM) initHashClass() *RClass {

--- a/vm/http.go
+++ b/vm/http.go
@@ -11,12 +11,12 @@ var (
 	httpResponseClass *RClass
 )
 
-func initializeHTTPClass(vm *VM) {
+func initHTTPClass(vm *VM) {
 	net := vm.loadConstant("Net", true)
 	http := vm.initializeClass("HTTP", false)
 	http.setBuiltInMethods(builtinHTTPClassMethods(), true)
-	initializeRequestClass(vm, http)
-	initializeResponseClass(vm, http)
+	initRequestClass(vm, http)
+	initResponseClass(vm, http)
 
 	net.setClassConstant(http)
 
@@ -25,7 +25,7 @@ func initializeHTTPClass(vm *VM) {
 	vm.execGobyLib("net/http/request.gb")
 }
 
-func initializeRequestClass(vm *VM, hc *RClass) *RClass {
+func initRequestClass(vm *VM, hc *RClass) *RClass {
 	requestClass := vm.initializeClass("Request", false)
 	hc.setClassConstant(requestClass)
 	builtinHTTPRequestInstanceMethods := []*BuiltInMethodObject{}
@@ -36,7 +36,7 @@ func initializeRequestClass(vm *VM, hc *RClass) *RClass {
 	return requestClass
 }
 
-func initializeResponseClass(vm *VM, hc *RClass) *RClass {
+func initResponseClass(vm *VM, hc *RClass) *RClass {
 	responseClass := vm.initializeClass("Response", false)
 	hc.setClassConstant(responseClass)
 	builtinHTTPResponseInstanceMethods := []*BuiltInMethodObject{}

--- a/vm/inspection_methods.go
+++ b/vm/inspection_methods.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+// Polymorphic helper functions for inspecting internal info.
+
 func (i *instruction) inspect() string {
 	var params []string
 

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -19,7 +19,10 @@ type IntegerObject struct {
 }
 
 func (vm *VM) initIntegerObject(value int) *IntegerObject {
-	return &IntegerObject{Value: value, baseObj: &baseObj{class: vm.topLevelClass(integerClass)}}
+	return &IntegerObject{
+		baseObj: &baseObj{class: vm.topLevelClass(integerClass)},
+		Value:   value,
+	}
 }
 
 func (vm *VM) initIntegerClass() *RClass {

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -18,16 +18,8 @@ type IntegerObject struct {
 	Value int
 }
 
-func (i *IntegerObject) toString() string {
-	return strconv.Itoa(i.Value)
-}
-
-func (i *IntegerObject) toJSON() string {
-	return i.toString()
-}
-
-func (i *IntegerObject) equal(e *IntegerObject) bool {
-	return i.Value == e.Value
+func (vm *VM) initIntegerObject(value int) *IntegerObject {
+	return &IntegerObject{Value: value, baseObj: &baseObj{class: vm.topLevelClass(integerClass)}}
 }
 
 func (vm *VM) initIntegerClass() *RClass {
@@ -37,8 +29,17 @@ func (vm *VM) initIntegerClass() *RClass {
 	return ic
 }
 
-func (vm *VM) initIntegerObject(value int) *IntegerObject {
-	return &IntegerObject{Value: value, baseObj: &baseObj{class: vm.topLevelClass(integerClass)}}
+func builtInIntegerClassMethods() []*BuiltInMethodObject {
+	return []*BuiltInMethodObject{
+		{
+			Name: "new",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					return t.UnsupportedMethodError("#new", receiver)
+				}
+			},
+		},
+	}
 }
 
 func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
@@ -570,15 +571,18 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 	}
 }
 
-func builtInIntegerClassMethods() []*BuiltInMethodObject {
-	return []*BuiltInMethodObject{
-		{
-			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					return t.UnsupportedMethodError("#new", receiver)
-				}
-			},
-		},
-	}
+// Polymorphic helper functions -----------------------------------------
+
+// toString converts the receiver into string.
+func (i *IntegerObject) toString() string {
+	return strconv.Itoa(i.Value)
+}
+
+// toJSON converts the receiver into JSON string.
+func (i *IntegerObject) toJSON() string {
+	return i.toString()
+}
+
+func (i *IntegerObject) equal(e *IntegerObject) bool {
+	return i.Value == e.Value
 }

--- a/vm/method.go
+++ b/vm/method.go
@@ -5,10 +5,6 @@ import (
 	"fmt"
 )
 
-func (vm *VM) initMethodClass() *RClass {
-	return vm.initializeClass(methodClass, false)
-}
-
 // MethodObject represents methods defined using goby.
 type MethodObject struct {
 	*baseObj
@@ -16,6 +12,21 @@ type MethodObject struct {
 	instructionSet *instructionSet
 	argc           int
 }
+
+type builtinMethodBody func(*thread, []Object, *callFrame) Object
+
+// BuiltInMethodObject represents methods defined in go.
+type BuiltInMethodObject struct {
+	*baseObj
+	Name string
+	Fn   func(receiver Object) builtinMethodBody
+}
+
+func (vm *VM) initMethodClass() *RClass {
+	return vm.initializeClass(methodClass, false)
+}
+
+// Polymorphic helper functions -----------------------------------------
 
 // toString returns method's name, params count and instruction set.
 func (m *MethodObject) toString() string {
@@ -29,15 +40,6 @@ func (m *MethodObject) toString() string {
 
 func (m *MethodObject) toJSON() string {
 	return m.toString()
-}
-
-type builtinMethodBody func(*thread, []Object, *callFrame) Object
-
-// BuiltInMethodObject represents methods defined in go.
-type BuiltInMethodObject struct {
-	*baseObj
-	Name string
-	Fn   func(receiver Object) builtinMethodBody
 }
 
 // toString just returns built in method's name.

--- a/vm/null.go
+++ b/vm/null.go
@@ -12,15 +12,6 @@ type NullObject struct {
 	*baseObj
 }
 
-// toString returns the name of NullObject
-func (n *NullObject) toString() string {
-	return "nil"
-}
-
-func (n *NullObject) toJSON() string {
-	return "null"
-}
-
 func (vm *VM) initNullClass() *RClass {
 	nc := vm.initializeClass(nullClass, false)
 	nc.setBuiltInMethods(builtInNullInstanceMethods(), false)
@@ -62,4 +53,15 @@ func builtInNullInstanceMethods() []*BuiltInMethodObject {
 			},
 		},
 	}
+}
+
+// Polymorphic helper functions -----------------------------------------
+
+// toString returns the name of NullObject
+func (n *NullObject) toString() string {
+	return "nil"
+}
+
+func (n *NullObject) toJSON() string {
+	return "null"
 }

--- a/vm/object.go
+++ b/vm/object.go
@@ -33,15 +33,6 @@ type baseObj struct {
 	InstanceVariables *environment
 }
 
-// toString tells which class it belongs to.
-func (ro *RObject) toString() string {
-	return "<Instance of: " + ro.class.Name + ">"
-}
-
-func (ro *RObject) toJSON() string {
-	return ro.toString()
-}
-
 // Class will return object's class
 func (b *baseObj) Class() *RClass {
 	if b.class == nil {
@@ -65,6 +56,20 @@ func (b *baseObj) instanceVariableSet(name string, value Object) Object {
 
 	return value
 }
+
+// Polymorphic helper functions -----------------------------------------
+
+// toString tells which class it belongs to.
+func (ro *RObject) toString() string {
+	return "<Instance of: " + ro.class.Name + ">"
+}
+
+// toJSON converts the receiver into JSON string.
+func (ro *RObject) toJSON() string {
+	return ro.toString()
+}
+
+// Other helper functions -----------------------------------------------
 
 func checkArgumentLen(args []Object, class *RClass, methodName string) *Error {
 	if len(args) > 1 {

--- a/vm/range.go
+++ b/vm/range.go
@@ -29,7 +29,11 @@ type RangeObject struct {
 }
 
 func (vm *VM) initRangeObject(start, end int) *RangeObject {
-	return &RangeObject{baseObj: &baseObj{class: vm.topLevelClass(rangeClass)}, Start: start, End: end}
+	return &RangeObject{
+		baseObj: &baseObj{class: vm.topLevelClass(rangeClass)},
+		Start:   start,
+		End:     end,
+	}
 }
 
 func (vm *VM) initRangeClass() *RClass {

--- a/vm/range.go
+++ b/vm/range.go
@@ -1,8 +1,6 @@
 package vm
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // RangeObject is the built in range class
 // Range represents an interval: a set of values from the beginning to the end specified.
@@ -28,14 +26,6 @@ type RangeObject struct {
 	*baseObj
 	Start int
 	End   int
-}
-
-func (ro *RangeObject) toString() string {
-	return fmt.Sprintf("(%d..%d)", ro.Start, ro.End)
-}
-
-func (ro *RangeObject) toJSON() string {
-	return ro.toString()
 }
 
 func (vm *VM) initRangeObject(start, end int) *RangeObject {
@@ -424,4 +414,16 @@ func builtInRangeInstanceMethods() []*BuiltInMethodObject {
 			},
 		},
 	}
+}
+
+// Polymorphic helper functions -----------------------------------------
+
+// toString converts range into string.
+func (ro *RangeObject) toString() string {
+	return fmt.Sprintf("(%d..%d)", ro.Start, ro.End)
+}
+
+// toJSON converts the receiver into JSON string.
+func (ro *RangeObject) toJSON() string {
+	return ro.toString()
 }

--- a/vm/simple_server.go
+++ b/vm/simple_server.go
@@ -27,8 +27,8 @@ type request struct {
 	Host   string
 }
 
-func initializeSimpleServerClass(vm *VM) {
-	initializeHTTPClass(vm)
+func initSimpleServerClass(vm *VM) {
+	initHTTPClass(vm)
 	net := vm.loadConstant("Net", true)
 	simpleServer := vm.initializeClass("SimpleServer", false)
 	simpleServer.setBuiltInMethods(builtinSimpleServerInstanceMethods(), false)

--- a/vm/string.go
+++ b/vm/string.go
@@ -31,7 +31,10 @@ type StringObject struct {
 
 func (vm *VM) initStringObject(value string) *StringObject {
 	replacer := strings.NewReplacer("\\n", "\n", "\\r", "\r", "\\t", "\t", "\\v", "\v", "\\\\", "\\")
-	return &StringObject{Value: replacer.Replace(value), baseObj: &baseObj{class: vm.topLevelClass(stringClass)}}
+	return &StringObject{
+		baseObj: &baseObj{class: vm.topLevelClass(stringClass)},
+		Value:   replacer.Replace(value),
+	}
 }
 
 func (vm *VM) initStringClass() *RClass {

--- a/vm/string.go
+++ b/vm/string.go
@@ -29,18 +29,6 @@ type StringObject struct {
 	Value string
 }
 
-func (s *StringObject) toString() string {
-	return s.Value
-}
-
-func (s *StringObject) toJSON() string {
-	return "\"" + s.Value + "\""
-}
-
-func (s *StringObject) equal(e *StringObject) bool {
-	return s.Value == e.Value
-}
-
 func (vm *VM) initStringObject(value string) *StringObject {
 	replacer := strings.NewReplacer("\\n", "\n", "\\r", "\r", "\\t", "\t", "\\v", "\v", "\\\\", "\\")
 	return &StringObject{Value: replacer.Replace(value), baseObj: &baseObj{class: vm.topLevelClass(stringClass)}}
@@ -485,4 +473,20 @@ func builtInStringClassMethods() []*BuiltInMethodObject {
 			},
 		},
 	}
+}
+
+// Polymorphic helper functions -----------------------------------------
+
+// toString just returns the value of string.
+func (s *StringObject) toString() string {
+	return s.Value
+}
+
+// toJSON converts the receiver into JSON string.
+func (s *StringObject) toJSON() string {
+	return "\"" + s.Value + "\""
+}
+
+func (s *StringObject) equal(e *StringObject) bool {
+	return s.Value == e.Value
 }

--- a/vm/uri.go
+++ b/vm/uri.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 )
 
-func initializeURIClass(vm *VM) {
+func initURIClass(vm *VM) {
 	uri := vm.initializeClass("URI", true)
 	http := vm.initializeClass("HTTP", false)
 	https := vm.initializeClass("HTTPS", false)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -26,9 +26,9 @@ type errorMessage string
 
 var standardLibraries = map[string]func(*VM){
 	"file":              initFileClass,
-	"net/http":          initializeHTTPClass,
-	"net/simple_server": initializeSimpleServerClass,
-	"uri":               initializeURIClass,
+	"net/http":          initHTTPClass,
+	"net/simple_server": initSimpleServerClass,
+	"uri":               initURIClass,
 }
 
 // VM represents a stack based virtual machine.

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -25,7 +25,7 @@ type filename string
 type errorMessage string
 
 var standardLibraries = map[string]func(*VM){
-	"file":              initializeFileClass,
+	"file":              initFileClass,
 	"net/http":          initializeHTTPClass,
 	"net/simple_server": initializeSimpleServerClass,
 	"uri":               initializeURIClass,


### PR DESCRIPTION
I hope this helps us.

1. type definitions
2. init*Object()
3. init*Class()
4. class methods
5. instance methods
6. polymorphic helper functions
7. other helper functions