### PR TITLE
WIP: Introducing readline in REPL

### DIFF
--- a/goby.go
+++ b/goby.go
@@ -25,7 +25,7 @@ func main() {
 	flag.Parse()
 
 	if *interactiveOptionPtr {
-		igb.Start(Version)
+		igb.StartIgb(Version)
 		os.Exit(0)
 	}
 

--- a/goby.go
+++ b/goby.go
@@ -1,17 +1,17 @@
 package main
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
-	"github.com/goby-lang/goby/compiler"
-	"github.com/goby-lang/goby/igb"
-	"github.com/goby-lang/goby/vm"
-	"github.com/pkg/profile"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/goby-lang/goby/compiler"
+	"github.com/goby-lang/goby/igb"
+	"github.com/goby-lang/goby/vm"
+	"github.com/pkg/profile"
 )
 
 // Version stores current Goby version
@@ -25,23 +25,8 @@ func main() {
 	flag.Parse()
 
 	if *interactiveOptionPtr {
-		scanner := bufio.NewScanner(os.Stdin)
-
-		ch := make(chan string)
-
-		go func() {
-			for {
-				scanned := scanner.Scan()
-
-				if !scanned {
-					continue
-				}
-
-				ch <- scanner.Text()
-			}
-		}()
-
-		igb.Start(ch, os.Stdout)
+		igb.Start(Version)
+		os.Exit(0)
 	}
 
 	if *profileOptionPtr {

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -1,145 +1,124 @@
 package igb
 
 import (
-	"bytes"
-	"fmt"
-	"github.com/goby-lang/goby/compiler/bytecode"
-	"github.com/goby-lang/goby/compiler/lexer"
-	"github.com/goby-lang/goby/compiler/parser"
-	"github.com/goby-lang/goby/vm"
 	"io"
-	"os"
+	"strings"
 
-	"github.com/goby-lang/goby/Godeps/_workspace/src/github.com/looplab/fsm"
+	"github.com/chzyer/readline"
 )
 
 const (
-	prompt = ">> "
+	//readyToExec = "readyToExec"
+	//Waiting     = "waiting"
+	//waitEnded   = "waitEnded"
 
-	readyToExec = "readyToExec"
-	Waiting     = "waiting"
-	waitEnded   = "waitEnded"
+	prompt    = "\033[31m»\033[0m "
+	echo      = "#=>"
+	interrupt = "^C"
+	exit      = "exit"
+	help      = "help"
 )
 
-var sm = fsm.NewFSM(
-	readyToExec,
-	fsm.Events{
-		{Name: Waiting, Src: []string{waitEnded, readyToExec}, Dst: Waiting},
-		{Name: waitEnded, Src: []string{Waiting}, Dst: waitEnded},
-		{Name: readyToExec, Src: []string{waitEnded, readyToExec}, Dst: readyToExec},
-	},
-	fsm.Callbacks{},
+var completer = readline.NewPrefixCompleter(
+	readline.PcItem(help),
+	readline.PcItem(exit),
 )
-var stmts = bytes.Buffer{}
+
+//var sm = fsm.NewFSM(
+//	readyToExec,
+//	fsm.Events{
+//		{Name: Waiting, Src: []string{waitEnded, readyToExec}, Dst: Waiting},
+//		{Name: waitEnded, Src: []string{Waiting}, Dst: waitEnded},
+//		{Name: readyToExec, Src: []string{waitEnded, readyToExec}, Dst: readyToExec},
+//	},
+//	fsm.Callbacks{},
+//)
+
+//var stmts = bytes.Buffer{}
 
 // Start starts goby's REPL.
-func Start(ch chan string, out io.Writer) {
-	// Initialize VM
-	v := vm.New(os.Getenv("GOBY_ROOT"), []string{})
-	v.SetClassISIndexTable("")
-	v.SetMethodISIndexTable("")
-	v.InitForREPL()
+func Start(version string) {
+	var err error
+	rl, err := readline.NewEx(&readline.Config{
+		Prompt:              prompt,
+		HistoryFile:         "/tmp/readline.tmp",
+		AutoComplete:        completer,
+		InterruptPrompt:     interrupt,
+		EOFPrompt:           exit,
+		HistorySearchFold:   true,
+		FuncFilterInputRune: filterInput,
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer rl.Close()
 
-	// Initialize parser, lexer is not important here
-	l := lexer.New("")
-	p := parser.New(l)
-	program, _ := p.ParseProgram()
+	//log.SetOutput(rl.Stderr())
 
-	// Initialize code generator, and it will behavior a little different in REPL mode.
-	g := bytecode.NewGenerator()
-	g.REPL = true
-	g.InitTopLevelScope(program)
+	println("Goby", version)
+
+	//// Initialize VM
+	//v := vm.New(os.Getenv("GOBY_ROOT"), []string{})
+	//v.SetClassISIndexTable("")
+	//v.SetMethodISIndexTable("")
+	//v.InitForREPL()
+	//
+	//// Initialize parser, lexer is not important here
+	//l := lexer.New("")
+	//p := parser.New(l)
+	//program, _ := p.ParseProgram()
+	//
+	//// Initialize code generator, and it will behavior a little different in REPL mode.
+	//g := bytecode.NewGenerator()
+	//g.REPL = true
+	//g.InitTopLevelScope(program)
 
 	for {
-		out.Write([]byte(prompt))
+		line, err := rl.Readline()
 
-		line := <-ch
-
-		out.Write([]byte(line + "\n"))
-
-		switch line {
-		case "exit":
-			return
-		case "\n":
-			continue
-		}
-
-		l := lexer.New(line)
-		p.Lexer = l
-		program, err := p.ParseProgram()
-
-		if err != nil {
-			if err.IsEOF() {
-				if !sm.Is(Waiting) {
-					sm.Event(Waiting)
-				}
-
-				appendStmt(line)
-				continue
-			}
-
-			if err.IsUnexpectedEnd() {
-				sm.Event(waitEnded)
-				appendStmt(line)
+		if err == readline.ErrInterrupt {
+			if len(line) == 0 {
+				break
 			} else {
-				fmt.Println(err.Message)
 				continue
 			}
-
+		} else if err == io.EOF {
+			break
 		}
 
-		if sm.Is(Waiting) {
-			appendStmt(line)
-			continue
-		}
-
-		if sm.Is(waitEnded) {
-			l := lexer.New(stmts.String())
-			p.Lexer = l
-
-			// Test if current input can be properly parsed.
-			program, err = p.ParseProgram()
-
-			/*
-			 This could mean there still are statements not ended, for example:
-
-			 ```ruby
-			 class Foo
-			   def bar
-			   end # This make state changes to WaitEnded
-			 # But here still needs an "end"
-			 ```
-			*/
-
-			if err != nil {
-				if !err.IsEOF() {
-					fmt.Println(err.Message)
-				}
-				continue
-			}
-
-			// If everything goes well, reset state and statements buffer
-			sm.Event(readyToExec)
-			stmts.Reset()
-		}
-
-		if sm.Is(readyToExec) {
-			instructions := g.GenerateInstructions(program.Statements)
-			g.ResetInstructionSets()
-			v.REPLExec(instructions)
-
-			r := v.GetREPLResult()
-
-			switch r {
-			case "\n", "":
-				continue
-			default:
-				out.Write([]byte(fmt.Sprintf("#=> %s\n", r)))
-			}
+		line = strings.TrimSpace(line)
+		switch {
+		case line == help:
+			usage(rl.Stderr())
+		case line == exit:
+			println("Bye!")
+			return
+		case line == "":
+		default:
+			println(echo, line)
+			//l := lexer.New(line)
+			//p.Lexer = l
+			//program, _ := p.ParseProgram()
+			//instructions := g.GenerateInstructions(program.Statements)
+			//g.ResetInstructionSets()
+			//v.REPLExec(instructions)
+			//
+			//r := v.GetREPLResult()
+			//println(echo, r)
 		}
 	}
 }
 
-func appendStmt(line string) {
-	stmts.WriteString(line + "\n")
+func usage(w io.Writer) {
+	io.WriteString(w, "commands:\n")
+	io.WriteString(w, completer.Tree("    "))
+}
+
+func filterInput(r rune) (rune, bool) {
+	switch r {
+	// block CtrlZ feature
+	case readline.CharCtrlZ:
+		return r, false
+	}
+	return r, true
 }

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -2,9 +2,15 @@ package igb
 
 import (
 	"io"
+	"log"
+	"os"
 	"strings"
 
 	"github.com/chzyer/readline"
+	"github.com/goby-lang/goby/compiler/bytecode"
+	"github.com/goby-lang/goby/compiler/lexer"
+	"github.com/goby-lang/goby/compiler/parser"
+	"github.com/goby-lang/goby/vm"
 )
 
 const (
@@ -24,18 +30,6 @@ var completer = readline.NewPrefixCompleter(
 	readline.PcItem(exit),
 )
 
-//var sm = fsm.NewFSM(
-//	readyToExec,
-//	fsm.Events{
-//		{Name: Waiting, Src: []string{waitEnded, readyToExec}, Dst: Waiting},
-//		{Name: waitEnded, Src: []string{Waiting}, Dst: waitEnded},
-//		{Name: readyToExec, Src: []string{waitEnded, readyToExec}, Dst: readyToExec},
-//	},
-//	fsm.Callbacks{},
-//)
-
-//var stmts = bytes.Buffer{}
-
 // Start starts goby's REPL.
 func Start(version string) {
 	var err error
@@ -53,25 +47,25 @@ func Start(version string) {
 	}
 	defer rl.Close()
 
-	//log.SetOutput(rl.Stderr())
+	log.SetOutput(rl.Stderr())
 
 	println("Goby", version)
 
-	//// Initialize VM
-	//v := vm.New(os.Getenv("GOBY_ROOT"), []string{})
-	//v.SetClassISIndexTable("")
-	//v.SetMethodISIndexTable("")
-	//v.InitForREPL()
-	//
-	//// Initialize parser, lexer is not important here
-	//l := lexer.New("")
-	//p := parser.New(l)
-	//program, _ := p.ParseProgram()
-	//
-	//// Initialize code generator, and it will behavior a little different in REPL mode.
-	//g := bytecode.NewGenerator()
-	//g.REPL = true
-	//g.InitTopLevelScope(program)
+	// Initialize VM
+	v := vm.New(os.Getenv("GOBY_ROOT"), []string{})
+	v.SetClassISIndexTable("")
+	v.SetMethodISIndexTable("")
+	v.InitForREPL()
+
+	// Initialize parser, lexer is not important here
+	l := lexer.New("")
+	p := parser.New(l)
+	program, _ := p.ParseProgram()
+
+	// Initialize code generator, and it will behavior a little different in REPL mode.
+	g := bytecode.NewGenerator()
+	g.REPL = true
+	g.InitTopLevelScope(program)
 
 	for {
 		line, err := rl.Readline()
@@ -96,15 +90,15 @@ func Start(version string) {
 		case line == "":
 		default:
 			println(echo, line)
-			//l := lexer.New(line)
-			//p.Lexer = l
-			//program, _ := p.ParseProgram()
-			//instructions := g.GenerateInstructions(program.Statements)
-			//g.ResetInstructionSets()
-			//v.REPLExec(instructions)
-			//
-			//r := v.GetREPLResult()
-			//println(echo, r)
+			l := lexer.New(line)
+			p.Lexer = l
+			program, _ := p.ParseProgram()
+			instructions := g.GenerateInstructions(program.Statements)
+			g.ResetInstructionSets()
+			v.REPLExec(instructions)
+
+			r := v.GetREPLResult()
+			println(echo, r)
 		}
 	}
 }

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -14,10 +14,6 @@ import (
 )
 
 const (
-	//readyToExec = "readyToExec"
-	//Waiting     = "waiting"
-	//waitEnded   = "waitEnded"
-
 	prompt    = "\033[31m»\033[0m "
 	echo      = "#=>"
 	interrupt = "^C"

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -71,7 +71,6 @@ func StartIgb(version string) {
 			return
 		case line == "":
 		default:
-			println(echo, line)
 			l := lexer.New(line)
 			p.Lexer = l
 			program, _ := p.ParseProgram()

--- a/igb/repl_test.go
+++ b/igb/repl_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestStart(t *testing.T) {
+func TestStartIgb(t *testing.T) {
 	tests := []struct {
 		inputs   []string
 		expected string


### PR DESCRIPTION
For #233, I tried for my interests https://github.com/chzyer/readline a little and looks very fine for improving REPL.

Currently, just a single-line execution is possible, but all readline features such as command history or autocomplete (`help` and `exit`) are availables.
I'm wondering how to write tests for igb.go.

[readline-multiline.go](https://github.com/chzyer/readline/blob/master/example/readline-multiline/readline-multiline.go) is also an example of multiline execution. 

Could you take a look at this?