### PR TITLE
Implementing auto-indentation in REPL

### DIFF
--- a/igb/repl.go
+++ b/igb/repl.go
@@ -95,17 +95,18 @@ func StartIgb(version string) {
 		if err != nil {
 			switch {
 			case err == io.EOF:
-				println(line + "-- err:io.EOF")
+				println(line + "")
 				return
 			case err == readline.ErrInterrupt: // Pressing Ctrl-C
 				if len(line) == 0 && cmds == nil {
-					println(line + "-- ctrl+c")
+					println("")
 					println("Bye!")
 					return
 				} else {
 					// Erasing command buffer
-					println(prompt(stack) + indent(stack) + line)
-					rl.SetPrompt(prompt(stack))
+					println("")
+					stack = 0
+					rl.SetPrompt(prompt1)
 					sm.Event(Waiting)
 					cmds = nil
 					continue
@@ -152,8 +153,9 @@ func StartIgb(version string) {
 			} else {
 				println(prompt(stack) + indent(stack) + line)
 				stack = 0
-				rl.SetPrompt(prompt(stack))
+				rl.SetPrompt(prompt1)
 				fmt.Println(perr.Message)
+				cmds = nil
 				continue
 			}
 

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -102,15 +102,14 @@ func StartIgb(version string) {
 					println("")
 					println("Bye!")
 					return
-				} else {
-					// Erasing command buffer
-					println("")
-					stack = 0
-					rl.SetPrompt(prompt1)
-					sm.Event(Waiting)
-					cmds = nil
-					continue
 				}
+				// Erasing command buffer
+				println("")
+				stack = 0
+				rl.SetPrompt(prompt1)
+				sm.Event(Waiting)
+				cmds = nil
+				continue
 			}
 		}
 
@@ -239,7 +238,6 @@ func indent(c int) string {
 func prompt(s int) string {
 	if s > 0 {
 		return prompt2
-	} else {
-		return prompt1
 	}
+	return prompt1
 }

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -132,7 +132,7 @@ func StartIgb(version string) {
 
 				stack++
 				rl.SetPrompt(prompt2 + indent(stack))
-				cmds = append(cmds, line)
+				cmds = append(cmds, strings.TrimSpace(line))
 				continue
 			}
 
@@ -141,7 +141,7 @@ func StartIgb(version string) {
 				stack--
 				rl.SetPrompt(prompt2 + indent(stack))
 				sm.Event(waitEnded)
-				cmds = append(cmds, line)
+				cmds = append(cmds, strings.TrimSpace(line))
 			} else {
 				stack = 0
 				rl.SetPrompt(prompt)
@@ -153,7 +153,7 @@ func StartIgb(version string) {
 
 		if sm.Is(Waiting) {
 			rl.SetPrompt(prompt2 + indent(stack))
-			cmds = append(cmds, line)
+			cmds = append(cmds, strings.TrimSpace(line))
 			continue
 		}
 


### PR DESCRIPTION
I'm a bit stucked: how do I redraw the previous line on unindentation.

<img width="166" alt="170716_0729_dvhdlw" src="https://user-images.githubusercontent.com/4289625/28243050-990db314-69f8-11e7-83a6-c5fe5757ca19.png">

Looks like the current [readline](https://github.com/chzyer/readline) package has no api to redraw the previous line (or might be I looked over). In addition, the document is too short.

Looking at [commit log](https://github.com/chzyer/readline/pulls), the package has not been updated for months while [some PRs](https://github.com/chzyer/readline/pulls) remain.

Controlling readline is pretty hard because the behavior often depends on terminal and OS environments.

Any suggestion?