### PR TITLE
Mark if constant is used as an namespace. (Fix #279)

### DIFF
--- a/compiler/ast/variables.go
+++ b/compiler/ast/variables.go
@@ -44,8 +44,9 @@ func (iv *InstanceVariable) String() string {
 }
 
 type Constant struct {
-	Token token.Token
-	Value string
+	Token       token.Token
+	Value       string
+	IsNamespace bool
 }
 
 func (c *Constant) variableNode() {}

--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -10,7 +10,7 @@ func (g *Generator) compileExpression(is *InstructionSet, exp ast.Expression, sc
 	if g.fsm.Is(keepExp) {
 		switch exp := exp.(type) {
 		case *ast.Constant:
-			is.define(GetConstant, exp.Value)
+			is.define(GetConstant, exp.Value, fmt.Sprint(exp.IsNamespace))
 		case *ast.InstanceVariable:
 			is.define(GetInstanceVariable, exp.Value)
 		case *ast.IntegerLiteral:

--- a/compiler/bytecode/expression_generation_test.go
+++ b/compiler/bytecode/expression_generation_test.go
@@ -120,10 +120,10 @@ func TestConstantCompilation(t *testing.T) {
 <ProgramStart>
 0 putobject 10
 1 setconstant Foo
-2 getconstant Foo
+2 getconstant Foo false
 3 setconstant Bar
-4 getconstant Foo
-5 getconstant Bar
+4 getconstant Foo false
+5 getconstant Bar false
 6 send + 1
 7 leave
 `

--- a/compiler/bytecode/generator_test.go
+++ b/compiler/bytecode/generator_test.go
@@ -19,7 +19,7 @@ func TestRequireRelativeCompilation(t *testing.T) {
 0 putself
 1 putstring "foo"
 2 send require_relative 1
-3 getconstant Foo
+3 getconstant Foo false
 4 send bar 0
 5 leave
 `
@@ -40,7 +40,7 @@ func TestRequireCompilation(t *testing.T) {
 0 putself
 1 putstring "foo"
 2 send require 1
-3 getconstant Foo
+3 getconstant Foo false
 4 send bar 0
 5 leave
 `
@@ -105,7 +105,7 @@ i
 6 setlocal 0 1
 7 putobject 1000
 8 setlocal 0 2
-9 getconstant Foo
+9 getconstant Foo false
 10 send new 0
 11 setlocal 0 3
 12 getlocal 0 3
@@ -158,64 +158,6 @@ puts(x)
 7 leave
 `
 
-	bytecode := compileToBytecode(input)
-	compareBytecode(t, bytecode, expected)
-}
-
-func TestCumstomConstructor(t *testing.T) {
-	input := `
-class Foo
-  def initialize(x, y)
-    @x = x
-    @y = y
-    @z = x - y
-  end
-
-  def bar
-    @x + @y + @z
-  end
-end
-
-Foo.new(100, 50).bar
-`
-
-	expected := `
-<Def:initialize>
-0 getlocal 0 0
-1 setinstancevariable @x
-2 getlocal 0 1
-3 setinstancevariable @y
-4 getlocal 0 0
-5 getlocal 0 1
-6 send - 1
-7 setinstancevariable @z
-8 leave
-<Def:bar>
-0 getinstancevariable @x
-1 getinstancevariable @y
-2 send + 1
-3 getinstancevariable @z
-4 send + 1
-5 leave
-<DefClass:Foo>
-0 putself
-1 putstring "initialize"
-2 def_method 2
-3 putself
-4 putstring "bar"
-5 def_method 0
-6 leave
-<ProgramStart>
-0 putself
-1 def_class class:Foo
-2 pop
-3 getconstant Foo
-4 putobject 100
-5 putobject 50
-6 send new 2
-7 send bar 0
-8 leave
-`
 	bytecode := compileToBytecode(input)
 	compareBytecode(t, bytecode, expected)
 }

--- a/compiler/bytecode/statement_generation_test.go
+++ b/compiler/bytecode/statement_generation_test.go
@@ -49,6 +49,64 @@ func TestWhileStatementInBlock(t *testing.T) {
 	compareBytecode(t, bytecode, expected)
 }
 
+func TestCustomClassConstructor(t *testing.T) {
+	input := `
+class Foo
+  def initialize(x, y)
+    @x = x
+    @y = y
+    @z = x - y
+  end
+
+  def bar
+    @x + @y + @z
+  end
+end
+
+Foo.new(100, 50).bar
+`
+
+	expected := `
+<Def:initialize>
+0 getlocal 0 0
+1 setinstancevariable @x
+2 getlocal 0 1
+3 setinstancevariable @y
+4 getlocal 0 0
+5 getlocal 0 1
+6 send - 1
+7 setinstancevariable @z
+8 leave
+<Def:bar>
+0 getinstancevariable @x
+1 getinstancevariable @y
+2 send + 1
+3 getinstancevariable @z
+4 send + 1
+5 leave
+<DefClass:Foo>
+0 putself
+1 putstring "initialize"
+2 def_method 2
+3 putself
+4 putstring "bar"
+5 def_method 0
+6 leave
+<ProgramStart>
+0 putself
+1 def_class class:Foo
+2 pop
+3 getconstant Foo false
+4 putobject 100
+5 putobject 50
+6 send new 2
+7 send bar 0
+8 leave
+`
+	bytecode := compileToBytecode(input)
+	compareBytecode(t, bytecode, expected)
+}
+
 func TestNextStatement(t *testing.T) {
 	input := `
 	x = 0
@@ -136,9 +194,9 @@ func TestNamespacedClass(t *testing.T) {
 0 putself
 1 def_class module:Foo
 2 pop
-3 getconstant Foo
-4 getconstant Bar
-5 getconstant Baz
+3 getconstant Foo true
+4 getconstant Bar true
+5 getconstant Baz false
 6 send new 0
 7 send bar 0
 8 leave
@@ -171,7 +229,7 @@ Foo.bar
 0 putself
 1 def_class class:Foo
 2 pop
-3 getconstant Foo
+3 getconstant Foo false
 4 send bar 0
 5 leave
 `
@@ -209,10 +267,10 @@ Foo.new.bar
 1 def_class class:Bar
 2 pop
 3 putself
-4 getconstant Bar
+4 getconstant Bar false
 5 def_class class:Foo Bar
 6 pop
-7 getconstant Foo
+7 getconstant Foo false
 8 send new 0
 9 send bar 0
 10 leave
@@ -248,7 +306,7 @@ Foo.new.bar
 3 leave
 <DefClass:Foo>
 0 putself
-1 getconstant Bar
+1 getconstant Bar false
 2 send include 1
 3 leave
 <ProgramStart>
@@ -258,7 +316,7 @@ Foo.new.bar
 3 putself
 4 def_class class:Foo
 5 pop
-6 getconstant Foo
+6 getconstant Foo false
 7 send new 0
 8 send bar 0
 9 leave

--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -132,6 +132,7 @@ func (p *Parser) parseConstant() ast.Expression {
 	c := &ast.Constant{Token: p.curToken, Value: p.curToken.Literal}
 
 	if p.peekTokenIs(token.ResolutionOperator) {
+		c.IsNamespace = true
 		p.nextToken()
 		return p.parseInfixExpression(c)
 	}

--- a/vm/class.go
+++ b/vm/class.go
@@ -723,7 +723,7 @@ func (c *RClass) lookupConstant(constName string, findInScope bool) *Pointer {
 }
 
 func (c *RClass) setClassConstant(constant *RClass) {
-	c.constants[constant.Name] = &Pointer{constant}
+	c.constants[constant.Name] = &Pointer{Target: constant}
 }
 
 func (c *RClass) getClassConstant(constName string) (class *RClass) {

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -109,6 +109,16 @@ func TestArgumentError(t *testing.T) {
 		foo(1, 2, 3)
 		`,
 			"ArgumentError: Expect at most 2 args for method 'foo'. got: 3"},
+		{`
+		"1234567890".include "123", Class
+		`,
+			"ArgumentError: Expect 1 argument. got=2",
+		},
+		{`
+		"1234567890".include "123", Class, String
+		`,
+			"ArgumentError: Expect 1 argument. got=3",
+		},
 	}
 
 	for i, tt := range tests {

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -54,10 +54,15 @@ var builtInActions = map[operationType]*action{
 		operation: func(t *thread, cf *callFrame, args ...interface{}) {
 			constName := args[0].(string)
 			c := t.vm.lookupConstant(cf, constName)
+			c.isNamespace = args[1].(string) == "true"
+
+			if t.stack.top() != nil && t.stack.top().isNamespace {
+				t.stack.pop()
+			}
 
 			if c == nil {
 				err := initErrorObject(NameErrorClass, "uninitialized constant %s", constName)
-				t.stack.push(&Pointer{err})
+				t.stack.push(&Pointer{Target: err})
 				return
 			}
 
@@ -73,7 +78,7 @@ var builtInActions = map[operationType]*action{
 			p := cf.getLCL(index, depth)
 
 			if p == nil {
-				t.stack.push(&Pointer{NULL})
+				t.stack.push(&Pointer{Target: NULL})
 				return
 			}
 
@@ -140,7 +145,7 @@ var builtInActions = map[operationType]*action{
 			rangeEnd := t.stack.pop().Target.(*IntegerObject).Value
 			rangeStart := t.stack.pop().Target.(*IntegerObject).Value
 
-			t.stack.push(&Pointer{t.vm.initRangeObject(rangeStart, rangeEnd)})
+			t.stack.push(&Pointer{Target: t.vm.initRangeObject(rangeStart, rangeEnd)})
 		},
 	},
 	bytecode.NewArray: {
@@ -155,7 +160,7 @@ var builtInActions = map[operationType]*action{
 			}
 
 			arr := t.vm.initArrayObject(elems)
-			t.stack.push(&Pointer{arr})
+			t.stack.push(&Pointer{Target: arr})
 		},
 	},
 	bytecode.NewHash: {
@@ -171,7 +176,7 @@ var builtInActions = map[operationType]*action{
 			}
 
 			hash := t.vm.initHashObject(pairs)
-			t.stack.push(&Pointer{hash})
+			t.stack.push(&Pointer{Target: hash})
 		},
 	},
 	bytecode.BranchUnless: {
@@ -225,20 +230,20 @@ var builtInActions = map[operationType]*action{
 	bytecode.PutSelf: {
 		name: bytecode.PutSelf,
 		operation: func(t *thread, cf *callFrame, args ...interface{}) {
-			t.stack.push(&Pointer{cf.self})
+			t.stack.push(&Pointer{Target: cf.self})
 		},
 	},
 	bytecode.PutString: {
 		name: bytecode.PutString,
 		operation: func(t *thread, cf *callFrame, args ...interface{}) {
 			object := t.vm.initObjectFromGoType(args[0])
-			t.stack.push(&Pointer{object})
+			t.stack.push(&Pointer{Target: object})
 		},
 	},
 	bytecode.PutNull: {
 		name: bytecode.PutNull,
 		operation: func(t *thread, cf *callFrame, args ...interface{}) {
-			t.stack.push(&Pointer{NULL})
+			t.stack.push(&Pointer{Target: NULL})
 		},
 	},
 	bytecode.DefMethod: {

--- a/vm/object.go
+++ b/vm/object.go
@@ -15,7 +15,8 @@ type Object interface {
 
 // Pointer is used to point to an object. Variables should hold pointer instead of holding a object directly.
 type Pointer struct {
-	Target Object
+	Target      Object
+	isNamespace bool
 }
 
 func (p *Pointer) returnClass() *RClass {

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -136,7 +136,7 @@ func (t *thread) evalBuiltInMethod(receiver Object, method *BuiltInMethodObject,
 			t.evalMethodObject(instance, instance.InitializeMethod, receiverPr, argCount, argPr, blockFrame)
 		}
 	}
-	t.stack.Data[receiverPr] = &Pointer{evaluated}
+	t.stack.Data[receiverPr] = &Pointer{Target: evaluated}
 	t.sp = receiverPr + 1
 }
 
@@ -154,10 +154,10 @@ func (t *thread) evalMethodObject(receiver Object, method *MethodObject, receive
 
 	if argC < normalArgCount {
 		e := initErrorObject(ArgumentErrorClass, "Expect at least %d args for method '%s'. got: %d", normalArgCount, method.Name, argC)
-		t.stack.push(&Pointer{e})
+		t.stack.push(&Pointer{Target: e})
 	} else if argC > method.argc {
 		e := initErrorObject(ArgumentErrorClass, "Expect at most %d args for method '%s'. got: %d", method.argc, method.Name, argC)
-		t.stack.push(&Pointer{e})
+		t.stack.push(&Pointer{Target: e})
 	} else {
 		for i := 0; i < argC; i++ {
 			c.insertLCL(i, 0, t.stack.Data[argPr+i].Target)
@@ -175,12 +175,12 @@ func (t *thread) evalMethodObject(receiver Object, method *MethodObject, receive
 // TODO: Use this method to replace unnecessary panics
 func (t *thread) returnError(msg string) {
 	err := &Error{Message: msg}
-	t.stack.push(&Pointer{err})
+	t.stack.push(&Pointer{Target: err})
 }
 
 func (t *thread) UndefinedMethodError(methodName string, receiver Object) {
 	err := initErrorObject(UndefinedMethodErrorClass, "Undefined Method '%+v' for %+v", methodName, receiver.toString())
-	t.stack.push(&Pointer{err})
+	t.stack.push(&Pointer{Target: err})
 }
 
 func (t *thread) UnsupportedMethodError(methodName string, receiver Object) *Error {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -264,11 +264,6 @@ func (vm *VM) lookupConstant(cf *callFrame, constName string) (constant *Pointer
 	}
 
 	if hasNamespace {
-		// pop namespace since we don't need it anymore
-		if namespace != cf.self {
-			vm.mainThread.stack.pop()
-		}
-
 		constant = namespace.lookupConstant(constName, true)
 
 		if constant != nil {
@@ -283,7 +278,7 @@ func (vm *VM) lookupConstant(cf *callFrame, constName string) (constant *Pointer
 	}
 
 	if constName == objectClass {
-		constant = &Pointer{vm.objectClass}
+		constant = &Pointer{Target: vm.objectClass}
 	}
 
 	return


### PR DESCRIPTION
This closes #279 

- Add IsNamespace attribute to constant node.
- Add second parameter to 'getconstant' instruction to determine if it's
  used as namespace.
- Add isNamespace attribute to pointer, which determines if the constant it holds it's used as namespace.
  Basically this attribute will be only used in such condition for now.
- When executing 'getconstant' instruction, pop previous constant if
  it's marked as namespace.