### PR TITLE
Refactor error system

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -59,14 +59,14 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 {
-						return &Error{Message: "Expect 1 arguments. got=%d" + string(len(args))}
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 arguments. got=%d", len(args))
 					}
 
 					i := args[0]
 					index, ok := i.(*IntegerObject)
 
 					if !ok {
-						return newError("Expect index argument to be Integer. got=%T", i)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -105,7 +105,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					// First arg is index
 					// Second arg is assigned value
 					if len(args) != 2 {
-						return newError("Expect 2 arguments. got=%d", len(args))
+						return t.vm.initErrorObject(ArgumentError, "Expect 2 arguments. got=%d", len(args))
 					}
 
 					i := args[0]
@@ -113,7 +113,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					indexValue := index.Value
 
 					if !ok {
-						return newError("Expect index argument to be Integer. got=%T", i)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -121,7 +121,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					// Negative index value condition
 					if indexValue < 0 {
 						if len(arr.Elements) < -indexValue {
-							return newError("Index is too small for array. got=%T", i)
+							return t.vm.initErrorObject(ArgumentError, "Index is too small for array. got=%s", i.Class().Name)
 						}
 						arr.Elements[len(arr.Elements)+indexValue] = args[1]
 						return arr.Elements[len(arr.Elements)+indexValue]
@@ -161,7 +161,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					index, ok := i.(*IntegerObject)
 
 					if !ok {
-						return newError("Expect index argument to be Integer. got=%T", i)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -216,7 +216,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 						addAr, ok := arg.(*ArrayObject)
 
 						if !ok {
-							return newError("Expect argument to be Array. got=%T", arg)
+							return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, arrayClass, arg.Class().Name)
 						}
 
 						for _, el := range addAr.Elements {
@@ -314,7 +314,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					arr := receiver.(*ArrayObject)
 
 					if blockFrame == nil {
-						t.returnError(InternalError, "Can't yield without a block")
+						t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
 					}
 
 					for _, obj := range arr.Elements {
@@ -331,7 +331,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					arr := receiver.(*ArrayObject)
 
 					if blockFrame == nil {
-						t.returnError(InternalError, "Can't yield without a block")
+						t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
 					}
 
 					for i := range arr.Elements {
@@ -355,7 +355,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 
 					arg, ok := args[0].(*IntegerObject)
 					if !ok {
-						return newError("Expect index argument to be Integer. got=%T", args[0])
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
 					}
 
 					return t.vm.initArrayObject(arr.Elements[:arg.Value])
@@ -375,7 +375,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 
 					arg, ok := args[0].(*IntegerObject)
 					if !ok {
-						return newError("Expect index argument to be Integer. got=%T", args[0])
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
 					}
 
 					l := len(arr.Elements)
@@ -395,7 +395,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 
 					if len(args) != 0 {
-						return newError("Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -421,7 +421,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					var elements = make([]Object, len(arr.Elements))
 
 					if blockFrame == nil {
-						t.returnError(InternalError, "Can't yield without a block")
+						t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
 					}
 
 					for i, obj := range arr.Elements {
@@ -446,7 +446,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 
 					if len(args) != 0 {
-						return newError("Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -492,7 +492,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					if len(args) != 0 {
 						arg, ok := args[0].(*IntegerObject)
 						if !ok {
-							return newError("Expect index argument to be Integer. got=%T", args[0])
+							return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
 						}
 						rotate = arg.Value
 					}
@@ -525,7 +525,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					var elements []Object
 
 					if blockFrame == nil {
-						t.returnError(InternalError, "Can't yield without a block")
+						t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
 					}
 
 					for _, obj := range arr.Elements {
@@ -551,7 +551,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 0 {
-						return newError("Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)

--- a/vm/array.go
+++ b/vm/array.go
@@ -314,7 +314,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					arr := receiver.(*ArrayObject)
 
 					if blockFrame == nil {
-						t.returnError("Can't yield without a block")
+						t.returnError(InternalError, "Can't yield without a block")
 					}
 
 					for _, obj := range arr.Elements {
@@ -331,7 +331,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					arr := receiver.(*ArrayObject)
 
 					if blockFrame == nil {
-						t.returnError("Can't yield without a block")
+						t.returnError(InternalError, "Can't yield without a block")
 					}
 
 					for i := range arr.Elements {
@@ -421,7 +421,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					var elements = make([]Object, len(arr.Elements))
 
 					if blockFrame == nil {
-						t.returnError("Can't yield without a block")
+						t.returnError(InternalError, "Can't yield without a block")
 					}
 
 					for i, obj := range arr.Elements {
@@ -525,7 +525,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					var elements []Object
 
 					if blockFrame == nil {
-						t.returnError("Can't yield without a block")
+						t.returnError(InternalError, "Can't yield without a block")
 					}
 
 					for _, obj := range arr.Elements {

--- a/vm/array.go
+++ b/vm/array.go
@@ -247,7 +247,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					var count int
 
 					if len(args) > 1 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1 argument, got=%v", len(args))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument, got=%v", len(args))
 					}
 
 					if blockFrame != nil {

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -200,29 +200,22 @@ func TestArrayConcatMethod(t *testing.T) {
 func TestArrayConcatMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input    string
-		expected *Error
+		expected string
 	}{
 		{`
 		a = [1, 2]
 		a.concat(3)
-		`, newError("Expect argument to be Array. got=*vm.IntegerObject")},
+		`, "TypeError: Expect argument to be Array. got: Integer"},
 		{`
 		a = []
 		a.concat("a")
-		`, newError("Expect argument to be Array. got=*vm.StringObject")},
+		`, "TypeError: Expect argument to be Array. got: String"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
-		err, ok := evaluated.(*Error)
-		if !ok {
-			t.Errorf("Expect error. got=%T (%+v)", err, err)
-		}
-		if err.Message != tt.expected.Message {
-			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
-		}
-
+		checkError(t, i, evaluated, TypeError, tt.expected)
 		v.checkCFP(t, i, 1)
 	}
 }
@@ -385,24 +378,18 @@ func TestArrayFirstMethod(t *testing.T) {
 func TestArrayFirstMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input    string
-		expected *Error
+		expected string
 	}{
 		{`
 		a = [1, 2]
 		a.first("a")
-		`, newError("Expect index argument to be Integer. got=*vm.StringObject")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
-		err, ok := evaluated.(*Error)
-		if !ok {
-			t.Errorf("Expect error. got=%T (%+v)", err, err)
-		}
-		if err.Message != tt.expected.Message {
-			t.Errorf("Expect error message \"%s\". got=\"%s\"", err.Message, tt.expected.Message)
-		}
+		checkError(t, i, evaluated, TypeError, tt.expected)
 		v.checkCFP(t, i, 1)
 	}
 }
@@ -433,24 +420,18 @@ func TestArrayLastMethod(t *testing.T) {
 func TestArrayLastMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input    string
-		expected *Error
+		expected string
 	}{
 		{`
 		a = [1, 2]
 		a.last("l")
-		`, newError("Expect index argument to be Integer. got=*vm.StringObject")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
-		err, ok := evaluated.(*Error)
-		if !ok {
-			t.Errorf("Expect error. got=%T (%+v)", err, err)
-		}
-		if err.Message != tt.expected.Message {
-			t.Errorf("Expect error message \"%s\". got=\"%s\"", err.Message, tt.expected.Message)
-		}
+		checkError(t, i, evaluated, TypeError, tt.expected)
 		v.checkCFP(t, i, 1)
 	}
 }
@@ -617,24 +598,18 @@ func TestArrayRotateMethod(t *testing.T) {
 func TestArrayRotateMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input    string
-		expected *Error
+		expected string
 	}{
 		{`
 		a = [1, 2]
 		a.rotate("a")
-		`, newError("Expect index argument to be Integer. got=*vm.StringObject")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
-		err, ok := evaluated.(*Error)
-		if !ok {
-			t.Errorf("Expect error. got=%T (%+v)", err, err)
-		}
-		if err.Message != tt.expected.Message {
-			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
-		}
+		checkError(t, i, evaluated, TypeError, tt.expected)
 
 		v.checkCFP(t, i, 1)
 	}
@@ -706,26 +681,18 @@ func TestArrayShiftMethod(t *testing.T) {
 func TestArrayShiftMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input    string
-		expected *Error
+		expected string
 	}{
 		{`
 		a = [1, 2]
 		a.shift(3, 3, 4, 5)
-		`, newError("Expect 0 argument. got=4")},
+		`, "ArgumentError: Expect 0 argument. got=4"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input)
-
-		err, ok := evaluated.(*Error)
-
-		if !ok {
-			t.Errorf("Expect error. got=%T (%+v)", err, err)
-		}
-		if err.Message != tt.expected.Message {
-			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
-		}
+		checkError(t, i, evaluated, ArgumentError, tt.expected)
 
 		v.checkCFP(t, i, 1)
 	}

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -56,15 +56,15 @@ func builtinBooleanInstanceMethods() []*BuiltInMethodObject {
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					err := checkArgumentLen(args, receiver.Class(), "==")
-					if err != nil {
+					if len(args) != 1 {
+						err := t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got: %d", len(args))
 						return err
 					}
 
 					if receiver == args[0] {
 						return TRUE
 					}
+
 					return FALSE
 				}
 			},
@@ -80,9 +80,8 @@ func builtinBooleanInstanceMethods() []*BuiltInMethodObject {
 			Name: "!=",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					err := checkArgumentLen(args, receiver.Class(), "!=")
-					if err != nil {
+					if len(args) != 1 {
+						err := t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got: %d", len(args))
 						return err
 					}
 
@@ -131,7 +130,8 @@ func builtinBooleanInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*BooleanObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, booleanClass, right.Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -161,7 +161,8 @@ func builtinBooleanInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*BooleanObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, booleanClass, right.Class().Name)
+						return err
 					}
 
 					rightValue := right.Value

--- a/vm/class.go
+++ b/vm/class.go
@@ -522,13 +522,13 @@ func builtinClassClassMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 0 {
-						return initErrorObject(ArgumentErrorClass, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
 
 					n, ok := receiver.(*RClass)
 
 					if !ok {
-						return initErrorObject(UndefinedMethodErrorClass, "Undefined Method '%+v' for %+v", "#name", receiver.toString())
+						return t.vm.initErrorObject(UndefinedMethodError, "Undefined Method '%s' for %s", "#name", receiver.toString())
 					}
 
 					name := n.ReturnName()
@@ -613,13 +613,13 @@ func builtinClassClassMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 0 {
-						return initErrorObject(ArgumentErrorClass, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
 
 					c, ok := receiver.(*RClass)
 
 					if !ok {
-						return initErrorObject(UndefinedMethodErrorClass, "Undefined Method '%+v' for %+v", "#superclass", receiver.toString())
+						return t.vm.initErrorObject(UndefinedMethodError, "Undefined Method '%s' for %s", "#superclass", receiver.toString())
 					}
 
 					superClass := c.returnSuperClass()

--- a/vm/class.go
+++ b/vm/class.go
@@ -102,7 +102,7 @@ func builtinCommonInstanceMethods() []*BuiltInMethodObject {
 					initFunc, ok := standardLibraries[libName]
 
 					if !ok {
-						return initErrorObject(InternalErrorClass, "Can't require \"%s\"", libName)
+						return t.vm.initErrorObject(InternalError, "Can't require \"%s\"", libName)
 					}
 
 					initFunc(t.vm)
@@ -134,7 +134,7 @@ func builtinCommonInstanceMethods() []*BuiltInMethodObject {
 					file, err := ioutil.ReadFile(filepath + ".gb")
 
 					if err != nil {
-						return initErrorObject(InternalErrorClass, err.Error())
+						return t.vm.initErrorObject(InternalError, err.Error())
 					}
 
 					t.vm.execRequiredFile(filepath, file)
@@ -483,7 +483,7 @@ func builtinClassClassMethods() []*BuiltInMethodObject {
 					module, ok := args[0].(*RClass)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be a module. got=%v", args[0].Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be a module. got=%v", args[0].Class().Name)
 					}
 
 					switch r := receiver.(type) {
@@ -566,7 +566,7 @@ func builtinClassClassMethods() []*BuiltInMethodObject {
 					}
 
 					if class.pseudoSuperClass.isModule {
-						return initErrorObject(InternalErrorClass, "Module inheritance is not supported: %s", class.pseudoSuperClass.Name)
+						return t.vm.initErrorObject(InternalError, "Module inheritance is not supported: %s", class.pseudoSuperClass.Name)
 					}
 
 					instance := class.initializeInstance()

--- a/vm/error.go
+++ b/vm/error.go
@@ -19,6 +19,11 @@ const (
 	UnsupportedMethodError = "UnsupportedMethodError"
 )
 
+const (
+	WrongArgumentTypeFormat     = "Expect argument to be %s. got: %s"
+	CantYieldWithoutBlockFormat = "Can't yield without a block"
+)
+
 // Error class is actually a special struct to hold internal error types with messages.
 // Goby developers need not to take care of the struct.
 // Goby maintainers should consider using the appropriate error type.

--- a/vm/error.go
+++ b/vm/error.go
@@ -4,21 +4,6 @@ import (
 	"fmt"
 )
 
-var (
-	// InternalErrorClass ...
-	InternalErrorClass *RClass
-	// ArgumentErrorClass ...
-	ArgumentErrorClass *RClass
-	// NameErrorClass ...
-	NameErrorClass *RClass
-	// TypeErrorClass ...
-	TypeErrorClass *RClass
-	// UndefinedMethodErrorClass ...
-	UndefinedMethodErrorClass *RClass
-	// UnsupportedMethodClass ...
-	UnsupportedMethodClass *RClass
-)
-
 const (
 	// InternalError is the default error type
 	InternalError = "InternalError"
@@ -53,20 +38,22 @@ type Error struct {
 	Message string
 }
 
-func initErrorObject(errorType *RClass, format string, args ...interface{}) *Error {
+func (vm *VM) initErrorObject(errorType, format string, args ...interface{}) *Error {
+	errClass := vm.objectClass.getClassConstant(errorType)
+
 	return &Error{
-		baseObj: &baseObj{class: errorType},
-		Message: fmt.Sprintf(errorType.Name+": "+format, args...),
+		baseObj: &baseObj{class: errClass},
+		Message: fmt.Sprintf(errorType+": "+format, args...),
 	}
 }
 
 func (vm *VM) initErrorClasses() {
-	InternalErrorClass = vm.initializeClass(InternalError, false)
-	ArgumentErrorClass = vm.initializeClass(ArgumentError, false)
-	NameErrorClass = vm.initializeClass(NameError, false)
-	TypeErrorClass = vm.initializeClass(TypeError, false)
-	UndefinedMethodErrorClass = vm.initializeClass(UndefinedMethodError, false)
-	UnsupportedMethodClass = vm.initializeClass(UnsupportedMethodError, false)
+	errTypes := []string{InternalError, ArgumentError, NameError, TypeError, UndefinedMethodError, UnsupportedMethodError}
+
+	for _, errType := range errTypes {
+		c := vm.initializeClass(errType, false)
+		vm.topLevelClass(objectClass).setClassConstant(c)
+	}
 }
 
 // Polymorphic helper functions -----------------------------------------

--- a/vm/error.go
+++ b/vm/error.go
@@ -19,6 +19,9 @@ const (
 	UnsupportedMethodError = "UnsupportedMethodError"
 )
 
+/*
+	Here defines different error message formats for different types of errors
+*/
 const (
 	WrongArgumentTypeFormat     = "Expect argument to be %s. got: %s"
 	CantYieldWithoutBlockFormat = "Can't yield without a block"

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -2,19 +2,6 @@ package vm
 
 import "testing"
 
-func TestTypeError(t *testing.T) {
-	vm := initTestVM()
-	evaluated := vm.testEval(t, "10 * \"foo\"")
-	err, ok := evaluated.(*Error)
-	if !ok {
-		t.Errorf("Expect Error. got=%T (%+v)", evaluated, evaluated)
-	}
-	if err.Class().ReturnName() != TypeError {
-		t.Errorf("Expect %s. got=%T (%+v)", TypeError, evaluated, evaluated)
-	}
-	vm.checkCFP(t, 0, 1)
-}
-
 func TestUndefinedMethodError(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/vm/file.go
+++ b/vm/file.go
@@ -70,7 +70,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 
 						err := os.Chmod(filename, os.FileMode(uint32(filemod)))
 						if err != nil {
-							t.returnError(InternalError, err.Error())
+							return t.vm.initErrorObject(InternalError, err.Error())
 						}
 					}
 
@@ -87,8 +87,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 						err := os.Remove(filename)
 
 						if err != nil {
-							t.returnError(InternalError, err.Error())
-							return nil
+							return t.vm.initErrorObject(InternalError, err.Error())
 						}
 					}
 
@@ -163,7 +162,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 					var perm os.FileMode
 
 					if len(args) < 1 {
-						return newError("Expect at least a filename to open file")
+						return t.vm.initErrorObject(InternalError, "Expect at least a filename to open file")
 					}
 
 					if len(args) >= 1 {
@@ -176,7 +175,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 							md, ok := fileModeTable[m]
 
 							if !ok {
-								t.returnError(InternalError, "Unknown file mode: %s", m)
+								return t.vm.initErrorObject(InternalError, "Unknown file mode: %s", m)
 							}
 
 							if md == syscall.O_RDWR || md == syscall.O_WRONLY {
@@ -196,7 +195,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 					f, err := os.OpenFile(fn, mode, perm)
 
 					if err != nil {
-						t.returnError(InternalError, err.Error())
+						return t.vm.initErrorObject(InternalError, err.Error())
 					}
 
 					// TODO: Refactor this class retrieval mess
@@ -224,7 +223,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 
 					fileStats, err := os.Stat(filename)
 					if err != nil {
-						panic(err)
+						return t.vm.initErrorObject(InternalError, err.Error())
 					}
 
 					return t.vm.initIntegerObject(int(fileStats.Size()))
@@ -286,7 +285,7 @@ func builtinFileInstanceMethods() []*BuiltInMethodObject {
 					data, err := ioutil.ReadFile(file.Name())
 
 					if err != nil {
-						t.returnError(InternalError, err.Error())
+						return t.vm.initErrorObject(InternalError, err.Error())
 					}
 
 					return t.vm.initStringObject(string(data))
@@ -307,7 +306,7 @@ func builtinFileInstanceMethods() []*BuiltInMethodObject {
 
 					fileStats, err := os.Stat(file.Name())
 					if err != nil {
-						panic(err)
+						return t.vm.initErrorObject(InternalError, err.Error())
 					}
 
 					return t.vm.initIntegerObject(int(fileStats.Size()))
@@ -323,7 +322,7 @@ func builtinFileInstanceMethods() []*BuiltInMethodObject {
 					length, err := file.Write([]byte(data))
 
 					if err != nil {
-						t.returnError(InternalError, err.Error())
+						return t.vm.initErrorObject(InternalError, err.Error())
 					}
 
 					return t.vm.initIntegerObject(length)

--- a/vm/file.go
+++ b/vm/file.go
@@ -70,7 +70,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 
 						err := os.Chmod(filename, os.FileMode(uint32(filemod)))
 						if err != nil {
-							t.returnError(err.Error())
+							t.returnError(InternalError, err.Error())
 						}
 					}
 
@@ -87,7 +87,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 						err := os.Remove(filename)
 
 						if err != nil {
-							t.returnError(err.Error())
+							t.returnError(InternalError, err.Error())
 							return nil
 						}
 					}
@@ -176,7 +176,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 							md, ok := fileModeTable[m]
 
 							if !ok {
-								t.returnError("Unknown file mode: " + m)
+								t.returnError(InternalError, "Unknown file mode: %s", m)
 							}
 
 							if md == syscall.O_RDWR || md == syscall.O_WRONLY {
@@ -196,7 +196,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 					f, err := os.OpenFile(fn, mode, perm)
 
 					if err != nil {
-						t.returnError(err.Error())
+						t.returnError(InternalError, err.Error())
 					}
 
 					// TODO: Refactor this class retrieval mess
@@ -286,7 +286,7 @@ func builtinFileInstanceMethods() []*BuiltInMethodObject {
 					data, err := ioutil.ReadFile(file.Name())
 
 					if err != nil {
-						t.returnError(err.Error())
+						t.returnError(InternalError, err.Error())
 					}
 
 					return t.vm.initStringObject(string(data))
@@ -323,7 +323,7 @@ func builtinFileInstanceMethods() []*BuiltInMethodObject {
 					length, err := file.Write([]byte(data))
 
 					if err != nil {
-						t.returnError(err.Error())
+						t.returnError(InternalError, err.Error())
 					}
 
 					return t.vm.initIntegerObject(length)

--- a/vm/http.go
+++ b/vm/http.go
@@ -69,14 +69,14 @@ func builtinHTTPClassMethods() []*BuiltInMethodObject {
 					resp, err := http.Get(domain + path)
 
 					if err != nil {
-						t.returnError(InternalError, err.Error())
+						return t.vm.initErrorObject(InternalError, err.Error())
 					}
 
 					content, err := ioutil.ReadAll(resp.Body)
 					resp.Body.Close()
 
 					if err != nil {
-						t.returnError(InternalError, err.Error())
+						return t.vm.initErrorObject(InternalError, err.Error())
 					}
 
 					return t.vm.initStringObject(string(content))

--- a/vm/http.go
+++ b/vm/http.go
@@ -69,14 +69,14 @@ func builtinHTTPClassMethods() []*BuiltInMethodObject {
 					resp, err := http.Get(domain + path)
 
 					if err != nil {
-						t.returnError(err.Error())
+						t.returnError(InternalError, err.Error())
 					}
 
 					content, err := ioutil.ReadAll(resp.Body)
 					resp.Body.Close()
 
 					if err != nil {
-						t.returnError(err.Error())
+						t.returnError(InternalError, err.Error())
 					}
 
 					return t.vm.initStringObject(string(content))

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -254,7 +254,7 @@ var builtInActions = map[operationType]*action{
 			is, ok := t.getMethodIS(methodName, cf.instructionSet.filename)
 
 			if !ok {
-				t.returnError(fmt.Sprintf("Can't get method %s's instruction set.", methodName))
+				t.returnError(InternalError, "Can't get method %s's instruction set.", methodName)
 			}
 
 			method := &MethodObject{Name: methodName, argc: argCount, instructionSet: is, baseObj: &baseObj{class: t.vm.topLevelClass(methodClass)}}
@@ -317,7 +317,7 @@ var builtInActions = map[operationType]*action{
 					inheritedClass, ok := superClass.Target.(*RClass)
 
 					if !ok {
-						t.returnError("Constant " + superClassName + " is not a class. got=" + string(superClass.Target.Class().ReturnName()))
+						t.returnError(InternalError, "Constant %s is not a class. got=%s", superClassName, string(superClass.Target.Class().ReturnName()))
 					}
 
 					class.pseudoSuperClass = inheritedClass
@@ -367,7 +367,7 @@ var builtInActions = map[operationType]*action{
 			case *BuiltInMethodObject:
 				t.evalBuiltInMethod(receiver, m, receiverPr, argCount, argPr, blockFrame)
 			case *Error:
-				t.returnError(m.toString())
+				t.returnError(InternalError, m.toString())
 			}
 		},
 	},
@@ -380,7 +380,7 @@ var builtInActions = map[operationType]*action{
 			receiver := t.stack.Data[receiverPr].Target
 
 			if cf.blockFrame == nil {
-				t.returnError("Can't yield without a block")
+				t.returnError(InternalError, "Can't yield without a block")
 			}
 
 			blockFrame := cf.blockFrame

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -61,7 +61,7 @@ var builtInActions = map[operationType]*action{
 			}
 
 			if c == nil {
-				err := initErrorObject(NameErrorClass, "uninitialized constant %s", constName)
+				err := t.vm.initErrorObject(NameError, "uninitialized constant %s", constName)
 				t.stack.push(&Pointer{Target: err})
 				return
 			}

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -131,7 +131,7 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect Integer. got=%T (%+v)", args[0], args[0])
+						return t.vm.initErrorObject(TypeError, "Expect Integer. got=%T (%+v)", args[0], args[0])
 					}
 
 					rightValue := right.Value

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -62,7 +62,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -85,7 +86,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -108,7 +110,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -131,7 +134,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect Integer. got=%T (%+v)", args[0], args[0])
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -154,7 +158,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -178,7 +183,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -202,7 +208,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -231,7 +238,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -260,7 +268,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -289,7 +298,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -319,7 +329,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -351,7 +362,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value
@@ -380,7 +392,8 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return wrongTypeError(receiver.Class())
+						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
+						return err
 					}
 
 					rightValue := right.Value

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -43,32 +43,26 @@ func TestIntegerArithmeticOperation(t *testing.T) {
 func TestIntegerArithmeticOperationFail(t *testing.T) {
 	testsFail := []struct {
 		input    string
-		expected *Error
+		expected string
 	}{
 		{`
 		1 + "p"
-		`, newError("expect argument to be Integer type")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 		{`
 		1 - "m"
-		`, newError("expect argument to be Integer type")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 		{`
 		1 ** "p"
-		`, newError("expect argument to be Integer type")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 		{`
 		1 / "t"
-		`, newError("expect argument to be Integer type")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 	}
 
 	for i, tt := range testsFail {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
-		err, ok := evaluated.(*Error)
-		if !ok {
-			t.Errorf("Expect error. got=%T (%+v)", err, err)
-		}
-		if err.Message != tt.expected.Message {
-			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
-		}
+		checkError(t, i, evaluated, TypeError, tt.expected)
 		vm.checkCFP(t, i, 1)
 	}
 }
@@ -112,41 +106,35 @@ func TestIntegerComparison(t *testing.T) {
 func TestIntegerComparisonFail(t *testing.T) {
 	testsFail := []struct {
 		input    string
-		expected *Error
+		expected string
 	}{
 		{`
 		1 > "m"
-		`, newError("expect argument to be Integer type")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 		{`
 		1 >= "m"
-		`, newError("expect argument to be Integer type")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 		{`
 		1 < "m"
-		`, newError("expect argument to be Integer type")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 		{`
 		1 <= "m"
-		`, newError("expect argument to be Integer type")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 		{`
 		1 <=> "m"
-		`, newError("expect argument to be Integer type")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 		{`
 		1 == "m"
-		`, newError("expect argument to be Integer type")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 		{`
 		1 != "m"
-		`, newError("expect argument to be Integer type")},
+		`, "TypeError: Expect argument to be Integer. got: String"},
 	}
 
 	for i, tt := range testsFail {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input)
-		err, ok := evaluated.(*Error)
-		if !ok {
-			t.Errorf("Expect error. got=%T (%+v)", err, err)
-		}
-		if err.Message != tt.expected.Message {
-			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
-		}
+		checkError(t, i, evaluated, TypeError, tt.expected)
 		vm.checkCFP(t, i, 1)
 	}
 }

--- a/vm/object.go
+++ b/vm/object.go
@@ -69,17 +69,3 @@ func (ro *RObject) toString() string {
 func (ro *RObject) toJSON() string {
 	return ro.toString()
 }
-
-// Other helper functions -----------------------------------------------
-
-func checkArgumentLen(args []Object, class *RClass, methodName string) *Error {
-	if len(args) > 1 {
-		return &Error{Message: fmt.Sprintf("Too many arguments for %s#%s", class.ReturnName(), methodName)}
-	}
-
-	return nil
-}
-
-func wrongTypeError(c *RClass) *Error {
-	return &Error{Message: fmt.Sprintf("expect argument to be %s type", c.ReturnName())}
-}

--- a/vm/range.go
+++ b/vm/range.go
@@ -193,7 +193,7 @@ func builtInRangeInstanceMethods() []*BuiltInMethodObject {
 					ran := receiver.(*RangeObject)
 
 					if blockFrame == nil {
-						t.returnError(InternalError, "Can't yield without a block")
+						return t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
 					}
 
 					if ran.Start <= ran.End {
@@ -341,7 +341,7 @@ func builtInRangeInstanceMethods() []*BuiltInMethodObject {
 					ran := receiver.(*RangeObject)
 
 					if blockFrame == nil {
-						t.returnError(InternalError, "Can't yield without a block")
+						return t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
 					}
 
 					stepValue := args[0].(*IntegerObject).Value

--- a/vm/range.go
+++ b/vm/range.go
@@ -193,7 +193,7 @@ func builtInRangeInstanceMethods() []*BuiltInMethodObject {
 					ran := receiver.(*RangeObject)
 
 					if blockFrame == nil {
-						t.returnError("Can't yield without a block")
+						t.returnError(InternalError, "Can't yield without a block")
 					}
 
 					if ran.Start <= ran.End {
@@ -341,7 +341,7 @@ func builtInRangeInstanceMethods() []*BuiltInMethodObject {
 					ran := receiver.(*RangeObject)
 
 					if blockFrame == nil {
-						t.returnError("Can't yield without a block")
+						t.returnError(InternalError, "Can't yield without a block")
 					}
 
 					stepValue := args[0].(*IntegerObject).Value

--- a/vm/range.go
+++ b/vm/range.go
@@ -158,7 +158,7 @@ func builtInRangeInstanceMethods() []*BuiltInMethodObject {
 								end = mid - 1
 							}
 						default:
-							return initErrorObject(TypeErrorClass, "Expect Integer or Boolean type. got=%T", r)
+							return t.vm.initErrorObject(TypeError, "Expect Integer or Boolean type. got=%s", r.Class().Name)
 						}
 					}
 				}

--- a/vm/range_test.go
+++ b/vm/range_test.go
@@ -149,25 +149,19 @@ func TestRangeBsearchMethodFail(t *testing.T) {
 	vm := initTestVM()
 	testsFail := []struct {
 		input    string
-		expected *Error
+		errorMsg string
 	}{
 		{`
 		ary = [0, 4, 7, 10, 12]
 		(0..4).bsearch do |i|
 			"Binary Search"
 		end
-		`, initErrorObject(TypeErrorClass, "Expect Integer or Boolean type. got=%T", vm.initStringObject("Binary Search"))},
+		`, "TypeError: Expect Integer or Boolean type. got=String"},
 	}
 
 	for i, tt := range testsFail {
 		evaluated := vm.testEval(t, tt.input)
-		err, ok := evaluated.(*Error)
-		if !ok {
-			t.Errorf("Expect error. got=%T (%+v)", err, err)
-		}
-		if err.Message != tt.expected.Message {
-			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
-		}
+		checkError(t, i, evaluated, TypeError, tt.errorMsg)
 		vm.checkCFP(t, i, 1)
 	}
 }

--- a/vm/string.go
+++ b/vm/string.go
@@ -78,7 +78,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, r.Class().Name)
 					}
 
 					rightValue := right.Value
@@ -103,7 +103,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be Integer. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, r.Class().Name)
 					}
 
 					if right.Value < 0 {
@@ -137,7 +137,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, r.Class().Name)
 					}
 
 					rightValue := right.Value
@@ -167,7 +167,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, r.Class().Name)
 					}
 
 					rightValue := right.Value
@@ -198,7 +198,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, r.Class().Name)
 					}
 
 					rightValue := right.Value
@@ -231,7 +231,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, r.Class().Name)
 					}
 
 					rightValue := right.Value
@@ -265,7 +265,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, r.Class().Name)
 					}
 
 					rightValue := right.Value
@@ -305,7 +305,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					index, ok := i.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect index to be Integer. got=%v", i.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, i.Class().Name)
 					}
 
 					indexValue := index.Value
@@ -354,7 +354,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					index, ok := i.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect index to be Integer. got=%v", i.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, i.Class().Name)
 					}
 
 					indexValue := index.Value
@@ -368,7 +368,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					replaceStr, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, r.Class().Name)
 					}
 					replaceStrValue := replaceStr.Value
 
@@ -457,7 +457,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					concatStr, ok := c.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", c.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, c.Class().Name)
 					}
 
 					return t.vm.initStringObject(str + concatStr.Value)
@@ -509,7 +509,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					deleteStr, ok := d.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", d.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, d.Class().Name)
 					}
 
 					return t.vm.initStringObject(strings.Replace(str, deleteStr.Value, "", -1))
@@ -580,7 +580,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					compareStr, ok := c.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", c.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, c.Class().Name)
 					}
 
 					compareStrValue := compareStr.Value
@@ -655,14 +655,14 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					pattern, ok := p.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect pattern to be String. got=%v", p.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect pattern to be String. got: %s", p.Class().Name)
 					}
 
 					r := args[1]
 					replacement, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect replacement to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect replacement to be String. got: %s", r.Class().Name)
 					}
 
 					return t.vm.initStringObject(strings.Replace(str, pattern.Value, replacement.Value, -1))
@@ -690,7 +690,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					includeStr, ok := i.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", i.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, i.Class().Name)
 					}
 
 					if strings.Contains(str, includeStr.Value) {
@@ -722,7 +722,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 2 {
-						return t.vm.initErrorObject(ArgumentError, "Expect 2 arguments. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 2 arguments. got=%d", len(args))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -730,7 +730,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					index, ok := i.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect index to be Integer. got=%v", i.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, i.Class().Name)
 					}
 
 					indexValue := index.Value
@@ -738,7 +738,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					insertStr, ok := ins.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect insert string to be String. got=%v", ins.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect insert string to be String. got: %s", ins.Class().Name)
 					}
 					strLength := utf8.RuneCountInString(str)
 
@@ -811,7 +811,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					strLength, ok := l.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect justify width to be Integer. got=%v", l.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect justify width to be Integer. got: %s", l.Class().Name)
 					}
 
 					strLengthValue := strLength.Value
@@ -824,7 +824,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 						padStr, ok := p.(*StringObject)
 
 						if !ok {
-							return t.vm.initErrorObject(TypeError, "Expect padding string to be String. got=%v", p.Class().Name)
+							return t.vm.initErrorObject(TypeError, "Expect padding string to be String. got: %s", p.Class().Name)
 						}
 
 						padStrValue = padStr.Value
@@ -867,7 +867,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					replaceStr, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, r.Class().Name)
 					}
 
 					return t.vm.initStringObject(replaceStr.Value)
@@ -928,7 +928,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					strLength, ok := l.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect justify width to be Integer. got=%v", l.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect justify width to be Integer. got: %s", l.Class().Name)
 					}
 
 					strLengthValue := strLength.Value
@@ -941,7 +941,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 						padStr, ok := p.(*StringObject)
 
 						if !ok {
-							return t.vm.initErrorObject(TypeError, "Expect padding string to be String. got=%v", p.Class().Name)
+							return t.vm.initErrorObject(TypeError, "Expect padding string to be String. got: %s", p.Class().Name)
 						}
 
 						padStrValue = padStr.Value
@@ -1090,7 +1090,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 						return t.vm.initStringObject(string([]rune(str)[intValue]))
 
 					default:
-						return t.vm.initErrorObject(TypeError, "Expect slice range to be Range or Integer. got=%v", args[0].Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect slice range to be Range or Integer. got: %s", args[0].Class().Name)
 					}
 				}
 			},
@@ -1117,7 +1117,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					seperator, ok := s.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", s.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, s.Class().Name)
 					}
 
 					str := receiver.(*StringObject).Value
@@ -1155,7 +1155,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					compareStr, ok := c.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", c.Class().Name)
+						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, c.Class().Name)
 					}
 
 					compareStrValue := compareStr.Value

--- a/vm/string.go
+++ b/vm/string.go
@@ -78,7 +78,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
 					}
 
 					rightValue := right.Value
@@ -103,11 +103,11 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*IntegerObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be Integer. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be Integer. got=%v", r.Class().Name)
 					}
 
 					if right.Value < 0 {
-						return initErrorObject(ArgumentErrorClass, "Second argument must be greater than or equal to 0. got=%v", right.Value)
+						return t.vm.initErrorObject(ArgumentError, "Second argument must be greater than or equal to 0. got=%v", right.Value)
 					}
 
 					var result string
@@ -137,7 +137,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
 					}
 
 					rightValue := right.Value
@@ -167,7 +167,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
 					}
 
 					rightValue := right.Value
@@ -198,7 +198,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
 					}
 
 					rightValue := right.Value
@@ -231,7 +231,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
 					}
 
 					rightValue := right.Value
@@ -265,7 +265,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
 					}
 
 					rightValue := right.Value
@@ -297,7 +297,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got=%d", len(args))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -305,7 +305,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					index, ok := i.(*IntegerObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect index to be Integer. got=%v", i.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect index to be Integer. got=%v", i.Class().Name)
 					}
 
 					indexValue := index.Value
@@ -346,7 +346,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 2 {
-						return initErrorObject(ArgumentErrorClass, "Expect 2 arguments. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 2 arguments. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -354,28 +354,28 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					index, ok := i.(*IntegerObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect index to be Integer. got=%v", i.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect index to be Integer. got=%v", i.Class().Name)
 					}
 
 					indexValue := index.Value
 					strLength := utf8.RuneCountInString(str)
 
 					if strLength < indexValue {
-						return initErrorObject(ArgumentErrorClass, "Index value out of range. got=%v", strconv.Itoa(indexValue))
+						return t.vm.initErrorObject(ArgumentError, "Index value out of range. got=%v", strconv.Itoa(indexValue))
 					}
 
 					r := args[1]
 					replaceStr, ok := r.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
 					}
 					replaceStrValue := replaceStr.Value
 
 					// Negative Index Case
 					if indexValue < 0 {
 						if -indexValue > strLength {
-							return initErrorObject(ArgumentErrorClass, "Index value out of range. got=%v", strconv.Itoa(indexValue))
+							return t.vm.initErrorObject(ArgumentError, "Index value out of range. got=%v", strconv.Itoa(indexValue))
 						}
 						// Change to positive index to replace the string
 						indexValue += strLength
@@ -449,7 +449,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -457,7 +457,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					concatStr, ok := c.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", c.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", c.Class().Name)
 					}
 
 					return t.vm.initStringObject(str + concatStr.Value)
@@ -501,7 +501,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -509,7 +509,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					deleteStr, ok := d.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", d.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", d.Class().Name)
 					}
 
 					return t.vm.initStringObject(strings.Replace(str, deleteStr.Value, "", -1))
@@ -572,7 +572,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -580,7 +580,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					compareStr, ok := c.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", c.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", c.Class().Name)
 					}
 
 					compareStrValue := compareStr.Value
@@ -612,7 +612,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -646,7 +646,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 2 {
-						return initErrorObject(ArgumentErrorClass, "Expect 2 arguments. got=%v", len(args))
+						return t.vm.initErrorObject(ArgumentError, "Expect 2 arguments. got=%v", len(args))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -655,14 +655,14 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					pattern, ok := p.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect pattern to be String. got=%v", p.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect pattern to be String. got=%v", p.Class().Name)
 					}
 
 					r := args[1]
 					replacement, ok := r.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect replacement to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect replacement to be String. got=%v", r.Class().Name)
 					}
 
 					return t.vm.initStringObject(strings.Replace(str, pattern.Value, replacement.Value, -1))
@@ -682,7 +682,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -690,7 +690,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					includeStr, ok := i.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", i.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", i.Class().Name)
 					}
 
 					if strings.Contains(str, includeStr.Value) {
@@ -722,7 +722,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 2 {
-						return initErrorObject(ArgumentErrorClass, "Expect 2 arguments. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 2 arguments. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -730,7 +730,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					index, ok := i.(*IntegerObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect index to be Integer. got=%v", i.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect index to be Integer. got=%v", i.Class().Name)
 					}
 
 					indexValue := index.Value
@@ -738,13 +738,13 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					insertStr, ok := ins.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect insert string to be String. got=%v", ins.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect insert string to be String. got=%v", ins.Class().Name)
 					}
 					strLength := utf8.RuneCountInString(str)
 
 					if indexValue < 0 {
 						if -indexValue > strLength+1 {
-							return initErrorObject(ArgumentErrorClass, "Index value out of range. got=%v", indexValue)
+							return t.vm.initErrorObject(ArgumentError, "Index value out of range. got=%v", indexValue)
 						} else if -indexValue == strLength+1 {
 							return t.vm.initStringObject(insertStr.Value + str)
 						}
@@ -753,7 +753,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					}
 
 					if strLength < indexValue {
-						return initErrorObject(ArgumentErrorClass, "Index value out of range. got=%v", indexValue)
+						return t.vm.initErrorObject(ArgumentError, "Index value out of range. got=%v", indexValue)
 					}
 
 					// Support UTF-8 Encoding
@@ -802,7 +802,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 && len(args) != 2 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -811,7 +811,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					strLength, ok := l.(*IntegerObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect justify width to be Integer. got=%v", l.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect justify width to be Integer. got=%v", l.Class().Name)
 					}
 
 					strLengthValue := strLength.Value
@@ -824,7 +824,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 						padStr, ok := p.(*StringObject)
 
 						if !ok {
-							return initErrorObject(TypeErrorClass, "Expect padding string to be String. got=%v", p.Class().Name)
+							return t.vm.initErrorObject(TypeError, "Expect padding string to be String. got=%v", p.Class().Name)
 						}
 
 						padStrValue = padStr.Value
@@ -860,14 +860,14 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					r := args[0]
 					replaceStr, ok := r.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", r.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", r.Class().Name)
 					}
 
 					return t.vm.initStringObject(replaceStr.Value)
@@ -920,7 +920,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 && len(args) != 2 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -928,7 +928,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					strLength, ok := l.(*IntegerObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect justify width to be Integer. got=%v", l.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect justify width to be Integer. got=%v", l.Class().Name)
 					}
 
 					strLengthValue := strLength.Value
@@ -941,7 +941,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 						padStr, ok := p.(*StringObject)
 
 						if !ok {
-							return initErrorObject(TypeErrorClass, "Expect padding string to be String. got=%v", p.Class().Name)
+							return t.vm.initErrorObject(TypeError, "Expect padding string to be String. got=%v", p.Class().Name)
 						}
 
 						padStrValue = padStr.Value
@@ -1031,7 +1031,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -1090,7 +1090,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 						return t.vm.initStringObject(string([]rune(str)[intValue]))
 
 					default:
-						return initErrorObject(TypeErrorClass, "Expect slice range to be Range or Integer. got=%v", args[0].Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect slice range to be Range or Integer. got=%v", args[0].Class().Name)
 					}
 				}
 			},
@@ -1110,14 +1110,14 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					s := args[0]
 					seperator, ok := s.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", s.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", s.Class().Name)
 					}
 
 					str := receiver.(*StringObject).Value
@@ -1147,7 +1147,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					if len(args) != 1 {
-						return initErrorObject(ArgumentErrorClass, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).Value
@@ -1155,7 +1155,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					compareStr, ok := c.(*StringObject)
 
 					if !ok {
-						return initErrorObject(TypeErrorClass, "Expect argument to be String. got=%v", c.Class().Name)
+						return t.vm.initErrorObject(TypeError, "Expect argument to be String. got=%v", c.Class().Name)
 					}
 
 					compareStrValue := compareStr.Value

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -103,11 +103,11 @@ func TestStringConparisonFail(t *testing.T) {
 		input  string
 		errMsg string
 	}{
-		{`"a" < 1`, "TypeError: Expect argument to be String. got=Integer"},
-		{`"a" > 1`, "TypeError: Expect argument to be String. got=Integer"},
-		{`"a" == 1`, "TypeError: Expect argument to be String. got=Integer"},
-		{`"a" <=> 1`, "TypeError: Expect argument to be String. got=Integer"},
-		{`"a" != 1`, "TypeError: Expect argument to be String. got=Integer"},
+		{`"a" < 1`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"a" > 1`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"a" == 1`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"a" <=> 1`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"a" != 1`, "TypeError: Expect argument to be String. got: Integer"},
 	}
 	for i, tt := range testsFail {
 		vm := initTestVM()
@@ -158,13 +158,13 @@ func TestStringOperationFail(t *testing.T) {
 		errType string
 		errMsg  string
 	}{
-		{`"Taipei" + 101`, TypeError, "TypeError: Expect argument to be String. got=Integer"},
-		{`"Taipei" * "101"`, TypeError, "TypeError: Expect argument to be Integer. got=String"},
+		{`"Taipei" + 101`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Taipei" * "101"`, TypeError, "TypeError: Expect argument to be Integer. got: String"},
 		{`"Taipei" * (-101)`, ArgumentError, "ArgumentError: Second argument must be greater than or equal to 0. got=-101"},
-		{`"Taipei"[1] = 1`, TypeError, "TypeError: Expect argument to be String. got=Integer"},
-		{`"Taipei"[1] = true`, TypeError, "TypeError: Expect argument to be String. got=Boolean"},
+		{`"Taipei"[1] = 1`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Taipei"[1] = true`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
 		{`"Taipei"[]`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Taipei"[true] = 101`, TypeError, "TypeError: Expect index to be Integer. got=Boolean"},
+		{`"Taipei"[true] = 101`, TypeError, "TypeError: Expect argument to be Integer. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
@@ -241,9 +241,9 @@ func TestStringConcatenateMethodFail(t *testing.T) {
 	}{
 		{`"a".concat`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
 		{`"a".concat("Hello", "World")`, ArgumentError, "ArgumentError: Expect 1 argument. got=2"},
-		{`"a".concat(1)`, TypeError, "TypeError: Expect argument to be String. got=Integer"},
-		{`"a".concat(true)`, TypeError, "TypeError: Expect argument to be String. got=Boolean"},
-		{`"a".concat(nil)`, TypeError, "TypeError: Expect argument to be String. got=Null"},
+		{`"a".concat(1)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
+		{`"a".concat(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"a".concat(nil)`, TypeError, "TypeError: Expect argument to be String. got: Null"},
 	}
 
 	for i, tt := range testsFail {
@@ -297,9 +297,9 @@ func TestStringDeleteMethodFail(t *testing.T) {
 		errMsg  string
 	}{
 		{`"Hello hello HeLlo".delete`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Hello hello HeLlo".delete(1)`, TypeError, "TypeError: Expect argument to be String. got=Integer"},
-		{`"Hello hello HeLlo".delete(true)`, TypeError, "TypeError: Expect argument to be String. got=Boolean"},
-		{`"Hello hello HeLlo".delete(nil)`, TypeError, "TypeError: Expect argument to be String. got=Null"},
+		{`"Hello hello HeLlo".delete(1)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Hello hello HeLlo".delete(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"Hello hello HeLlo".delete(nil)`, TypeError, "TypeError: Expect argument to be String. got: Null"},
 	}
 
 	for i, tt := range testsFail {
@@ -359,9 +359,9 @@ func TestStringEndWithMethodFail(t *testing.T) {
 		errMsg  string
 	}{
 		{`"Taipei".end_with("1", "0", "1")`, ArgumentError, "ArgumentError: Expect 1 argument. got=3"},
-		{`"Taipei".end_with(101)`, TypeError, "TypeError: Expect argument to be String. got=Integer"},
-		{`"Hello".end_with(true)`, TypeError, "TypeError: Expect argument to be String. got=Boolean"},
-		{`"Hello".end_with(1..5)`, TypeError, "TypeError: Expect argument to be String. got=Range"},
+		{`"Taipei".end_with(101)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Hello".end_with(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"Hello".end_with(1..5)`, TypeError, "TypeError: Expect argument to be String. got: Range"},
 	}
 
 	for i, tt := range testsFail {
@@ -455,8 +455,8 @@ func TestStringGlobalSubstituteMethodFail(t *testing.T) {
 	}{
 		{`"Ruby".gsub()`, ArgumentError, "ArgumentError: Expect 2 arguments. got=0"},
 		{`"Ruby".gsub("Ru")`, ArgumentError, "ArgumentError: Expect 2 arguments. got=1"},
-		{`"Ruby".gsub(123, "Go")`, TypeError, "TypeError: Expect pattern to be String. got=Integer"},
-		{`"Ruby".gsub("Ru", 456)`, TypeError, "TypeError: Expect replacement to be String. got=Integer"},
+		{`"Ruby".gsub(123, "Go")`, TypeError, "TypeError: Expect pattern to be String. got: Integer"},
+		{`"Ruby".gsub("Ru", 456)`, TypeError, "TypeError: Expect replacement to be String. got: Integer"},
 	}
 
 	for i, tt := range testsFail {
@@ -497,9 +497,9 @@ func TestStringIncludeMethodFail(t *testing.T) {
 	}{
 		{`"Goby".include`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
 		{`"Goby".include("Ruby", "Lang")`, ArgumentError, "ArgumentError: Expect 1 argument. got=2"},
-		{`"Goby".include(2)`, TypeError, "TypeError: Expect argument to be String. got=Integer"},
-		{`"Goby".include(true)`, TypeError, "TypeError: Expect argument to be String. got=Boolean"},
-		{`"Goby".include(nil)`, TypeError, "TypeError: Expect argument to be String. got=Null"},
+		{`"Goby".include(2)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Goby".include(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"Goby".include(nil)`, TypeError, "TypeError: Expect argument to be String. got: Null"},
 	}
 
 	for i, tt := range testsFail {
@@ -543,8 +543,8 @@ func TestStringInsertMethodFail(t *testing.T) {
 	}{
 		{`"Goby Lang".insert`, ArgumentError, "ArgumentError: Expect 2 arguments. got=0"},
 		{`"Taipei".insert(6, " ", "101")`, ArgumentError, "ArgumentError: Expect 2 arguments. got=3"},
-		{`"Taipei".insert("6", " 101")`, TypeError, "TypeError: Expect index to be Integer. got=String"},
-		{`"Taipei".insert(6, 101)`, TypeError, "TypeError: Expect insert string to be String. got=Integer"},
+		{`"Taipei".insert("6", " 101")`, TypeError, "TypeError: Expect argument to be Integer. got: String"},
+		{`"Taipei".insert(6, 101)`, TypeError, "TypeError: Expect insert string to be String. got: Integer"},
 		{`"Taipei".insert(-8, "101")`, ArgumentError, "ArgumentError: Index value out of range. got=-8"},
 		{`"Taipei".insert(7, "101")`, ArgumentError, "ArgumentError: Index value out of range. got=7"},
 	}
@@ -584,12 +584,12 @@ func TestStringLeftJustifyMethodFail(t *testing.T) {
 	}{
 		{`"Hello".ljust`, ArgumentError, "ArgumentError: Expect 1..2 arguments. got=0"},
 		{`"Hello".ljust(1, 2, 3, 4, 5)`, ArgumentError, "ArgumentError: Expect 1..2 arguments. got=5"},
-		{`"Hello".ljust(true)`, TypeError, "TypeError: Expect justify width to be Integer. got=Boolean"},
-		{`"Hello".ljust("World")`, TypeError, "TypeError: Expect justify width to be Integer. got=String"},
-		{`"Hello".ljust(2..5)`, TypeError, "TypeError: Expect justify width to be Integer. got=Range"},
-		{`"Hello".ljust(10, 10)`, TypeError, "TypeError: Expect padding string to be String. got=Integer"},
-		{`"Hello".ljust(10, 2..5)`, TypeError, "TypeError: Expect padding string to be String. got=Range"},
-		{`"Hello".ljust(10, true)`, TypeError, "TypeError: Expect padding string to be String. got=Boolean"},
+		{`"Hello".ljust(true)`, TypeError, "TypeError: Expect justify width to be Integer. got: Boolean"},
+		{`"Hello".ljust("World")`, TypeError, "TypeError: Expect justify width to be Integer. got: String"},
+		{`"Hello".ljust(2..5)`, TypeError, "TypeError: Expect justify width to be Integer. got: Range"},
+		{`"Hello".ljust(10, 10)`, TypeError, "TypeError: Expect padding string to be String. got: Integer"},
+		{`"Hello".ljust(10, 2..5)`, TypeError, "TypeError: Expect padding string to be String. got: Range"},
+		{`"Hello".ljust(10, true)`, TypeError, "TypeError: Expect padding string to be String. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
@@ -644,8 +644,8 @@ func TestStringReplaceMethodFail(t *testing.T) {
 		errMsg  string
 	}{
 		{`"Taipei".replace`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Taipei".replace(101)`, TypeError, "TypeError: Expect argument to be String. got=Integer"},
-		{`"Taipei".replace(true)`, TypeError, "TypeError: Expect argument to be String. got=Boolean"},
+		{`"Taipei".replace(101)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Taipei".replace(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
@@ -703,12 +703,12 @@ func TestStringRightJustifyFail(t *testing.T) {
 	}{
 		{`"Hello".rjust`, ArgumentError, "ArgumentError: Expect 1..2 arguments. got=0"},
 		{`"Hello".rjust(1, 2, 3, 4, 5)`, ArgumentError, "ArgumentError: Expect 1..2 arguments. got=5"},
-		{`"Hello".rjust(true)`, TypeError, "TypeError: Expect justify width to be Integer. got=Boolean"},
-		{`"Hello".rjust("World")`, TypeError, "TypeError: Expect justify width to be Integer. got=String"},
-		{`"Hello".rjust(2..5)`, TypeError, "TypeError: Expect justify width to be Integer. got=Range"},
-		{`"Hello".rjust(10, 10)`, TypeError, "TypeError: Expect padding string to be String. got=Integer"},
-		{`"Hello".rjust(10, 2..5)`, TypeError, "TypeError: Expect padding string to be String. got=Range"},
-		{`"Hello".rjust(10, true)`, TypeError, "TypeError: Expect padding string to be String. got=Boolean"},
+		{`"Hello".rjust(true)`, TypeError, "TypeError: Expect justify width to be Integer. got: Boolean"},
+		{`"Hello".rjust("World")`, TypeError, "TypeError: Expect justify width to be Integer. got: String"},
+		{`"Hello".rjust(2..5)`, TypeError, "TypeError: Expect justify width to be Integer. got: Range"},
+		{`"Hello".rjust(10, 10)`, TypeError, "TypeError: Expect padding string to be String. got: Integer"},
+		{`"Hello".rjust(10, 2..5)`, TypeError, "TypeError: Expect padding string to be String. got: Range"},
+		{`"Hello".rjust(10, true)`, TypeError, "TypeError: Expect padding string to be String. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
@@ -790,8 +790,8 @@ func TestStringSliceMethodFail(t *testing.T) {
 		errMsg  string
 	}{
 		{`"Goby Lang".slice`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Goby Lang".slice("Hello")`, TypeError, "TypeError: Expect slice range to be Range or Integer. got=String"},
-		{`"Goby Lang".slice(true)`, TypeError, "TypeError: Expect slice range to be Range or Integer. got=Boolean"},
+		{`"Goby Lang".slice("Hello")`, TypeError, "TypeError: Expect slice range to be Range or Integer. got: String"},
+		{`"Goby Lang".slice(true)`, TypeError, "TypeError: Expect slice range to be Range or Integer. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
@@ -888,9 +888,9 @@ func TestStringSplitMethodFail(t *testing.T) {
 		errMsg  string
 	}{
 		{`"Hello World".split`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Hello World".split(true)`, TypeError, "TypeError: Expect argument to be String. got=Boolean"},
-		{`"Hello World".split(123)`, TypeError, "TypeError: Expect argument to be String. got=Integer"},
-		{`"Hello World".split(1..2)`, TypeError, "TypeError: Expect argument to be String. got=Range"},
+		{`"Hello World".split(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"Hello World".split(123)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Hello World".split(1..2)`, TypeError, "TypeError: Expect argument to be String. got: Range"},
 	}
 
 	for i, tt := range testsFail {
@@ -931,9 +931,9 @@ func TestStringStartWithMethodFail(t *testing.T) {
 		errMsg  string
 	}{
 		{`"Taipei".start_with("1", "0", "1")`, ArgumentError, "ArgumentError: Expect 1 argument. got=3"},
-		{`"Taipei".start_with(101)`, TypeError, "TypeError: Expect argument to be String. got=Integer"},
-		{`"Hello".start_with(true)`, TypeError, "TypeError: Expect argument to be String. got=Boolean"},
-		{`"Hello".start_with(1..5)`, TypeError, "TypeError: Expect argument to be String. got=Range"},
+		{`"Taipei".start_with(101)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Hello".start_with(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"Hello".start_with(1..5)`, TypeError, "TypeError: Expect argument to be String. got: Range"},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -154,7 +154,7 @@ func (t *thread) evalMethodObject(receiver Object, method *MethodObject, receive
 
 	if argC < normalArgCount {
 		e := t.vm.initErrorObject(ArgumentError, "Expect at least %d args for method '%s'. got: %d", normalArgCount, method.Name, argC)
-		t.stack.push(&Pointer{Target:e})
+		t.stack.push(&Pointer{Target: e})
 	} else if argC > method.argc {
 		e := t.vm.initErrorObject(ArgumentError, "Expect at most %d args for method '%s'. got: %d", method.argc, method.Name, argC)
 		t.stack.push(&Pointer{Target: e})
@@ -179,7 +179,7 @@ func (t *thread) returnError(errorType, format string, args ...interface{}) {
 
 func (t *thread) UndefinedMethodError(methodName string, receiver Object) {
 	err := t.vm.initErrorObject(UndefinedMethodError, "Undefined Method '%+v' for %+v", methodName, receiver.toString())
-	t.stack.push(&Pointer{Target:err})
+	t.stack.push(&Pointer{Target: err})
 }
 
 func (t *thread) UnsupportedMethodError(methodName string, receiver Object) *Error {

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -153,10 +153,10 @@ func (t *thread) evalMethodObject(receiver Object, method *MethodObject, receive
 	}
 
 	if argC < normalArgCount {
-		e := initErrorObject(ArgumentErrorClass, "Expect at least %d args for method '%s'. got: %d", normalArgCount, method.Name, argC)
-		t.stack.push(&Pointer{Target: e})
+		e := t.vm.initErrorObject(ArgumentError, "Expect at least %d args for method '%s'. got: %d", normalArgCount, method.Name, argC)
+		t.stack.push(&Pointer{Target:e})
 	} else if argC > method.argc {
-		e := initErrorObject(ArgumentErrorClass, "Expect at most %d args for method '%s'. got: %d", method.argc, method.Name, argC)
+		e := t.vm.initErrorObject(ArgumentError, "Expect at most %d args for method '%s'. got: %d", method.argc, method.Name, argC)
 		t.stack.push(&Pointer{Target: e})
 	} else {
 		for i := 0; i < argC; i++ {
@@ -179,10 +179,10 @@ func (t *thread) returnError(msg string) {
 }
 
 func (t *thread) UndefinedMethodError(methodName string, receiver Object) {
-	err := initErrorObject(UndefinedMethodErrorClass, "Undefined Method '%+v' for %+v", methodName, receiver.toString())
-	t.stack.push(&Pointer{Target: err})
+	err := t.vm.initErrorObject(UndefinedMethodError, "Undefined Method '%+v' for %+v", methodName, receiver.toString())
+	t.stack.push(&Pointer{Target:err})
 }
 
 func (t *thread) UnsupportedMethodError(methodName string, receiver Object) *Error {
-	return initErrorObject(UnsupportedMethodClass, "Unsupported Method %s for %+v", methodName, receiver.toString())
+	return t.vm.initErrorObject(UnsupportedMethodError, "Unsupported Method %s for %+v", methodName, receiver.toString())
 }

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -172,9 +172,8 @@ func (t *thread) evalMethodObject(receiver Object, method *MethodObject, receive
 	t.sp = receiverPr + 1
 }
 
-// TODO: Use this method to replace unnecessary panics
-func (t *thread) returnError(msg string) {
-	err := &Error{Message: msg}
+func (t *thread) returnError(errorType, format string, args ...interface{}) {
+	err := t.vm.initErrorObject(errorType, format, args)
 	t.stack.push(&Pointer{Target: err})
 }
 

--- a/vm/uri.go
+++ b/vm/uri.go
@@ -51,7 +51,7 @@ func builtinURIClassMethods() []*BuiltInMethodObject {
 					u, err := url.Parse(uri)
 
 					if err != nil {
-						t.returnError(InternalError, err.Error())
+						return t.vm.initErrorObject(InternalError, err.Error())
 					}
 
 					uriAttrs := map[string]Object{
@@ -79,7 +79,7 @@ func builtinURIClassMethods() []*BuiltInMethodObject {
 						p, err := strconv.ParseInt(u.Port(), 0, 64)
 
 						if err != nil {
-							t.returnError(InternalError, err.Error())
+							return t.vm.initErrorObject(InternalError, err.Error())
 						}
 
 						uriAttrs["@port"] = t.vm.initIntegerObject(int(p))

--- a/vm/uri.go
+++ b/vm/uri.go
@@ -51,7 +51,7 @@ func builtinURIClassMethods() []*BuiltInMethodObject {
 					u, err := url.Parse(uri)
 
 					if err != nil {
-						t.returnError(err.Error())
+						t.returnError(InternalError, err.Error())
 					}
 
 					uriAttrs := map[string]Object{
@@ -79,7 +79,7 @@ func builtinURIClassMethods() []*BuiltInMethodObject {
 						p, err := strconv.ParseInt(u.Port(), 0, 64)
 
 						if err != nil {
-							t.returnError(err.Error())
+							t.returnError(InternalError, err.Error())
 						}
 
 						uriAttrs["@port"] = t.vm.initIntegerObject(int(p))

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -289,7 +289,7 @@ func (vm *VM) execGobyLib(libName string) {
 	file, err := ioutil.ReadFile(libPath)
 
 	if err != nil {
-		vm.mainThread.returnError(err.Error())
+		vm.mainThread.returnError(InternalError, err.Error())
 	}
 
 	vm.execRequiredFile(libPath, file)


### PR DESCRIPTION
Refer to #237.

The error style code  is formally formatted in VM part. The rules are listed below.

- Part of the `vm/vm.go`, `thread.go` & `vm/instruction.go` uses the `t.returnError` as the error function

- VM part now unified `&Error`, `wrongTypeError`, `newError` ... different various style of errors into `t.vm.initErrorObject`.

- The first params of `initErrorObject` function now modified to pass in Go `string` type value instead of `*RClass` type value. For instance, previous format:

```go
return initErrorObject(ArgumentErrorClass, "Expect 1 argument. got: %d", len(args))
```

should now become:

```go
return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got: %d", len(args))
```

- The error message will also abandon the pure code-in string format, instead using constants listed in `vm/error.go` to represent the error message. For instance, instead of code-in string format:

```go
return t.vm.initErrorObject(InternalError, "Can't yield without a block")
```

should now use:

```go
return t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
```

- Error (or API failure) testing should not use the `*Error` format. To implement failure testing of error message, use pure Go `string` format, for instance:

```go

func TestArrayShiftMethodFail(t *testing.T) {
	testsFail := []struct {
		input    string
		expected string // Do not use *Error
	}{
		{`
		a = [1, 2]
		a.shift(3, 3, 4, 5)
		`, "ArgumentError: Expect 0 argument. got=4"}, // Error message using string format
	}

	for i, tt := range testsFail {
		v := initTestVM()
		evaluated := v.testEval(t, tt.input)
		// Using checkError function to check error message
		checkError(t, i, evaluated, ArgumentError, tt.expected)
		v.checkCFP(t, i, 1)
	}
}
```