### PR TITLE
#260 Fix Equality Comparison Part

### DIFF
--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -23,6 +23,47 @@ func TestArrayEvaluation(t *testing.T) {
 	checkExpected(t, 0, arr.Elements[2], true)
 }
 
+func TestArrayComparisonOperation(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`[1, "String", true, 2..5] == 123`, false},
+		{`[1, "String", true, 2..5] == "123"`, false},
+		{`[1, "String", true, 2..5] == "124"`, false},
+		{`[1, "String", true, 2..5] == (1..3)`, false},
+		{`[1, "String", true, 2..5] == { a: 1, b: 2 }`, false},
+		{`[1, "String", true, 2..5] == [1, "String", true, 2..5]`, true},
+		{`[1, "String", true, 2..5] == [1, "String", false, 2..5]`, false},
+		{`[1, "String", true, 2..5] == ["String", 1, false, 2..5]`, false}, // Array has order issue
+		{`[1, { a: 1, b: 2 }, "Goby" ] == [1, { a: 1, b: 2 }, "Goby"]`, true},
+		{`[1, { a: 1, b: 2 }, "Goby" ] == [1, { b: 2, a: 1 }, "Goby"]`, true},
+		{`[1, { a: 1, b: 2 }, "Goby" ] == [1, { a: 1, b: 2, c: 3 }, "Goby"]`, false}, // Array of hash has no order issue
+		{`[1, { a: 1, b: 2 }, "Goby" ] == [1, { a: 2, b: 2, a: 1 }, "Goby"]`, true},  // Array of hash key will be overwritten if duplicated
+		{`[1, "String", true, 2..5] == Integer`, false},
+		{`[1, "String", true, 2..5] != 123`, true},
+		{`[1, "String", true, 2..5] != "123"`, true},
+		{`[1, "String", true, 2..5] != "124"`, true},
+		{`[1, "String", true, 2..5] != (1..3)`, true},
+		{`[1, "String", true, 2..5] != { a: 1, b: 2 }`, true},
+		{`[1, "String", true, 2..5] != [1, "String", true, 2..5]`, false},
+		{`[1, "String", true, 2..5] != [1, "String", false, 2..5]`, true},
+		{`[1, "String", true, 2..5] != ["String", 1, false, 2..5]`, true}, // Array has order issue
+		{`[1, { a: 1, b: 2 }, "Goby" ] != [1, { a: 1, b: 2 }, "Goby"]`, false},
+		{`[1, { a: 1, b: 2 }, "Goby" ] != [1, { b: 2, a: 1 }, "Goby"]`, false},
+		{`[1, { a: 1, b: 2 }, "Goby" ] != [1, { a: 1, b: 2, c: 3 }, "Goby"]`, true},  // Array of hash has no order issue
+		{`[1, { a: 1, b: 2 }, "Goby" ] != [1, { a: 2, b: 2, a: 1 }, "Goby"]`, false}, // Array of hash key will be overwritten if duplicated
+		{`[1, "String", true, 2..5] != Integer`, true},
+	}
+
+	for i, tt := range tests {
+		vm := initTestVM()
+		evaluated := vm.testEval(t, tt.input)
+		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
+	}
+}
+
 func TestArrayIndex(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -56,10 +56,6 @@ func builtinBooleanInstanceMethods() []*BuiltInMethodObject {
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					if len(args) != 1 {
-						err := t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got: %d", len(args))
-						return err
-					}
 
 					if receiver == args[0] {
 						return TRUE
@@ -80,10 +76,6 @@ func builtinBooleanInstanceMethods() []*BuiltInMethodObject {
 			Name: "!=",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					if len(args) != 1 {
-						err := t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got: %d", len(args))
-						return err
-					}
 
 					if receiver != args[0] {
 						return TRUE

--- a/vm/class.go
+++ b/vm/class.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
+	"reflect"
 	"time"
 )
 
@@ -75,6 +76,73 @@ func initObjectClass(c *RClass) *RClass {
 
 func builtinCommonInstanceMethods() []*BuiltInMethodObject {
 	return []*BuiltInMethodObject{
+		{
+			// General method for comparing equalty of the objects
+			//
+			// ```ruby
+			// 123 == 123   # => true
+			// 123 == "123" # => false
+			//
+			// # Hash will not concern about the key-value pair order
+			// { a: 1, b: 2 } == { a: 1, b: 2 } # => true
+			// { a: 1, b: 2 } == { b: 2, a: 1 } # => true
+			//
+			// # Hash key will be override if the key duplicated
+			// { a: 1, b: 2 } == { a: 2, b: 2, a: 1 } # => true
+			// { a: 1, b: 2 } == { a: 1, b: 2, a: 2 } # => false
+			//
+			// # Array will concern about the order of the elements
+			// [1, 2, 3] == [1, 2, 3] # => true
+			// [1, 2, 3] == [3, 2, 1] # => false
+			// ```
+			//
+			// @return [@boolean]
+			Name: "==",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					className := receiver.Class().Name
+					compareClassName := args[0].Class().Name
+
+					if className == compareClassName && reflect.DeepEqual(receiver, args[0]) {
+						return TRUE
+					}
+					return FALSE
+				}
+			},
+		}, {
+			// General method for comparing inequalty of the objects
+			//
+			// ```ruby
+			// 123 != 123   # => false
+			// 123 != "123" # => true
+			//
+			// # Hash will not concern about the key-value pair order
+			// { a: 1, b: 2 } != { a: 1, b: 2 } # => false
+			// { a: 1, b: 2 } != { b: 2, a: 1 } # => false
+			//
+			// # Hash key will be override if the key duplicated
+			// { a: 1, b: 2 } != { a: 2, b: 2, a: 1 } # => false
+			// { a: 1, b: 2 } != { a: 1, b: 2, a: 2 } # => true
+			//
+			// # Array will concern about the order of the elements
+			// [1, 2, 3] != [1, 2, 3] # => false
+			// [1, 2, 3] != [3, 2, 1] # => true
+			// ```
+			//
+			// @return [@boolean]
+			Name: "!=",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					className := receiver.Class().Name
+					compareClassName := args[0].Class().Name
+
+					if className == compareClassName && reflect.DeepEqual(receiver, args[0]) {
+						return FALSE
+					}
+					return TRUE
+				}
+			},
+		},
 		{
 			// Loads the given Goby library name without extension (mainly for modules), returning `true`
 			// if successful and `false` if the feature is already loaded.

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -455,6 +455,47 @@ func TestRequireFail(t *testing.T) {
 	}
 }
 
+func TestClassGeneralComparisonOperation(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`Integer == 123`, false},
+		{`Integer == "123"`, false},
+		{`Integer == "124"`, false},
+		{`Integer == (1..3)`, false},
+		{`Integer == { a: 1, b: 2 }`, false},
+		{`Integer == [1, "String", true, 2..5]`, false},
+		{`Integer == Integer`, true},
+		{`Integer == String`, false},
+		{`123.class == Integer`, true},
+		// TODO: Comparing to Object cause panic
+		//{`Integer == Object`, false},
+		//{`Integer.superclass == Object`, true},
+		//{`123.class.superclass == Object`, true},
+		{`Integer != 123`, true},
+		{`Integer != "123"`, true},
+		{`Integer != "124"`, true},
+		{`Integer != (1..3)`, true},
+		{`Integer != { a: 1, b: 2 }`, true},
+		{`Integer != [1, "String", true, 2..5]`, true},
+		{`Integer != Integer`, false},
+		{`Integer != String`, true},
+		{`123.class != Integer`, false},
+		// TODO: Comparing to Object cause panic
+		//{`Integer != Object`, true},
+		//{`Integer.superclass != Object`, false},
+		//{`123.class.superclass != Object`, false},
+	}
+
+	for i, tt := range tests {
+		vm := initTestVM()
+		evaluated := vm.testEval(t, tt.input)
+		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
+	}
+}
+
 func TestClassNameClassMethod(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -6,6 +6,49 @@ import (
 	"testing"
 )
 
+func TestHashComparisonOperation(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`{ a: 1, b: 2 } == 123`, false},
+		{`{ a: 1, b: 2 } == "123"`, false},
+		{`{ a: 1, b: 2 } == "124"`, false},
+		{`{ a: 1, b: 2 } == (1..3)`, false},
+		{`{ a: 1, b: 2 } == { a: 1, b: 2 }`, true},
+		{`{ b: 2, a: 1 } == { a: 1, b: 2 }`, true}, // Hash has no order issue
+		{`{ a: 1, b: 2 } == { a: 2, b: 1 }`, false},
+		{`{ a: 1, b: 2 } == { b: 1, a: 2 }`, false},
+		{`{ a: 1, b: 2 } == { a: 1, b: 2, c: 3 }`, false},
+		{`{ a: 1, b: 2 } == { a: 2, b: 2, a: 1 }`, true}, // Hash front key will be overwritten if duplicated
+		{`{ a: [1, 2, 3], b: 2 } == { a: [1, 2, 3], b: 2 }`, true},
+		{`{ a: [1, 2, 3], b: 2 } == { a: [3, 2, 1], b: 2 }`, false}, // Hash of array has order issue
+		{`{ a: 1, b: 2 } == [1, "String", true, 2..5]`, false},
+		{`{ a: 1, b: 2 } == Integer`, false},
+		{`{ a: 1, b: 2 } != 123`, true},
+		{`{ a: 1, b: 2 } != "123"`, true},
+		{`{ a: 1, b: 2 } != "124"`, true},
+		{`{ a: 1, b: 2 } != (1..3)`, true},
+		{`{ a: 1, b: 2 } != { a: 1, b: 2 }`, false},
+		{`{ b: 2, a: 1 } != { a: 1, b: 2 }`, false}, // Hash has no order issue
+		{`{ a: 1, b: 2 } != { a: 2, b: 1 }`, true},
+		{`{ a: 1, b: 2 } != { b: 1, a: 2 }`, true},
+		{`{ a: 1, b: 2 } != { a: 1, b: 2, c: 3 }`, true},
+		{`{ a: 1, b: 2 } != { a: 2, b: 2, a: 1 }`, false}, // Hash front key will be overwritten if duplicated
+		{`{ a: [1, 2, 3], b: 2 } != { a: [1, 2, 3], b: 2 }`, false},
+		{`{ a: [1, 2, 3], b: 2 } != { a: [3, 2, 1], b: 2 }`, true}, // Hash of array has order issue
+		{`{ a: 1, b: 2 } != [1, "String", true, 2..5]`, true},
+		{`{ a: 1, b: 2 } != Integer`, true},
+	}
+
+	for i, tt := range tests {
+		vm := initTestVM()
+		evaluated := vm.testEval(t, tt.input)
+		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
+	}
+}
+
 func TestHashToJSONMethodWithArray(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -362,8 +362,7 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
-						return err
+						return FALSE
 					}
 
 					rightValue := right.Value
@@ -392,8 +391,7 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					right, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						err := t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, integerClass, args[0].Class().Name)
-						return err
+						return TRUE
 					}
 
 					rightValue := right.Value

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -76,8 +76,6 @@ func TestIntegerComparison(t *testing.T) {
 		{`4 > 6`, false},
 		{`-5 < -4`, true},
 		{`100 < 81`, false},
-		{`5 ** 4`, 625},
-		{`25 / 5`, 5},
 		{`25 > 5`, true},
 		{`4 > 6`, false},
 		{`4 >= 4`, true},
@@ -89,10 +87,20 @@ func TestIntegerComparison(t *testing.T) {
 		{`10 <=> 0`, 1},
 		{`1 <=> 2`, -1},
 		{`4 <=> 4`, 0},
-		{`8 == 8`, true},
-		{`3 == 4`, false},
-		{`3 != 4`, true},
-		{`4 != 4`, false},
+		{`123 == 123`, true},
+		{`123 == 124`, false},
+		{`123 == "123"`, false},
+		{`123 == (1..3)`, false},
+		{`123 == { a: 1, b: 2 }`, false},
+		{`123 == [1, "String", true, 2..5]`, false},
+		{`123 == Integer`, false},
+		{`123 != 123`, false},
+		{`123 != 124`, true},
+		{`123 != "123"`, true},
+		{`123 != (1..3)`, true},
+		{`123 != { a: 1, b: 2 }`, true},
+		{`123 != [1, "String", true, 2..5]`, true},
+		{`123 != Integer`, true},
 	}
 
 	for i, tt := range tests {
@@ -122,12 +130,6 @@ func TestIntegerComparisonFail(t *testing.T) {
 		`, "TypeError: Expect argument to be Integer. got: String"},
 		{`
 		1 <=> "m"
-		`, "TypeError: Expect argument to be Integer. got: String"},
-		{`
-		1 == "m"
-		`, "TypeError: Expect argument to be Integer. got: String"},
-		{`
-		1 != "m"
 		`, "TypeError: Expect argument to be Integer. got: String"},
 	}
 

--- a/vm/null.go
+++ b/vm/null.go
@@ -35,7 +35,6 @@ func builtInNullClassMethods() []*BuiltInMethodObject {
 
 func builtInNullInstanceMethods() []*BuiltInMethodObject {
 	return []*BuiltInMethodObject{
-
 		{
 			// Returns true: the flipped boolean value of nil object.
 			//
@@ -49,6 +48,50 @@ func builtInNullInstanceMethods() []*BuiltInMethodObject {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 
 					return TRUE
+				}
+			},
+		},
+		{
+			// Returns true: the flipped boolean value of nil object.
+			//
+			// ```ruby
+			// a = nil
+			// a == nil
+			// # => true
+			// ```
+			Name: "==",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					if len(args) != 1 {
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got: %d", len(args))
+					}
+
+					if _, ok := args[0].(*NullObject); ok {
+						return TRUE
+					}
+					return FALSE
+				}
+			},
+		},
+		{
+			// Returns true: the flipped boolean value of nil object.
+			//
+			// ```ruby
+			// a = nil
+			// a != nil
+			// # => false
+			// ```
+			Name: "!=",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					if len(args) != 1 {
+						return t.vm.initErrorObject(ArgumentError, "Expect 1 argument. got: %d", len(args))
+					}
+
+					if _, ok := args[0].(*NullObject); !ok {
+						return TRUE
+					}
+					return FALSE
 				}
 			},
 		},

--- a/vm/null_test.go
+++ b/vm/null_test.go
@@ -22,3 +22,24 @@ func TestBangPrefix(t *testing.T) {
 	checkExpected(t, 0, evaluated, true)
 	vm.checkCFP(t, 0, 0)
 }
+
+func TestNullComparisonOperation(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{`123 == nil`, false},
+		{`nil == nil`, true},
+		{`nil == 123`, false},
+		{`123 != nil`, true},
+		{`nil != nil`, false},
+		{`nil != 123`, true},
+	}
+
+	for i, tt := range tests {
+		vm := initTestVM()
+		evaluated := vm.testEval(t, tt.input)
+		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
+	}
+}

--- a/vm/range.go
+++ b/vm/range.go
@@ -59,6 +59,64 @@ func builtInRangeClassMethods() []*BuiltInMethodObject {
 func builtInRangeInstanceMethods() []*BuiltInMethodObject {
 	return []*BuiltInMethodObject{
 		{
+			// Returns a Boolean of compared two ranges
+			//
+			// ```ruby
+			// (1..5) == (1..5) # => true
+			// (1..5) == (1..6) # => false
+			// ```
+			//
+			// @return [Boolean]
+			Name: "==",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					left := receiver.(*RangeObject)
+					r := args[0]
+					right, ok := r.(*RangeObject)
+
+					if !ok {
+						return FALSE
+					}
+
+					if left.Start == right.Start && left.End == right.End {
+						return TRUE
+					}
+
+					return FALSE
+				}
+			},
+		},
+		{
+			// Returns a Boolean of compared two ranges
+			//
+			// ```ruby
+			// (1..5) != (1..5) # => false
+			// (1..5) != (1..6) # => true
+			// ```
+			//
+			// @return [Boolean]
+			Name: "!=",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					left := receiver.(*RangeObject)
+					r := args[0]
+					right, ok := r.(*RangeObject)
+
+					if !ok {
+						return TRUE
+					}
+
+					if left.Start == right.Start && left.End == right.End {
+						return FALSE
+					}
+
+					return TRUE
+				}
+			},
+		},
+		{
 			// By using binary search, finds a value in range which meets the given condition in O(log n)
 			// where n is the size of the range.
 			//

--- a/vm/range_test.go
+++ b/vm/range_test.go
@@ -4,6 +4,37 @@ import (
 	"testing"
 )
 
+func TestRangeComparisonOperation(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{`(1..3) == (1..3)`, true},
+		{`(1..3) == (1..4)`, false},
+		{`(1..3) == 123`, false},
+		{`(1..3) == "123"`, false},
+		{`(1..3) == "124"`, false},
+		{`(1..3) == { a: 1, b: 2 }`, false},
+		{`(1..3) == [1, "String", true, 2..5]`, false},
+		{`(1..3) == Integer`, false},
+		{`(1..3) != (1..3)`, false},
+		{`(1..3) != (1..4)`, true},
+		{`(1..3) != 123`, true},
+		{`(1..3) != "123"`, true},
+		{`(1..3) != "124"`, true},
+		{`(1..3) != { a: 1, b: 2 }`, true},
+		{`(1..3) != [1, "String", true, 2..5]`, true},
+		{`(1..3) != Integer`, true},
+	}
+
+	for i, tt := range tests {
+		vm := initTestVM()
+		evaluated := vm.testEval(t, tt.input)
+		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
+	}
+}
+
 func TestRangeBsearchMethod(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/vm/string.go
+++ b/vm/string.go
@@ -198,7 +198,7 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, r.Class().Name)
+						return FALSE
 					}
 
 					rightValue := right.Value
@@ -261,11 +261,10 @@ func builtinStringInstanceMethods() []*BuiltInMethodObject {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 
 					leftValue := receiver.(*StringObject).Value
-					r := args[0]
 					right, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(TypeError, WrongArgumentTypeFormat, stringClass, r.Class().Name)
+						return TRUE
 					}
 
 					rightValue := right.Value

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -70,13 +70,23 @@ func TestStringComparison(t *testing.T) {
 		input    string
 		expected interface{}
 	}{
-		{`"Dog" == "Dog"`, true},
+		{`"123" == "123"`, true},
+		{`"123" == "124"`, false},
+		{`"123" == 123`, false},
+		{`"123" == (1..3)`, false},
+		{`"123" == { a: 1, b: 2 }`, false},
+		{`"123" == [1, "String", true, 2..5]`, false},
+		{`"123" != "123"`, false},
+		{`"123" != "124"`, true},
+		{`"123" != 123`, true},
+		{`"123" != (1..3)`, true},
+		{`"123" != { a: 1, b: 2 }`, true},
+		{`"123" != [1, "String", true, 2..5]`, true},
+		{`"123" != String`, true},
 		{`"1234" > "123"`, true},
 		{`"123" > "1235"`, false},
 		{`"1234" < "123"`, false},
 		{`"1234" < "12jdkfj3"`, true},
-		{`"1234" != "123"`, true},
-		{`"123" != "123"`, false},
 		{`"1234" <=> "1234"`, 0},
 		{`"1234" <=> "4"`, -1},
 		{`"abcdef" <=> "abcde"`, 1},
@@ -105,9 +115,7 @@ func TestStringConparisonFail(t *testing.T) {
 	}{
 		{`"a" < 1`, "TypeError: Expect argument to be String. got: Integer"},
 		{`"a" > 1`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"a" == 1`, "TypeError: Expect argument to be String. got: Integer"},
 		{`"a" <=> 1`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"a" != 1`, "TypeError: Expect argument to be String. got: Integer"},
 	}
 	for i, tt := range testsFail {
 		vm := initTestVM()


### PR DESCRIPTION
This PR aims to redefine the general or specific class' `#==` & `#!=` method, and it should also return `false` when using `#==` (and return `true` using `#!=`) when comparing different types of value. For example:

```
$ go run goby.go -i
Goby 0.0.9 😂 😅 🤧
» 123 == 123
#=> true
» 123 == 124
#=> false
» 123 == "123"
#=> false
» 123 == [1, 2, 3]
#=> false
» 123 == (1..3)
#=> false
» 123 == { a: 1, b: 2, c: 3 }
#=> false
» 123 == Integer
#=> false
» 123 == true
#=> false
» 123.class == Integer
#=> true
```

Tips: It only solves **comparison** part of the issue in #260