### PR TITLE
Add two small features to Igb

### DIFF
--- a/igb/repl.go
+++ b/igb/repl.go
@@ -19,9 +19,9 @@ import (
 
 const (
 	prompt1   = "\033[32m»\033[0m "
-	prompt2   = "\033[31m*\033[0m "
+	prompt2   = "\033[31m›\033[0m "
 	pad       = "  "
-	echo      = "#=>"
+	echo      = "\033[33m#»\033[0m"
 	interrupt = "^C"
 	exit      = "exit"
 	help      = "help"

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -23,6 +23,7 @@ const (
 	pad       = "  "
 	echo      = "\033[33m#»\033[0m"
 	interrupt = "^C"
+	semicolon = ";"
 	exit      = "exit"
 	help      = "help"
 	reset     = "reset"
@@ -210,7 +211,6 @@ reset:
 			// If everything goes well, reset state and statements buffer
 			rl.SetPrompt(prompt(stack))
 			sm.Event(readyToExec)
-			cmds = nil
 		}
 		if sm.Is(readyToExec) {
 			println(prompt(stack) + line)
@@ -218,7 +218,19 @@ reset:
 			v.REPLExec(instructions)
 
 			r := v.GetREPLResult()
-			println(echo, r)
+			
+			// Suppress echo back on trailing ';'
+			if cmds != nil {
+				if t := cmds[len(cmds)-1]; string(t[len(t)-1]) != semicolon {
+					println(echo, r)
+				}
+			} else {
+				if string(line[len(line)-1]) != semicolon {
+					println(echo, r)
+				}
+			}
+			//}
+			cmds = nil
 		}
 	}
 }

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -18,8 +18,10 @@ import (
 )
 
 const (
-	prompt1   = "\033[32m»\033[0m "
-	prompt2   = "\033[31m›\033[0m "
+	prmpt1    = "»"
+	prmpt2    = "¤"
+	prompt1   = "\033[32m" + prmpt1 + "\033[0m "
+	prompt2   = "\033[31m" + prmpt2 + "\033[0m "
 	pad       = "  "
 	echo      = "\033[33m#»\033[0m"
 	interrupt = "^C"
@@ -97,6 +99,8 @@ reset:
 		line, err := rl.Readline()
 		rl.Config.UniqueEditLine = false
 
+		line = strings.TrimPrefix(line, prmpt1)
+		line = strings.TrimPrefix(line, prmpt2)
 		line = strings.TrimSpace(line)
 
 		if err != nil {
@@ -218,7 +222,7 @@ reset:
 			v.REPLExec(instructions)
 
 			r := v.GetREPLResult()
-			
+
 			// Suppress echo back on trailing ';'
 			if cmds != nil {
 				if t := cmds[len(cmds)-1]; string(t[len(t)-1]) != semicolon {


### PR DESCRIPTION
* you can add a trailing `;` to suppress echo back (inspired by Pry)

```ruby
Goby 0.0.9 🤧 😪 😏
» 42
#» 42
» 42;
»                       #<- echo back suppressed
» def foo
¤   42
» end;
»                       #<- echo back suppressed
```

* Now you can paste the copied lines from Igb directory: leading prompt characters are trimmed on Igb.

I can't show the feature graphically, but you may notice when you copy the lines from Igb and paste it.

[![asciicast](https://asciinema.org/a/luJNuvZ23vs3TfiG1SR08p0Wl.png)](https://asciinema.org/a/luJNuvZ23vs3TfiG1SR08p0Wl)

* Changed the prompt slightly: 

![image](https://user-images.githubusercontent.com/4289625/28497940-3a158f36-6fce-11e7-85ee-5bfee89d3559.png)
