### PR TITLE
Implement #257 (Break statement)

### DIFF
--- a/compiler/ast/statements.go
+++ b/compiler/ast/statements.go
@@ -144,6 +144,21 @@ func (ns *NextStatement) String() string {
 	return "next"
 }
 
+// BreakStatement represents "break" keyword
+type BreakStatement struct {
+	Token token.Token
+}
+
+func (bs *BreakStatement) statementNode() {}
+
+// TokenLiteral returns token's literal
+func (bs *BreakStatement) TokenLiteral() string {
+	return bs.Token.Literal
+}
+func (bs *BreakStatement) String() string {
+	return bs.TokenLiteral()
+}
+
 type WhileStatement struct {
 	Token     token.Token
 	Condition Expression

--- a/compiler/bytecode/generator.go
+++ b/compiler/bytecode/generator.go
@@ -13,11 +13,11 @@ type scope struct {
 	program    *ast.Program
 	localTable *localTable
 	line       int
-	anchor     *anchor
+	anchors    map[string]*anchor
 }
 
 func newScope(stmt ast.Statement) *scope {
-	return &scope{localTable: newLocalTable(0), self: stmt, line: 0}
+	return &scope{localTable: newLocalTable(0), self: stmt, line: 0, anchors: make(map[string]*anchor)}
 }
 
 // Generator contains program's AST and will store generated instruction sets
@@ -93,7 +93,7 @@ func (g *Generator) ResetInstructionSets() {
 
 // InitTopLevelScope sets generator's scope with program node, which means it's the top level scope
 func (g *Generator) InitTopLevelScope(program *ast.Program) {
-	g.scope = &scope{program: program, localTable: newLocalTable(0)}
+	g.scope = &scope{program: program, localTable: newLocalTable(0), anchors: make(map[string]*anchor)}
 }
 
 // GenerateByteCode returns compiled instructions in string format

--- a/compiler/bytecode/statement_generation_test.go
+++ b/compiler/bytecode/statement_generation_test.go
@@ -2,53 +2,6 @@ package bytecode
 
 import "testing"
 
-func TestWhileStatementInBlock(t *testing.T) {
-	input := `
-	i = 1
-	thread do
-	  puts(i)
-	  while i <= 1000 do
-		puts(i)
-		i = i + 1
-	  end
-	end
-	`
-
-	expected := `
-<Block:0>
-0 putself
-1 getlocal 1 0
-2 send puts 1
-3 jump 14
-4 putnil
-5 pop
-6 jump 14
-7 putself
-8 getlocal 1 0
-9 send puts 1
-10 getlocal 1 0
-11 putobject 1
-12 send + 1
-13 setlocal 1 0
-14 getlocal 1 0
-15 putobject 1000
-16 send <= 1
-17 branchif 7
-18 putnil
-19 pop
-20 leave
-<ProgramStart>
-0 putobject 1
-1 setlocal 0 0
-2 putself
-3 send thread 0 block:0
-4 leave
-`
-
-	bytecode := compileToBytecode(input)
-	compareBytecode(t, bytecode, expected)
-}
-
 func TestCustomClassConstructor(t *testing.T) {
 	input := `
 class Foo
@@ -103,56 +56,6 @@ Foo.new(100, 50).bar
 7 send bar 0
 8 leave
 `
-	bytecode := compileToBytecode(input)
-	compareBytecode(t, bytecode, expected)
-}
-
-func TestNextStatement(t *testing.T) {
-	input := `
-	x = 0
-	y = 0
-
-	while x < 10 do
-	  x = x + 1
-	  if x == 5
-	    next
-	  end
-	  y = y + 1
-	end
-	`
-
-	expected := `
-<ProgramStart>
-0 putobject 0
-1 setlocal 0 0
-2 putobject 0
-3 setlocal 0 1
-4 jump 21
-5 putnil
-6 pop
-7 jump 21
-8 getlocal 0 0
-9 putobject 1
-10 send + 1
-11 setlocal 0 0
-12 getlocal 0 0
-13 putobject 5
-14 send == 1
-15 branchunless 17
-16 jump 21
-17 getlocal 0 1
-18 putobject 1
-19 send + 1
-20 setlocal 0 1
-21 getlocal 0 0
-22 putobject 10
-23 send < 1
-24 branchif 8
-25 putnil
-26 pop
-27 leave
-`
-
 	bytecode := compileToBytecode(input)
 	compareBytecode(t, bytecode, expected)
 }
@@ -325,6 +228,53 @@ Foo.new.bar
 	compareBytecode(t, bytecode, expected)
 }
 
+func TestWhileStatementInBlock(t *testing.T) {
+	input := `
+	i = 1
+	thread do
+	  puts(i)
+	  while i <= 1000 do
+		puts(i)
+		i = i + 1
+	  end
+	end
+	`
+
+	expected := `
+<Block:0>
+0 putself
+1 getlocal 1 0
+2 send puts 1
+3 jump 14
+4 putnil
+5 pop
+6 jump 14
+7 putself
+8 getlocal 1 0
+9 send puts 1
+10 getlocal 1 0
+11 putobject 1
+12 send + 1
+13 setlocal 1 0
+14 getlocal 1 0
+15 putobject 1000
+16 send <= 1
+17 branchif 7
+18 putnil
+19 pop
+20 leave
+<ProgramStart>
+0 putobject 1
+1 setlocal 0 0
+2 putself
+3 send thread 0 block:0
+4 leave
+`
+
+	bytecode := compileToBytecode(input)
+	compareBytecode(t, bytecode, expected)
+}
+
 func TestWhileStatementWithoutMethodCallInCondition(t *testing.T) {
 	input := `
 	i = 10
@@ -398,6 +348,56 @@ func TestWhileStatementWithMethodCallInCondition(t *testing.T) {
 21 pop
 22 getlocal 0 0
 23 leave
+`
+
+	bytecode := compileToBytecode(input)
+	compareBytecode(t, bytecode, expected)
+}
+
+func TestNextStatement(t *testing.T) {
+	input := `
+	x = 0
+	y = 0
+
+	while x < 10 do
+	  x = x + 1
+	  if x == 5
+	    next
+	  end
+	  y = y + 1
+	end
+	`
+
+	expected := `
+<ProgramStart>
+0 putobject 0
+1 setlocal 0 0
+2 putobject 0
+3 setlocal 0 1
+4 jump 21
+5 putnil
+6 pop
+7 jump 21
+8 getlocal 0 0
+9 putobject 1
+10 send + 1
+11 setlocal 0 0
+12 getlocal 0 0
+13 putobject 5
+14 send == 1
+15 branchunless 17
+16 jump 21
+17 getlocal 0 1
+18 putobject 1
+19 send + 1
+20 setlocal 0 1
+21 getlocal 0 0
+22 putobject 10
+23 send < 1
+24 branchif 8
+25 putnil
+26 pop
+27 leave
 `
 
 	bytecode := compileToBytecode(input)

--- a/compiler/bytecode/statement_generation_test.go
+++ b/compiler/bytecode/statement_generation_test.go
@@ -404,6 +404,89 @@ func TestNextStatement(t *testing.T) {
 	compareBytecode(t, bytecode, expected)
 }
 
+func TestBreakStatement(t *testing.T) {
+	input := `
+x = 0
+y = 0
+i = 0
+
+while x < 10 do
+  x = x + 1
+  while y < 5 do
+	y = y + 1
+
+	if y == 3
+	  break
+	end
+
+	i = i + x * y
+  end
+end
+
+a = i * 10
+a + 100
+`
+	expected := `
+<ProgramStart>
+0 putobject 0
+1 setlocal 0 0
+2 putobject 0
+3 setlocal 0 1
+4 putobject 0
+5 setlocal 0 2
+6 jump 39
+7 putnil
+8 pop
+9 jump 39
+10 getlocal 0 0
+11 putobject 1
+12 send + 1
+13 setlocal 0 0
+14 jump 33
+15 putnil
+16 pop
+17 jump 33
+18 getlocal 0 1
+19 putobject 1
+20 send + 1
+21 setlocal 0 1
+22 getlocal 0 1
+23 putobject 3
+24 send == 1
+25 branchunless 27
+26 jump 39
+27 getlocal 0 2
+28 getlocal 0 0
+29 getlocal 0 1
+30 send * 1
+31 send + 1
+32 setlocal 0 2
+33 getlocal 0 1
+34 putobject 5
+35 send < 1
+36 branchif 18
+37 putnil
+38 pop
+39 getlocal 0 0
+40 putobject 10
+41 send < 1
+42 branchif 10
+43 putnil
+44 pop
+45 getlocal 0 2
+46 putobject 10
+47 send * 1
+48 setlocal 0 3
+49 getlocal 0 3
+50 putobject 100
+51 send + 1
+52 leave
+
+`
+	bytecode := compileToBytecode(input)
+	compareBytecode(t, bytecode, expected)
+}
+
 func TestRemoveUnusedExpression(t *testing.T) {
 	input := `
 	i = 0

--- a/compiler/lexer/lexer_test.go
+++ b/compiler/lexer/lexer_test.go
@@ -106,6 +106,10 @@ func TestNextToken(t *testing.T) {
 	{ test:abc }
 
 	(1..5)
+
+	while i < 10 do
+	  break
+	end
 	`
 
 	tests := []struct {
@@ -387,7 +391,15 @@ func TestNextToken(t *testing.T) {
 		{token.Int, "5", 99},
 		{token.RParen, ")", 99},
 
-		{token.EOF, "", 100},
+		{token.While, "while", 101},
+		{token.Ident, "i", 101},
+		{token.LT, "<", 101},
+		{token.Int, "10", 101},
+		{token.Do, "do", 101},
+		{token.Break, "break", 102},
+		{token.End, "end", 103},
+
+		{token.EOF, "", 104},
 	}
 	l := New(input)
 

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -24,6 +24,8 @@ func (p *Parser) parseStatement() ast.Statement {
 		return p.parseModuleStatement()
 	case token.Next:
 		return &ast.NextStatement{Token: p.curToken}
+	case token.Break:
+		return &ast.BreakStatement{Token: p.curToken}
 	default:
 		return p.parseExpressionStatement()
 	}

--- a/compiler/token/token.go
+++ b/compiler/token/token.go
@@ -65,6 +65,7 @@ const (
 	Else   = "ELSE"
 	Return = "RETURN"
 	Next   = "NEXT"
+	Break  = "BREAK"
 	Def    = "DEF"
 	Self   = "SELF"
 	End    = "END"
@@ -93,6 +94,7 @@ var keywords = map[string]Type{
 	"next":   Next,
 	"class":  Class,
 	"module": Module,
+	"break":  Break,
 }
 
 // LookupIdent is used for keyword identification

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -350,8 +350,9 @@ while x < 10 do
   end
 end
 
-i
-		`, 21},
+a = i * 10
+a + 100
+		`, 310},
 	}
 
 	for i, tt := range tests {

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -270,39 +270,88 @@ func TestNextStatement(t *testing.T) {
 		expected interface{}
 	}{
 		{`
-		x = 0
-		y = 0
+x = 0
+y = 0
 
-		while x < 10 do
-		  x = x + 1
-		  if x == 5
-		    next
-		  end
-		  y = y + 1
-		end
+while x < 10 do
+  x = x + 1
+  if x == 5
+	next
+  end
+  y = y + 1
+end
 
-		x + y
+x + y
 		`, 19},
 		{`
-		x = 0
-		y = 0
-		i = 0
+x = 0
+y = 0
+i = 0
 
-		while x < 10 do
-		  x = x + 1
-		  while y < 5 do
-		    y = y + 1
+while x < 10 do
+  x = x + 1
+  while y < 5 do
+	y = y + 1
 
-		    if y == 3
-		      next
-		    end
+	if y == 3
+	  next
+	end
 
-		    i = i + x * y
-		  end
-		end
+	i = i + x * y
+  end
+end
 
-		i
+i
 		`, 12},
+	}
+
+	for i, tt := range tests {
+		vm := initTestVM()
+		evaluated := vm.testEval(t, tt.input)
+		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
+	}
+}
+
+func TestBreakStatement(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`
+x = 0
+y = 0
+
+while x < 10 do
+  x = x + 1
+  if x == 5
+	break
+  end
+  y = y + 1
+end
+
+x + y
+		`, 9},
+		{`
+x = 0
+y = 0
+i = 0
+
+while x < 10 do
+  x = x + 1
+  while y < 5 do
+	y = y + 1
+
+	if y == 3
+	  break
+	end
+
+	i = i + x * y
+  end
+end
+
+i
+		`, 21},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
This closes #257 

### Other changes:

Code generator's scope can have multiple anchors now, it uses map to store anchor name & anchor pointer pairs.