### PR TITLE
REPL: trim spaces twice to avoid panic

### DIFF
--- a/igb/manual_test.md
+++ b/igb/manual_test.md
@@ -113,6 +113,9 @@ Currently we are unable to perform automated tests against REPL. Follow the step
     #»
     ```
 
+ 4. Paste " ¤ #"
+    * expect: no error causes
+
 ### 5. Interruption
 
 1. type Ctrl-z

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -272,7 +272,7 @@ func readIgb(igb *iGb, err error) (*iGb, error) {
 	igb.rl.Config.UniqueEditLine = true // required to update the previous prompt
 	igb.lines, err = igb.rl.Readline()
 	igb.rl.Config.UniqueEditLine = false
-	
+
 	igb.lines = strings.TrimSpace(igb.lines)
 	igb.lines = strings.TrimPrefix(igb.lines, prmpt1)
 	igb.lines = strings.TrimPrefix(igb.lines, prmpt2)

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -272,7 +272,8 @@ func readIgb(igb *iGb, err error) (*iGb, error) {
 	igb.rl.Config.UniqueEditLine = true // required to update the previous prompt
 	igb.lines, err = igb.rl.Readline()
 	igb.rl.Config.UniqueEditLine = false
-
+	
+	igb.lines = strings.TrimSpace(igb.lines)
 	igb.lines = strings.TrimPrefix(igb.lines, prmpt1)
 	igb.lines = strings.TrimPrefix(igb.lines, prmpt2)
 	igb.lines = strings.TrimSpace(igb.lines)


### PR DESCRIPTION
Fix the issue that asting " ¤ #, with reading spaces, causes panic