### PR TITLE
Implement #175 multiple variable assignment

### DIFF
--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -138,6 +138,28 @@ func (ie *InfixExpression) String() string {
 	return out.String()
 }
 
+// MultiVariableExpression is not really an expression, it's just a container that holds multiple Variables
+type MultiVariableExpression struct {
+	Variables []Variable
+}
+
+func (me *MultiVariableExpression) expressionNode() {}
+func (me *MultiVariableExpression) TokenLiteral() string {
+	return ""
+}
+func (me *MultiVariableExpression) String() string {
+	var out bytes.Buffer
+	var variables []string
+
+	for _, v := range me.Variables {
+		variables = append(variables, v.String())
+	}
+
+	out.WriteString(strings.Join(variables, ", "))
+
+	return out.String()
+}
+
 // AssignExpression represents variable assignment in Goby.
 type AssignExpression struct {
 	Token     token.Token

--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -142,7 +142,6 @@ func (ie *InfixExpression) String() string {
 type AssignExpression struct {
 	Token     token.Token
 	Variables []Variable
-	Operator  string
 	Value     Expression
 	// Optioned attribute is only used when infix expression is local assignment in params.
 	// For example: `foo(x = 10)`'s `x = 10` is an optioned assign expression

--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -140,10 +140,10 @@ func (ie *InfixExpression) String() string {
 
 // AssignExpression represents variable assignment in Goby.
 type AssignExpression struct {
-	Token    token.Token
-	Variable Variable
-	Operator string
-	Value    Expression
+	Token     token.Token
+	Variables []Variable
+	Operator  string
+	Value     Expression
 	// Optioned attribute is only used when infix expression is local assignment in params.
 	// For example: `foo(x = 10)`'s `x = 10` is an optioned assign expression
 	// TODO: Remove this when we can put metadata inside bytecode.
@@ -156,9 +156,14 @@ func (ae *AssignExpression) TokenLiteral() string {
 }
 func (ae *AssignExpression) String() string {
 	var out bytes.Buffer
+	var variables []string
+
+	for _, v := range ae.Variables {
+		variables = append(variables, v.String())
+	}
 
 	out.WriteString("(")
-	out.WriteString(ae.Variable.String())
+	out.WriteString(strings.Join(variables, ", "))
 	out.WriteString(" = ")
 	out.WriteString(ae.Value.String())
 	out.WriteString(")")

--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -143,15 +143,15 @@ type MultiVariableExpression struct {
 	Variables []Variable
 }
 
-func (me *MultiVariableExpression) expressionNode() {}
-func (me *MultiVariableExpression) TokenLiteral() string {
+func (m *MultiVariableExpression) expressionNode() {}
+func (m *MultiVariableExpression) TokenLiteral() string {
 	return ""
 }
-func (me *MultiVariableExpression) String() string {
+func (m *MultiVariableExpression) String() string {
 	var out bytes.Buffer
 	var variables []string
 
-	for _, v := range me.Variables {
+	for _, v := range m.Variables {
 		variables = append(variables, v.String())
 	}
 

--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -125,8 +125,12 @@ func (g *Generator) compileAssignExpression(is *InstructionSet, exp *ast.AssignE
 	g.compileExpression(is, exp.Value, scope, table)
 	g.fsm.Event(oldState)
 
-	if len(exp.Variables) == 1 {
-		switch name := exp.Variables[0].(type) {
+	if len(exp.Variables) > 1 {
+		is.define(ExpandArray, len(exp.Variables))
+	}
+
+	for _, v := range exp.Variables {
+		switch name := v.(type) {
 		case *ast.Identifier:
 			index, depth := table.setLCL(name.Value, table.depth)
 

--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -125,20 +125,22 @@ func (g *Generator) compileAssignExpression(is *InstructionSet, exp *ast.AssignE
 	g.compileExpression(is, exp.Value, scope, table)
 	g.fsm.Event(oldState)
 
-	switch name := exp.Variable.(type) {
-	case *ast.Identifier:
-		index, depth := table.setLCL(name.Value, table.depth)
+	if len(exp.Variables) == 1 {
+		switch name := exp.Variables[0].(type) {
+		case *ast.Identifier:
+			index, depth := table.setLCL(name.Value, table.depth)
 
-		if exp.Optioned != 0 {
-			is.define(SetLocal, depth, index, exp.Optioned)
-			return
+			if exp.Optioned != 0 {
+				is.define(SetLocal, depth, index, exp.Optioned)
+				return
+			}
+
+			is.define(SetLocal, depth, index)
+		case *ast.InstanceVariable:
+			is.define(SetInstanceVariable, name.Value)
+		case *ast.Constant:
+			is.define(SetConstant, name.Value)
 		}
-
-		is.define(SetLocal, depth, index)
-	case *ast.InstanceVariable:
-		is.define(SetInstanceVariable, name.Value)
-	case *ast.Constant:
-		is.define(SetConstant, name.Value)
 	}
 }
 

--- a/compiler/bytecode/expression_generation_test.go
+++ b/compiler/bytecode/expression_generation_test.go
@@ -109,6 +109,40 @@ func TestConditionWithAlternativeCompilation(t *testing.T) {
 	compareBytecode(t, bytecode, expected)
 }
 
+func TestMultipleVariableAssignment(t *testing.T) {
+	input := `
+
+	def foo
+	  [1, 2, 3]
+	end
+
+	a, @b, c = foo
+	`
+
+	expected := `
+<Def:foo>
+0 putobject 1
+1 putobject 2
+2 putobject 3
+3 newarray 3
+4 leave
+<ProgramStart>
+0 putself
+1 putstring "foo"
+2 def_method 0
+3 putself
+4 send foo 0
+5 expand_array 3
+6 setlocal 0 0
+7 setinstancevariable @b
+8 setlocal 0 1
+9 leave
+`
+
+	bytecode := compileToBytecode(input)
+	compareBytecode(t, bytecode, expected)
+}
+
 func TestConstantCompilation(t *testing.T) {
 	input := `
 	Foo = 10

--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -27,6 +27,7 @@ const (
 	PutObject           = "putobject"
 	PutNull             = "putnil"
 	NewArray            = "newarray"
+	ExpandArray         = "expand_array"
 	NewHash             = "newhash"
 	NewRange            = "newrange"
 	BranchUnless        = "branchunless"

--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -335,9 +335,9 @@ func (p *Parser) parseAssignExpression(v ast.Expression) ast.Expression {
 	// Pure assignment case
 	if p.curTokenIs(token.Assign) {
 		exp := &ast.AssignExpression{
-			Token:    p.curToken,
-			Variable: variable,
-			Operator: p.curToken.Literal,
+			Token:     p.curToken,
+			Variables: []ast.Variable{variable},
+			Operator:  p.curToken.Literal,
 		}
 
 		precedence := p.curPrecedence()
@@ -370,10 +370,10 @@ func (p *Parser) parseAssignExpression(v ast.Expression) ast.Expression {
 	}
 
 	exp := &ast.AssignExpression{
-		Token:    assignment,
-		Variable: variable,
-		Operator: assignment.Literal,
-		Value:    infixExp,
+		Token:     assignment,
+		Variables: []ast.Variable{variable},
+		Operator:  assignment.Literal,
+		Value:     infixExp,
 	}
 
 	return exp

--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -613,7 +613,7 @@ func (p *Parser) parseMultiVariables(left ast.Expression) ast.Expression {
 
 	p.nextToken()
 
-	exp := p.parseExpression(NORMAL)
+	exp := p.parseExpression(CALL)
 
 	var2, ok := exp.(ast.Variable)
 

--- a/compiler/parser/expression_parsing_test.go
+++ b/compiler/parser/expression_parsing_test.go
@@ -728,7 +728,7 @@ func TestAssignIndexExpressionWithVariableValue(t *testing.T) {
 			t.Fatalf("exp is not AssignExpression. got=%T", exp)
 		}
 
-		if !tt.variableMatchFunc(t, infixExp.Variable, tt.expectedIdentifier) {
+		if !tt.variableMatchFunc(t, infixExp.Variables, tt.expectedIdentifier) {
 			return
 		}
 
@@ -750,7 +750,7 @@ func testAssignExpression(t *testing.T, exp ast.Expression, expectedIdentifier s
 		t.Fatalf("exp is not AssignExpression. got=%T", exp)
 	}
 
-	if !variableMatchFunction(t, infixExp.Variable, expectedIdentifier) {
+	if !variableMatchFunction(t, infixExp.Variables, expectedIdentifier) {
 		return
 	}
 

--- a/compiler/parser/expression_parsing_test.go
+++ b/compiler/parser/expression_parsing_test.go
@@ -728,12 +728,7 @@ func TestAssignIndexExpressionWithVariableValue(t *testing.T) {
 			t.Fatalf("exp is not AssignExpression. got=%T", exp)
 		}
 
-		if !tt.variableMatchFunc(t, infixExp.Variables, tt.expectedIdentifier) {
-			return
-		}
-
-		if infixExp.Operator != "=" {
-			t.Errorf("AssignExpression's operator is not =. got=%q", infixExp.Operator)
+		if !tt.variableMatchFunc(t, infixExp.Variables[0], tt.expectedIdentifier) {
 			return
 		}
 
@@ -744,27 +739,22 @@ func TestAssignIndexExpressionWithVariableValue(t *testing.T) {
 }
 
 func testAssignExpression(t *testing.T, exp ast.Expression, expectedIdentifier string, variableMatchFunction func(*testing.T, ast.Expression, string) bool, expected interface{}) {
-	infixExp, ok := exp.(*ast.AssignExpression)
+	assignExp, ok := exp.(*ast.AssignExpression)
 
 	if !ok {
 		t.Fatalf("exp is not AssignExpression. got=%T", exp)
 	}
 
-	if !variableMatchFunction(t, infixExp.Variables, expectedIdentifier) {
-		return
-	}
-
-	if infixExp.Operator != "=" {
-		t.Errorf("Assignment's operator is not =. got=%q", infixExp.Operator)
+	if !variableMatchFunction(t, assignExp.Variables[0], expectedIdentifier) {
 		return
 	}
 
 	switch expected := expected.(type) {
 	case int:
-		testIntegerLiteral(t, infixExp.Value, expected)
+		testIntegerLiteral(t, assignExp.Value, expected)
 	case string:
-		testStringLiteral(t, infixExp.Value, expected)
+		testStringLiteral(t, assignExp.Value, expected)
 	case bool:
-		testBoolLiteral(t, infixExp.Value, expected)
+		testBoolLiteral(t, assignExp.Value, expected)
 	}
 }

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -123,6 +123,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.And, p.parseInfixExpression)
 	p.registerInfix(token.Or, p.parseInfixExpression)
 	p.registerInfix(token.OrEq, p.parseAssignExpression)
+	p.registerInfix(token.Comma, p.parseMultiVariables)
 	p.registerInfix(token.ResolutionOperator, p.parseInfixExpression)
 	p.registerInfix(token.Assign, p.parseAssignExpression)
 	p.registerInfix(token.Range, p.parseRangeExpression)

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -167,8 +167,9 @@ func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 	stmt := &ast.ExpressionStatement{Token: p.curToken}
 
-	if p.curTokenIs(token.Ident) {
-		// I use precedence to identify call_without_parens case, this is not an appropriate way but it work in current situation
+	if p.curTokenIs(token.Ident) || p.curTokenIs(token.InstanceVariable) {
+		// This is used for identifying method call without parens
+		// Or multiple variable assignment
 		stmt.Expression = p.parseExpression(LOWEST)
 	} else {
 		stmt.Expression = p.parseExpression(NORMAL)

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -1346,3 +1346,81 @@ func TestClassInheritance(t *testing.T) {
 	testStringObject(t, 0, evaluated, "Bar")
 	vm.checkCFP(t, 0, 0)
 }
+
+func TestMultiVarAssignment(t *testing.T) {
+	tests := []struct {
+		input      string
+		expected   interface{}
+		expectedSP int
+	}{
+		{`
+		a, b = [1, 2]
+		a
+		`,
+			1,
+			1},
+		{`
+		a, b = [1, 2]
+		b
+		`,
+			2,
+			1},
+
+		{`
+		a, b, c = [1, 2, 3]
+		c
+		`,
+			3,
+			1},
+		{`
+		a, b, c = [1]
+		b
+		`,
+			nil,
+			1},
+		{`
+		a, b, c = [1]
+		c
+		`,
+			nil,
+			1},
+		{`
+		arr = [1, 2, 3]
+		a, b, c = arr
+		b
+		`, 2,
+			1},
+		{`
+		arr = [1, 2, 3]
+		a, b, c = arr
+		c
+		`, 3,
+			1},
+		{`
+		arr = [1]
+		a, b, c = arr
+		a
+		`, 1,
+			1},
+		{`
+		arr = [1]
+		a, b, c = arr
+		b
+		`, nil,
+			1},
+		{`
+		arr = [1]
+		a, b, c = arr
+		c
+		`, nil,
+			1},
+	}
+
+	for i, tt := range tests {
+		vm := initTestVM()
+		evaluated := vm.testEval(t, tt.input)
+		checkExpected(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
+		vm.checkSP(t, i, tt.expectedSP)
+	}
+}

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -1414,6 +1414,78 @@ func TestMultiVarAssignment(t *testing.T) {
 		c
 		`, nil,
 			1},
+		{`
+		arr = [1]
+		a, b, c, d = arr
+		d
+		`, nil,
+			1},
+		{`
+		arr = [1, 2, 3]
+		@a, @b, c = arr
+		@a
+		`, 1,
+			1},
+		{`
+		arr = [1, 2, 3]
+		@a, @b, c = arr
+		@b
+		`, 2,
+			1},
+		{`
+		arr = [1, 2, 3]
+		@a, @b, c = arr
+		c
+		`, 3,
+			1},
+		{`
+		class Foo
+		  attr_reader :a, :b, :c
+
+		  def bar(arr)
+		    @a, @b, c = arr
+		    @c = @a + @b + c
+		  end
+		end
+
+		f = Foo.new
+
+		f.bar([10, 100, 200])
+		f.a
+		`, 10,
+			3},
+		{`
+		class Foo
+		  attr_reader :a, :b, :c
+
+		  def bar(arr)
+		    @a, @b, c = arr
+		    @c = @a + @b + c
+		  end
+		end
+
+		f = Foo.new
+
+		f.bar([10, 100, 200])
+		f.b
+		`, 100,
+			3},
+		{`
+		class Foo
+		  attr_reader :a, :b, :c
+
+		  def bar(arr)
+		    @a, @b, c = arr
+		    @c = @a + @b + c
+		  end
+		end
+
+		f = Foo.new
+
+		f.bar([10, 100, 200])
+		f.c
+		`, 310,
+			3},
 	}
 
 	for i, tt := range tests {

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -163,6 +163,34 @@ var builtInActions = map[operationType]*action{
 			t.stack.push(&Pointer{Target: arr})
 		},
 	},
+	bytecode.ExpandArray: {
+		name: bytecode.ExpandArray,
+		operation: func(t *thread, cf *callFrame, args ...interface{}) {
+			arrLength := args[0].(int)
+			arr, ok := t.stack.pop().Target.(*ArrayObject)
+
+			if !ok {
+				t.returnError(TypeError, "Expect stack top's value to be an Array when executing 'expandarray' instruction.")
+			}
+
+			elems := []Object{}
+
+			for i := 0; i < arrLength; i++ {
+				var elem Object
+				if i < len(arr.Elements) {
+					elem = arr.Elements[i]
+				} else {
+					elem = NULL
+				}
+
+				elems = append([]Object{elem}, elems...)
+			}
+
+			for _, elem := range elems {
+				t.stack.push(&Pointer{Target: elem})
+			}
+		},
+	},
 	bytecode.NewHash: {
 		name: bytecode.NewHash,
 		operation: func(t *thread, cf *callFrame, args ...interface{}) {

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -466,6 +466,8 @@ var builtInActions = map[operationType]*action{
 
 func (vm *VM) initObjectFromGoType(value interface{}) Object {
 	switch v := value.(type) {
+	case nil:
+		return NULL
 	case int:
 		return vm.initIntegerObject(v)
 	case int64:

--- a/vm/struct_test.go
+++ b/vm/struct_test.go
@@ -9,9 +9,9 @@ func TestCallingStructFunctionWithReturnValue(t *testing.T) {
 
 	input := `
 	p = import "github.com/goby-lang/goby/test_fixtures/import_test/struct/struct.go"
-	result = p.send("NewBar", "xyz") # multiple result, so result is an array
-	bar = result[0]
-	bar.send("Name", "!")[0]
+	bar, err = p.send("NewBar", "xyz") # multiple result, so result is an array
+	result, err = bar.send("Name", "!")
+	result
 	`
 
 	vm := initTestVM()
@@ -20,13 +20,28 @@ func TestCallingStructFunctionWithReturnValue(t *testing.T) {
 	vm.checkCFP(t, 0, 0)
 }
 
+func TestCallingStructFunctionWithReturnError(t *testing.T) {
+	skipPluginTestIfEnvNotSet(t)
+
+	input := `
+	p = import "github.com/goby-lang/goby/test_fixtures/import_test/struct/struct.go"
+	bar, err = p.send("NewBar", "xyz") # multiple result, so result is an array
+	result, err = bar.send("Name", "!")
+	err
+	`
+
+	vm := initTestVM()
+	evaluated := vm.testEval(t, input)
+	checkExpected(t, 0, evaluated, nil)
+	vm.checkCFP(t, 0, 0)
+}
+
 func TestCallingStructFuncWithDifferentType(t *testing.T) {
 	skipPluginTestIfEnvNotSet(t)
 
 	input := `
 	p = import "github.com/goby-lang/goby/test_fixtures/import_test/struct/struct.go"
-	result = p.send("NewBar", "xyz") # multiple result, so result is an array
-	bar = result[0]
+	bar, err = p.send("NewBar", "xyz") # multiple result, so result is an array
 	bar.send("Add", 10, 100.to_int64) # Add is func(int, int64) int64
 	`
 


### PR DESCRIPTION
## Subject

This PR is to support multiple variable assignment like:

```ruby
a, b = [1, 2]
a #=> 1
b #=> 2
```

Currently the value can only be an `Array` object, so we're not supporting this for now:

```ruby
a, b = 1, 2
```

And variable's type can only be local variables or instance variables.

Also, if number of values is less than variables the variable will be given `nil` value:

```ruby
a, b = [1]
a #=> 1
b #=> nil
```


(This closes #175)