### PR TITLE
[HTTP Library] Implement set_header Method to Response Object in Symmetric Sense of Request Object

### DIFF
--- a/lib/net/http/request.gb
+++ b/lib/net/http/request.gb
@@ -9,6 +9,9 @@ module Net
       end
 
       def set_header(key, value)
+        if @headers.is_nil
+          @headers = {}
+        end
         @headers[key] = value
       end
 

--- a/lib/net/http/response.gb
+++ b/lib/net/http/response.gb
@@ -3,6 +3,25 @@ module Net
     class Response
       attr_accessor :body, :status, :status_code, :protocol, :transfer_encoding, :http_version, :request_http_version, :request
       attr_reader :headers
+
+      def initialize(headers = {})
+        @headers = headers
+      end
+
+      def set_header(key, value)
+        if @headers.is_nil
+          @headers = {}
+        end
+        @headers[key] = value
+      end
+
+      def get_header(key)
+        @headers[key]
+      end
+
+      def remove_header(key)
+        @headers.delete(key)
+      end
     end
   end
 end

--- a/vm/simple_server.go
+++ b/vm/simple_server.go
@@ -172,16 +172,18 @@ func setupResponse(w http.ResponseWriter, req *http.Request, res *RObject) {
 		r.body = resBody.(*StringObject).value
 	}
 
-	contentType, ok := res.instanceVariableGet("@content_type")
+	h, ok := res.instanceVariableGet("@headers")
 
-	if !ok {
-		r.contentType = "text/plain; charset=utf-8"
+	if headers, isHashObject := h.(*HashObject); ok && isHashObject {
+		for k, v := range headers.Pairs {
+			w.Header().Set(k, v.(*StringObject).value)
+		}
 	} else {
-		r.contentType = contentType.toString()
+		r.contentType = "text/plain; charset=utf-8"
+		w.Header().Set("Content-Type", r.contentType) // normal header
 	}
 
 	w.WriteHeader(r.status)
-	w.Header().Set("Content-Type", r.contentType) // normal header
 
 	io.WriteString(w, r.body)
 	log.Printf("%s %s %s %d\n", req.Method, req.URL.Path, req.Proto, r.status)


### PR DESCRIPTION
In the `goby-lang/sample-web-app` repo, previous version of the `server.gb` is 

```
# ... some code omitted

server.mount("/") do |req, res|
  # ... some code omitted
  res.status = 200
  res.body = content
  res.content_type = "text/html; charset=utf-8"
end
# ... some code omitted
```

This mechanism enables us to set `Content-Type` in response object with the `set_header` method:

```
  res.set_header("Content-Type", "text/html; charset=utf-8")
```
