### PR TITLE
Refactor parser and pop all unused expressions

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -6,22 +6,32 @@ import (
 )
 
 type BaseNode struct {
-	Token token.Token
-	isExp bool
+	Token  token.Token
+	isStmt bool
 }
 
 func (b *BaseNode) IsExp() bool {
-	return b.isExp
+	return !b.isStmt
+}
+
+func (b *BaseNode) IsStmt() bool {
+	return b.isStmt
+}
+
+func (b *BaseNode) MarkAsStmt() {
+	b.isStmt = true
 }
 
 func (b *BaseNode) MarkAsExp() {
-	b.isExp = true
+	b.isStmt = false
 }
 
 type node interface {
 	TokenLiteral() string
 	String() string
 	IsExp() bool
+	IsStmt() bool
+	MarkAsStmt()
 	MarkAsExp()
 }
 

--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -7,6 +7,15 @@ import (
 
 type BaseNode struct {
 	Token token.Token
+	isExp bool
+}
+
+func (b *BaseNode) IsExp() bool {
+	return b.isExp
+}
+
+func (b *BaseNode) MarkAsExp() {
+	b.isExp = true
 }
 
 type node interface {

--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -2,7 +2,12 @@ package ast
 
 import (
 	"bytes"
+	"github.com/goby-lang/goby/compiler/token"
 )
+
+type BaseNode struct {
+	Token token.Token
+}
 
 type node interface {
 	TokenLiteral() string

--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -5,23 +5,28 @@ import (
 	"github.com/goby-lang/goby/compiler/token"
 )
 
+// BaseNode holds the attribute every expression or statement should have
 type BaseNode struct {
 	Token  token.Token
 	isStmt bool
 }
 
+// IsExp returns if current node should be considered as an expression
 func (b *BaseNode) IsExp() bool {
 	return !b.isStmt
 }
 
+// IsStmt returns if current node should be considered as a statement
 func (b *BaseNode) IsStmt() bool {
 	return b.isStmt
 }
 
+// MarkAsStmt marks current node to be statement
 func (b *BaseNode) MarkAsStmt() {
 	b.isStmt = true
 }
 
+// MarkAsExp marks current node to be expression
 func (b *BaseNode) MarkAsExp() {
 	b.isStmt = false
 }

--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -21,6 +21,8 @@ func (b *BaseNode) MarkAsExp() {
 type node interface {
 	TokenLiteral() string
 	String() string
+	IsExp() bool
+	MarkAsExp()
 }
 
 type Statement interface {

--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -3,12 +3,11 @@ package ast
 import (
 	"bytes"
 	"fmt"
-	"github.com/goby-lang/goby/compiler/token"
 	"strings"
 )
 
 type IntegerLiteral struct {
-	Token token.Token
+	*BaseNode
 	Value int
 }
 
@@ -21,7 +20,7 @@ func (il *IntegerLiteral) String() string {
 }
 
 type StringLiteral struct {
-	Token token.Token
+	*BaseNode
 	Value string
 }
 
@@ -39,7 +38,7 @@ func (sl *StringLiteral) String() string {
 }
 
 type ArrayExpression struct {
-	Token    token.Token
+	*BaseNode
 	Elements []Expression
 }
 
@@ -69,8 +68,8 @@ func (ae *ArrayExpression) String() string {
 }
 
 type HashExpression struct {
-	Token token.Token
-	Data  map[string]Expression
+	*BaseNode
+	Data map[string]Expression
 }
 
 func (he *HashExpression) expressionNode() {}
@@ -93,7 +92,7 @@ func (he *HashExpression) String() string {
 }
 
 type PrefixExpression struct {
-	Token    token.Token
+	*BaseNode
 	Operator string
 	Right    Expression
 }
@@ -114,7 +113,7 @@ func (pe *PrefixExpression) String() string {
 }
 
 type InfixExpression struct {
-	Token    token.Token
+	*BaseNode
 	Left     Expression
 	Operator string
 	Right    Expression
@@ -162,7 +161,7 @@ func (m *MultiVariableExpression) String() string {
 
 // AssignExpression represents variable assignment in Goby.
 type AssignExpression struct {
-	Token     token.Token
+	*BaseNode
 	Variables []Variable
 	Value     Expression
 	IsStmt    bool
@@ -194,7 +193,7 @@ func (ae *AssignExpression) String() string {
 }
 
 type BooleanExpression struct {
-	Token token.Token
+	*BaseNode
 	Value bool
 }
 
@@ -208,7 +207,7 @@ func (b *BooleanExpression) String() string {
 
 // NilExpression represents nil node
 type NilExpression struct {
-	Token token.Token
+	*BaseNode
 }
 
 func (n *NilExpression) expressionNode() {}
@@ -224,7 +223,7 @@ func (n *NilExpression) String() string {
 }
 
 type IfExpression struct {
-	Token       token.Token
+	*BaseNode
 	Condition   Expression
 	Consequence *BlockStatement
 	Alternative *BlockStatement
@@ -255,8 +254,8 @@ func (ie *IfExpression) String() string {
 }
 
 type CallExpression struct {
+	*BaseNode
 	Receiver       Expression
-	Token          token.Token
 	Method         string
 	Arguments      []Expression
 	Block          *BlockStatement
@@ -305,7 +304,7 @@ func (ce *CallExpression) String() string {
 }
 
 type SelfExpression struct {
-	Token token.Token
+	*BaseNode
 }
 
 func (se *SelfExpression) expressionNode() {}
@@ -317,7 +316,7 @@ func (se *SelfExpression) String() string {
 }
 
 type YieldExpression struct {
-	Token     token.Token
+	*BaseNode
 	Arguments []Expression
 }
 
@@ -342,7 +341,7 @@ func (ye *YieldExpression) String() string {
 }
 
 type RangeExpression struct {
-	Token token.Token
+	*BaseNode
 	Start Expression
 	End   Expression
 }

--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -164,7 +164,6 @@ type AssignExpression struct {
 	*BaseNode
 	Variables []Variable
 	Value     Expression
-	IsStmt    bool
 	// Optioned attribute is only used when infix expression is local assignment in params.
 	// For example: `foo(x = 10)`'s `x = 10` is an optioned assign expression
 	// TODO: Remove this when we can put metadata inside bytecode.

--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -139,6 +139,7 @@ func (ie *InfixExpression) String() string {
 
 // MultiVariableExpression is not really an expression, it's just a container that holds multiple Variables
 type MultiVariableExpression struct {
+	*BaseNode
 	Variables []Variable
 }
 

--- a/compiler/ast/statements.go
+++ b/compiler/ast/statements.go
@@ -2,11 +2,10 @@ package ast
 
 import (
 	"bytes"
-	"github.com/goby-lang/goby/compiler/token"
 )
 
 type ClassStatement struct {
-	Token          token.Token
+	*BaseNode
 	Name           *Constant
 	Body           *BlockStatement
 	SuperClass     Expression
@@ -31,7 +30,7 @@ func (cs *ClassStatement) String() string {
 
 // ModuleStatement represents module node in AST
 type ModuleStatement struct {
-	Token      token.Token
+	*BaseNode
 	Name       *Constant
 	Body       *BlockStatement
 	SuperClass *Constant
@@ -56,7 +55,7 @@ func (ms *ModuleStatement) String() string {
 }
 
 type ReturnStatement struct {
-	Token       token.Token
+	*BaseNode
 	ReturnValue Expression
 }
 
@@ -79,7 +78,7 @@ func (rs *ReturnStatement) String() string {
 }
 
 type ExpressionStatement struct {
-	Token      token.Token
+	*BaseNode
 	Expression Expression
 }
 
@@ -96,7 +95,7 @@ func (es *ExpressionStatement) String() string {
 }
 
 type DefStatement struct {
-	Token          token.Token
+	*BaseNode
 	Name           *Identifier
 	Receiver       Expression
 	Parameters     []Expression
@@ -131,7 +130,7 @@ func (ds *DefStatement) String() string {
 
 // NextStatement represents "next" keyword
 type NextStatement struct {
-	Token token.Token
+	*BaseNode
 }
 
 func (ns *NextStatement) statementNode() {}
@@ -146,7 +145,7 @@ func (ns *NextStatement) String() string {
 
 // BreakStatement represents "break" keyword
 type BreakStatement struct {
-	Token token.Token
+	*BaseNode
 }
 
 func (bs *BreakStatement) statementNode() {}
@@ -160,7 +159,7 @@ func (bs *BreakStatement) String() string {
 }
 
 type WhileStatement struct {
-	Token     token.Token
+	*BaseNode
 	Condition Expression
 	Body      *BlockStatement
 }
@@ -182,7 +181,7 @@ func (ws *WhileStatement) String() string {
 }
 
 type BlockStatement struct {
-	Token      token.Token // {
+	*BaseNode
 	Statements []Statement
 }
 

--- a/compiler/ast/statements.go
+++ b/compiler/ast/statements.go
@@ -198,6 +198,8 @@ func (bs *BlockStatement) String() string {
 
 	return out.String()
 }
+
+// KeepLastValue prevents block's last expression statement to be popped.
 func (bs *BlockStatement) KeepLastValue() {
 	if len(bs.Statements) == 0 {
 		return

--- a/compiler/ast/statements.go
+++ b/compiler/ast/statements.go
@@ -198,3 +198,15 @@ func (bs *BlockStatement) String() string {
 
 	return out.String()
 }
+func (bs *BlockStatement) KeepLastValue() {
+	if len(bs.Statements) == 0 {
+		return
+	}
+
+	stmt := bs.Statements[len(bs.Statements)-1]
+	expStmt, ok := stmt.(*ExpressionStatement)
+
+	if ok {
+		expStmt.Expression.MarkAsExp()
+	}
+}

--- a/compiler/ast/variables.go
+++ b/compiler/ast/variables.go
@@ -1,7 +1,5 @@
 package ast
 
-import "github.com/goby-lang/goby/compiler/token"
-
 // Variable interface represents assignable nodes in Goby, currently are Identifier, InstanceVariable and Constant
 type Variable interface {
 	variableNode()
@@ -10,7 +8,7 @@ type Variable interface {
 }
 
 type Identifier struct {
-	Token token.Token
+	*BaseNode
 	Value string
 }
 
@@ -27,7 +25,7 @@ func (i *Identifier) String() string {
 }
 
 type InstanceVariable struct {
-	Token token.Token
+	*BaseNode
 	Value string
 }
 
@@ -44,7 +42,7 @@ func (iv *InstanceVariable) String() string {
 }
 
 type Constant struct {
-	Token       token.Token
+	*BaseNode
 	Value       string
 	IsNamespace bool
 }

--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -141,7 +141,15 @@ func (g *Generator) compileAssignExpression(is *InstructionSet, exp *ast.AssignE
 			is.define(SetConstant, name.Value)
 		}
 
-		if !exp.IsExp() && !g.REPL && i != len(exp.Variables) - 1 {
+		/*
+			Keep last value so we can have value to pop
+
+			```ruby
+			a, b = [1, 2]
+
+			Here we only pop '2', and the statement compilation will add another pop to pop '1'
+		*/
+		if exp.IsStmt() && !g.REPL && i != len(exp.Variables)-1 {
 			is.define(Pop)
 		}
 	}

--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -7,45 +7,40 @@ import (
 
 func (g *Generator) compileExpression(is *InstructionSet, exp ast.Expression, scope *scope, table *localTable) {
 	// See fsm initialization's comment
-	if g.fsm.Is(keepExp) {
-		switch exp := exp.(type) {
-		case *ast.Constant:
-			is.define(GetConstant, exp.Value, fmt.Sprint(exp.IsNamespace))
-		case *ast.InstanceVariable:
-			is.define(GetInstanceVariable, exp.Value)
-		case *ast.IntegerLiteral:
-			is.define(PutObject, fmt.Sprint(exp.Value))
-		case *ast.StringLiteral:
-			is.define(PutString, fmt.Sprintf("\"%s\"", exp.Value))
-		case *ast.BooleanExpression:
-			is.define(PutObject, fmt.Sprint(exp.Value))
-		case *ast.NilExpression:
-			is.define(PutNull)
-		case *ast.RangeExpression:
-			g.compileExpression(is, exp.Start, scope, table)
-			g.compileExpression(is, exp.End, scope, table)
-			is.define(NewRange, 0)
-		case *ast.ArrayExpression:
-			for _, elem := range exp.Elements {
-				g.compileExpression(is, elem, scope, table)
-			}
-			is.define(NewArray, len(exp.Elements))
-		case *ast.HashExpression:
-			for key, value := range exp.Data {
-				is.define(PutString, fmt.Sprintf("\"%s\"", key))
-				g.compileExpression(is, value, scope, table)
-			}
-			is.define(NewHash, len(exp.Data)*2)
-		case *ast.SelfExpression:
-			is.define(PutSelf)
-		case *ast.PrefixExpression:
-			g.compilePrefixExpression(is, exp, scope, table)
-		case *ast.InfixExpression:
-			g.compileInfixExpression(is, exp, scope, table)
-		}
-	}
-
 	switch exp := exp.(type) {
+	case *ast.Constant:
+		is.define(GetConstant, exp.Value, fmt.Sprint(exp.IsNamespace))
+	case *ast.InstanceVariable:
+		is.define(GetInstanceVariable, exp.Value)
+	case *ast.IntegerLiteral:
+		is.define(PutObject, fmt.Sprint(exp.Value))
+	case *ast.StringLiteral:
+		is.define(PutString, fmt.Sprintf("\"%s\"", exp.Value))
+	case *ast.BooleanExpression:
+		is.define(PutObject, fmt.Sprint(exp.Value))
+	case *ast.NilExpression:
+		is.define(PutNull)
+	case *ast.RangeExpression:
+		g.compileExpression(is, exp.Start, scope, table)
+		g.compileExpression(is, exp.End, scope, table)
+		is.define(NewRange, 0)
+	case *ast.ArrayExpression:
+		for _, elem := range exp.Elements {
+			g.compileExpression(is, elem, scope, table)
+		}
+		is.define(NewArray, len(exp.Elements))
+	case *ast.HashExpression:
+		for key, value := range exp.Data {
+			is.define(PutString, fmt.Sprintf("\"%s\"", key))
+			g.compileExpression(is, value, scope, table)
+		}
+		is.define(NewHash, len(exp.Data)*2)
+	case *ast.SelfExpression:
+		is.define(PutSelf)
+	case *ast.PrefixExpression:
+		g.compilePrefixExpression(is, exp, scope, table)
+	case *ast.InfixExpression:
+		g.compileInfixExpression(is, exp, scope, table)
 	case *ast.Identifier:
 		g.compileIdentifier(is, exp, scope, table)
 	case *ast.AssignExpression:

--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -146,7 +146,7 @@ func (g *Generator) compileAssignExpression(is *InstructionSet, exp *ast.AssignE
 			is.define(SetConstant, name.Value)
 		}
 
-		if exp.IsStmt && !g.REPL {
+		if !exp.IsExp() && !g.REPL {
 			is.define(Pop)
 		}
 	}

--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -124,7 +124,7 @@ func (g *Generator) compileAssignExpression(is *InstructionSet, exp *ast.AssignE
 		is.define(ExpandArray, len(exp.Variables))
 	}
 
-	for _, v := range exp.Variables {
+	for i, v := range exp.Variables {
 		switch name := v.(type) {
 		case *ast.Identifier:
 			index, depth := table.setLCL(name.Value, table.depth)
@@ -141,7 +141,7 @@ func (g *Generator) compileAssignExpression(is *InstructionSet, exp *ast.AssignE
 			is.define(SetConstant, name.Value)
 		}
 
-		if !exp.IsExp() && !g.REPL {
+		if !exp.IsExp() && !g.REPL && i != len(exp.Variables) - 1 {
 			is.define(Pop)
 		}
 	}

--- a/compiler/bytecode/expression_generation_test.go
+++ b/compiler/bytecode/expression_generation_test.go
@@ -18,22 +18,30 @@ func TestLocalVariableAccessCompilation(t *testing.T) {
 0 putobject 10
 1 setlocal 0 0
 2 pop
-3 putobject 100
-4 setlocal 0 0
-5 pop
-6 putobject 5
-7 setlocal 0 1
-8 pop
-9 getlocal 0 1
-10 getlocal 0 0
-11 send * 1
-12 putobject 100
-13 send + 1
-14 putobject 2
-15 send / 1
-16 putself
-17 send foo 0
-18 leave`
+3 pop
+4 putobject 100
+5 setlocal 0 0
+6 pop
+7 pop
+8 putobject 5
+9 setlocal 0 1
+10 pop
+11 pop
+12 getlocal 0 1
+13 getlocal 0 0
+14 send * 1
+15 putobject 100
+16 send + 1
+17 putobject 2
+18 send / 1
+19 pop
+20 pop
+21 putself
+22 send foo 0
+23 pop
+24 pop
+25 leave
+`
 
 	bytecode := compileToBytecode(input)
 	compareBytecode(t, bytecode, expected)
@@ -55,22 +63,27 @@ func TestIfExpressionWithoutAlternativeCompilation(t *testing.T) {
 0 putobject 10
 1 setlocal 0 0
 2 pop
-3 putobject 5
-4 setlocal 0 1
-5 pop
-6 getlocal 0 0
-7 getlocal 0 1
-8 send > 1
-9 branchunless 14
-10 putobject 10
-11 setlocal 0 2
-12 pop
-13 jump 15
-14 putnil
-15 getlocal 0 2
-16 putobject 1
-17 send + 1
-18 leave
+3 pop
+4 putobject 5
+5 setlocal 0 1
+6 pop
+7 pop
+8 getlocal 0 0
+9 getlocal 0 1
+10 send > 1
+11 branchunless 15
+12 putobject 10
+13 setlocal 0 2
+14 jump 16
+15 putnil
+16 pop
+17 pop
+18 getlocal 0 2
+19 putobject 1
+20 send + 1
+21 pop
+22 pop
+23 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -95,24 +108,28 @@ func TestIfExpressionWithAlternativeCompilation(t *testing.T) {
 0 putobject 10
 1 setlocal 0 0
 2 pop
-3 putobject 5
-4 setlocal 0 1
-5 pop
-6 getlocal 0 0
-7 getlocal 0 1
-8 send > 1
-9 branchunless 14
-10 putobject 10
-11 setlocal 0 2
-12 pop
-13 jump 17
-14 putobject 5
-15 setlocal 0 2
-16 pop
-17 getlocal 0 2
-18 putobject 1
-19 send + 1
-20 leave
+3 pop
+4 putobject 5
+5 setlocal 0 1
+6 pop
+7 pop
+8 getlocal 0 0
+9 getlocal 0 1
+10 send > 1
+11 branchunless 15
+12 putobject 10
+13 setlocal 0 2
+14 jump 17
+15 putobject 5
+16 setlocal 0 2
+17 pop
+18 pop
+19 getlocal 0 2
+20 putobject 1
+21 send + 1
+22 pop
+23 pop
+24 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -140,16 +157,18 @@ func TestMultipleVariableAssignmentCompilation(t *testing.T) {
 0 putself
 1 putstring "foo"
 2 def_method 0
-3 putself
-4 send foo 0
-5 expand_array 3
-6 setlocal 0 0
-7 pop
-8 setinstancevariable @b
-9 pop
-10 setlocal 0 1
-11 pop
-12 leave
+3 pop
+4 putself
+5 send foo 0
+6 expand_array 3
+7 setlocal 0 0
+8 pop
+9 setinstancevariable @b
+10 pop
+11 setlocal 0 1
+12 pop
+13 pop
+14 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -168,13 +187,17 @@ func TestConstantCompilation(t *testing.T) {
 0 putobject 10
 1 setconstant Foo
 2 pop
-3 getconstant Foo false
-4 setconstant Bar
-5 pop
-6 getconstant Foo false
-7 getconstant Bar false
-8 send + 1
-9 leave
+3 pop
+4 getconstant Foo false
+5 setconstant Bar
+6 pop
+7 pop
+8 getconstant Foo false
+9 getconstant Bar false
+10 send + 1
+11 pop
+12 pop
+13 leave
 `
 	bytecode := compileToBytecode(input)
 	compareBytecode(t, bytecode, expected)
@@ -191,14 +214,18 @@ func TestBooleanCompilation(t *testing.T) {
 0 putobject true
 1 setlocal 0 0
 2 pop
-3 putobject false
-4 setlocal 0 1
-5 pop
-6 getlocal 0 0
-7 send ! 0
-8 getlocal 0 1
-9 send == 1
-10 leave
+3 pop
+4 putobject false
+5 setlocal 0 1
+6 pop
+7 pop
+8 getlocal 0 0
+9 send ! 0
+10 getlocal 0 1
+11 send == 1
+12 pop
+13 pop
+14 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -220,16 +247,20 @@ func TestArrayCompilation(t *testing.T) {
 3 newarray 3
 4 setlocal 0 0
 5 pop
-6 getlocal 0 0
-7 putobject 0
-8 putstring "foo"
-9 send []= 2
-10 getlocal 0 0
-11 putobject 0
-12 send [] 1
-13 setlocal 0 1
-14 pop
-15 leave
+6 pop
+7 getlocal 0 0
+8 putobject 0
+9 putstring "foo"
+10 send []= 2
+11 pop
+12 pop
+13 getlocal 0 0
+14 putobject 0
+15 send [] 1
+16 setlocal 0 1
+17 pop
+18 pop
+19 leave
 `
 	bytecode := compileToBytecode(input)
 	compareBytecode(t, bytecode, expected)
@@ -245,37 +276,6 @@ func TestHashCompilation(t *testing.T) {
 
 	expected1 := `
 <ProgramStart>
-0 putstring "foo"
-1 putobject 1
-2 putstring "bar"
-3 putobject 5
-4 newhash 4
-5 setlocal 0 0
-6 pop
-7 newhash 0
-8 setlocal 0 1
-9 pop
-10 getlocal 0 1
-11 putstring "baz"
-12 getlocal 0 0
-13 putstring "bar"
-14 send [] 1
-15 getlocal 0 0
-16 putstring "foo"
-17 send [] 1
-18 send - 1
-19 send []= 2
-20 getlocal 0 1
-21 putstring "baz"
-22 send [] 1
-23 getlocal 0 0
-24 putstring "bar"
-25 send [] 1
-26 send + 1
-27 leave
-`
-	expected2 := `
-<ProgramStart>
 0 putstring "bar"
 1 putobject 5
 2 putstring "foo"
@@ -283,27 +283,70 @@ func TestHashCompilation(t *testing.T) {
 4 newhash 4
 5 setlocal 0 0
 6 pop
-7 newhash 0
-8 setlocal 0 1
-9 pop
-10 getlocal 0 1
-11 putstring "baz"
-12 getlocal 0 0
-13 putstring "bar"
-14 send [] 1
-15 getlocal 0 0
-16 putstring "foo"
-17 send [] 1
-18 send - 1
-19 send []= 2
-20 getlocal 0 1
-21 putstring "baz"
-22 send [] 1
-23 getlocal 0 0
-24 putstring "bar"
-25 send [] 1
-26 send + 1
-27 leave
+7 pop
+8 newhash 0
+9 setlocal 0 1
+10 pop
+11 pop
+12 getlocal 0 1
+13 putstring "baz"
+14 getlocal 0 0
+15 putstring "bar"
+16 send [] 1
+17 getlocal 0 0
+18 putstring "foo"
+19 send [] 1
+20 send - 1
+21 send []= 2
+22 pop
+23 pop
+24 getlocal 0 1
+25 putstring "baz"
+26 send [] 1
+27 getlocal 0 0
+28 putstring "bar"
+29 send [] 1
+30 send + 1
+31 pop
+32 pop
+33 leave
+`
+	expected2 := `
+<ProgramStart>
+0 putstring "foo"
+1 putobject 1
+2 putstring "bar"
+3 putobject 5
+4 newhash 4
+5 setlocal 0 0
+6 pop
+7 pop
+8 newhash 0
+9 setlocal 0 1
+10 pop
+11 pop
+12 getlocal 0 1
+13 putstring "baz"
+14 getlocal 0 0
+15 putstring "bar"
+16 send [] 1
+17 getlocal 0 0
+18 putstring "foo"
+19 send [] 1
+20 send - 1
+21 send []= 2
+22 pop
+23 pop
+24 getlocal 0 1
+25 putstring "baz"
+26 send [] 1
+27 getlocal 0 0
+28 putstring "bar"
+29 send [] 1
+30 send + 1
+31 pop
+32 pop
+33 leave
 `
 	bytecode := strings.TrimSpace(compileToBytecode(input))
 
@@ -349,7 +392,9 @@ func TestRangeCompilation(t *testing.T) {
 3 send + 1
 4 newrange 0
 5 send each 0 block:0
-6 leave
+6 pop
+7 pop
+8 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -373,23 +418,29 @@ func TestUnusedExpressionRemoval(t *testing.T) {
 0 putobject 0
 1 setlocal 0 0
 2 pop
-3 jump 12
-4 putnil
-5 pop
-6 jump 12
-7 getlocal 0 0
-8 putobject 1
-9 send + 1
-10 setlocal 0 0
-11 pop
-12 getlocal 0 0
-13 putobject 100
-14 send < 1
-15 branchif 7
-16 putnil
-17 pop
-18 getlocal 0 0
-19 leave
+3 pop
+4 jump 15
+5 putnil
+6 pop
+7 jump 15
+8 putobject 10
+9 pop
+10 getlocal 0 0
+11 putobject 1
+12 send + 1
+13 setlocal 0 0
+14 pop
+15 getlocal 0 0
+16 putobject 100
+17 send < 1
+18 branchif 8
+19 putnil
+20 pop
+21 pop
+22 getlocal 0 0
+23 pop
+24 pop
+25 leave
 `
 
 	bytecode := compileToBytecode(input)

--- a/compiler/bytecode/generator.go
+++ b/compiler/bytecode/generator.go
@@ -99,19 +99,27 @@ func (g *Generator) InitTopLevelScope(program *ast.Program) {
 // GenerateByteCode returns compiled instructions in string format
 func (g *Generator) GenerateByteCode(stmts []ast.Statement) string {
 	g.compileStatements(stmts, g.scope, g.scope.localTable)
+
+	return strings.TrimSpace(strings.Replace(g.instructionsToString(), "\n\n", "\n", -1))
+}
+
+// GenerateInstructions returns compiled instructions
+func (g *Generator) GenerateInstructions(stmts []ast.Statement) []*InstructionSet {
+	g.compileStatements(stmts, g.scope, g.scope.localTable)
+
+	//fmt.Println(g.instructionsToString())
+	//fmt.Print()
+	return g.instructionSets
+}
+
+func (g *Generator) instructionsToString() string {
 	var out bytes.Buffer
 
 	for _, is := range g.instructionSets {
 		out.WriteString(is.compile())
 	}
 
-	return strings.TrimSpace(strings.Replace(out.String(), "\n\n", "\n", -1))
-}
-
-// GenerateInstructions returns compiled instructions
-func (g *Generator) GenerateInstructions(stmts []ast.Statement) []*InstructionSet {
-	g.compileStatements(stmts, g.scope, g.scope.localTable)
-	return g.instructionSets
+	return out.String()
 }
 
 func (g *Generator) compileCodeBlock(is *InstructionSet, stmt *ast.BlockStatement, scope *scope, table *localTable) {

--- a/compiler/bytecode/generator_test.go
+++ b/compiler/bytecode/generator_test.go
@@ -19,9 +19,13 @@ func TestRequireRelativeCompilation(t *testing.T) {
 0 putself
 1 putstring "foo"
 2 send require_relative 1
-3 getconstant Foo false
-4 send bar 0
-5 leave
+3 pop
+4 pop
+5 getconstant Foo false
+6 send bar 0
+7 pop
+8 pop
+9 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -40,9 +44,13 @@ func TestRequireCompilation(t *testing.T) {
 0 putself
 1 putstring "foo"
 2 send require 1
-3 getconstant Foo false
-4 send bar 0
-5 leave
+3 pop
+4 pop
+5 getconstant Foo false
+6 send bar 0
+7 pop
+8 pop
+9 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -86,8 +94,7 @@ i
 1 getlocal 2 1
 2 send + 1
 3 setlocal 2 1
-4 pop
-5 leave
+4 leave
 <Block:0>
 0 putobject 3
 1 getlocal 1 0
@@ -101,23 +108,32 @@ i
 0 putself
 1 def_class class:Foo
 2 pop
-3 putobject 100
-4 setlocal 0 0
-5 pop
-6 putobject 10
-7 setlocal 0 1
-8 pop
-9 putobject 1000
-10 setlocal 0 2
+3 pop
+4 putobject 100
+5 setlocal 0 0
+6 pop
+7 pop
+8 putobject 10
+9 setlocal 0 1
+10 pop
 11 pop
-12 getconstant Foo false
-13 send new 0
-14 setlocal 0 3
+12 putobject 1000
+13 setlocal 0 2
+14 pop
 15 pop
-16 getlocal 0 3
-17 send bar 0 block:0
-18 getlocal 0 1
-19 leave
+16 getconstant Foo false
+17 send new 0
+18 setlocal 0 3
+19 pop
+20 pop
+21 getlocal 0 3
+22 send bar 0 block:0
+23 pop
+24 pop
+25 getlocal 0 1
+26 pop
+27 pop
+28 leave
 `
 	bytecode := compileToBytecode(input)
 	compareBytecode(t, bytecode, expected)
@@ -142,29 +158,36 @@ puts(x)
 0 putself
 1 getlocal 1 0
 2 send puts 1
-3 putobject 1
-4 setlocal 0 0
-5 pop
-6 putself
-7 getlocal 0 0
-8 send puts 1
-9 putobject 2
-10 setlocal 1 0
-11 pop
-12 putself
-13 getlocal 1 0
-14 send puts 1
-15 leave
+3 pop
+4 putobject 1
+5 setlocal 0 0
+6 pop
+7 putself
+8 getlocal 0 0
+9 send puts 1
+10 pop
+11 putobject 2
+12 setlocal 1 0
+13 pop
+14 putself
+15 getlocal 1 0
+16 send puts 1
+17 leave
 <ProgramStart>
 0 putobject 1
 1 setlocal 0 0
 2 pop
-3 putself
-4 send foo 0 block:0
-5 putself
-6 getlocal 0 0
-7 send puts 1
-8 leave
+3 pop
+4 putself
+5 send foo 0 block:0
+6 pop
+7 pop
+8 putself
+9 getlocal 0 0
+10 send puts 1
+11 pop
+12 pop
+13 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -185,7 +208,9 @@ func TestArithmeticCompilation(t *testing.T) {
 4 send + 1
 5 putobject 2
 6 send / 1
-7 leave
+7 pop
+8 pop
+9 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -220,13 +245,17 @@ func TestBasicMethodReDefineAndExecution(t *testing.T) {
 0 putself
 1 putstring "foo"
 2 def_method 1
-3 putself
-4 putstring "foo"
-5 def_method 1
-6 putself
-7 putobject 11
-8 send foo 1
-9 leave
+3 pop
+4 putself
+5 putstring "foo"
+6 def_method 1
+7 pop
+8 putself
+9 putobject 11
+10 send foo 1
+11 pop
+12 pop
+13 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -258,11 +287,14 @@ func TestBasicMethodDefineAndExecution(t *testing.T) {
 0 putself
 1 putstring "foo"
 2 def_method 2
-3 putself
-4 putobject 11
-5 putobject 1
-6 send foo 2
-7 leave
+3 pop
+4 putself
+5 putobject 11
+6 putobject 1
+7 send foo 2
+8 pop
+9 pop
+10 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -290,10 +322,13 @@ func TestMethodDefWithDefaultValueArgument(t *testing.T) {
 0 putself
 1 putstring "foo"
 2 def_method 2
-3 putself
-4 putobject 100
-5 send foo 1
-6 leave
+3 pop
+4 putself
+5 putobject 100
+6 send foo 1
+7 pop
+8 pop
+9 leave
 `
 
 	bytecode := compileToBytecode(input)

--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -111,9 +111,7 @@ func (g *Generator) compileClassStmt(is *InstructionSet, stmt *ast.ClassStatemen
 		is.define(DefClass, "class:"+stmt.Name.Value)
 	}
 
-	if stmt.IsStmt() {
-		is.define(Pop)
-	}
+	is.define(Pop)
 
 	scope = newScope(stmt)
 
@@ -130,9 +128,7 @@ func (g *Generator) compileClassStmt(is *InstructionSet, stmt *ast.ClassStatemen
 func (g *Generator) compileModuleStmt(is *InstructionSet, stmt *ast.ModuleStatement, scope *scope) {
 	is.define(PutSelf)
 	is.define(DefClass, "module:"+stmt.Name.Value)
-	if stmt.IsStmt() {
-		is.define(Pop)
-	}
+	is.define(Pop)
 
 	scope = newScope(stmt)
 	newIS := &InstructionSet{}

--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -97,7 +97,10 @@ func (g *Generator) compileClassStmt(is *InstructionSet, stmt *ast.ClassStatemen
 		is.define(DefClass, "class:"+stmt.Name.Value)
 	}
 
-	is.define(Pop)
+	if !stmt.IsExp() {
+		is.define(Pop)
+	}
+
 	scope = newScope(stmt)
 
 	// compile class's content
@@ -113,7 +116,9 @@ func (g *Generator) compileClassStmt(is *InstructionSet, stmt *ast.ClassStatemen
 func (g *Generator) compileModuleStmt(is *InstructionSet, stmt *ast.ModuleStatement, scope *scope) {
 	is.define(PutSelf)
 	is.define(DefClass, "module:"+stmt.Name.Value)
-	is.define(Pop)
+	if !stmt.IsExp() {
+		is.define(Pop)
+	}
 
 	scope = newScope(stmt)
 	newIS := &InstructionSet{}

--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -18,7 +18,18 @@ func (g *Generator) compileStatements(stmts []ast.Statement, scope *scope, table
 
 	for _, statement := range stmts {
 		g.compileStatement(is, statement, scope, table)
+
+		if !g.REPL {
+			expStmt, ok := statement.(*ast.ExpressionStatement)
+
+			if ok && expStmt.Expression.IsExp() {
+				continue
+			}
+
+			is.define(Pop)
+		}
 	}
+
 
 	g.endInstructions(is)
 	g.instructionSets = append(g.instructionSets, is)

--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -30,7 +30,6 @@ func (g *Generator) compileStatements(stmts []ast.Statement, scope *scope, table
 		}
 	}
 
-
 	g.endInstructions(is)
 	g.instructionSets = append(g.instructionSets, is)
 }
@@ -108,7 +107,7 @@ func (g *Generator) compileClassStmt(is *InstructionSet, stmt *ast.ClassStatemen
 		is.define(DefClass, "class:"+stmt.Name.Value)
 	}
 
-	if !stmt.IsExp() {
+	if stmt.IsStmt() {
 		is.define(Pop)
 	}
 
@@ -127,7 +126,7 @@ func (g *Generator) compileClassStmt(is *InstructionSet, stmt *ast.ClassStatemen
 func (g *Generator) compileModuleStmt(is *InstructionSet, stmt *ast.ModuleStatement, scope *scope) {
 	is.define(PutSelf)
 	is.define(DefClass, "module:"+stmt.Name.Value)
-	if !stmt.IsExp() {
+	if stmt.IsStmt() {
 		is.define(Pop)
 	}
 

--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -39,6 +39,10 @@ func (g *Generator) compileStatement(is *InstructionSet, statement ast.Statement
 	switch stmt := statement.(type) {
 	case *ast.ExpressionStatement:
 		g.compileExpression(is, stmt.Expression, scope, table)
+
+		if stmt.Expression.IsStmt() {
+			is.define(Pop)
+		}
 	case *ast.DefStatement:
 		g.compileDefStmt(is, stmt, scope)
 	case *ast.ClassStatement:

--- a/compiler/bytecode/statement_generation_test.go
+++ b/compiler/bytecode/statement_generation_test.go
@@ -31,8 +31,7 @@ Foo.new(100, 50).bar
 7 getlocal 0 1
 8 send - 1
 9 setinstancevariable @z
-10 pop
-11 leave
+10 leave
 <Def:bar>
 0 getinstancevariable @x
 1 getinstancevariable @y
@@ -52,12 +51,15 @@ Foo.new(100, 50).bar
 0 putself
 1 def_class class:Foo
 2 pop
-3 getconstant Foo false
-4 putobject 100
-5 putobject 50
-6 send new 2
-7 send bar 0
-8 leave
+3 pop
+4 getconstant Foo false
+5 putobject 100
+6 putobject 50
+7 send new 2
+8 send bar 0
+9 pop
+10 pop
+11 leave
 `
 	bytecode := compileToBytecode(input)
 	compareBytecode(t, bytecode, expected)
@@ -100,12 +102,15 @@ func TestNamespacedClass(t *testing.T) {
 0 putself
 1 def_class module:Foo
 2 pop
-3 getconstant Foo true
-4 getconstant Bar true
-5 getconstant Baz false
-6 send new 0
-7 send bar 0
-8 leave
+3 pop
+4 getconstant Foo true
+5 getconstant Bar true
+6 getconstant Baz false
+7 send new 0
+8 send bar 0
+9 pop
+10 pop
+11 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -135,9 +140,12 @@ Foo.bar
 0 putself
 1 def_class class:Foo
 2 pop
-3 getconstant Foo false
-4 send bar 0
-5 leave
+3 pop
+4 getconstant Foo false
+5 send bar 0
+6 pop
+7 pop
+8 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -172,14 +180,18 @@ Foo.new.bar
 0 putself
 1 def_class class:Bar
 2 pop
-3 putself
-4 getconstant Bar false
-5 def_class class:Foo Bar
-6 pop
-7 getconstant Foo false
-8 send new 0
-9 send bar 0
-10 leave
+3 pop
+4 putself
+5 getconstant Bar false
+6 def_class class:Foo Bar
+7 pop
+8 pop
+9 getconstant Foo false
+10 send new 0
+11 send bar 0
+12 pop
+13 pop
+14 leave
 `
 	bytecode := compileToBytecode(input)
 	compareBytecode(t, bytecode, expected)
@@ -214,18 +226,23 @@ Foo.new.bar
 0 putself
 1 getconstant Bar false
 2 send include 1
-3 leave
+3 pop
+4 leave
 <ProgramStart>
 0 putself
 1 def_class module:Bar
 2 pop
-3 putself
-4 def_class class:Foo
-5 pop
-6 getconstant Foo false
-7 send new 0
-8 send bar 0
-9 leave
+3 pop
+4 putself
+5 def_class class:Foo
+6 pop
+7 pop
+8 getconstant Foo false
+9 send new 0
+10 send bar 0
+11 pop
+12 pop
+13 leave
 `
 	bytecode := compileToBytecode(input)
 	compareBytecode(t, bytecode, expected)
@@ -248,32 +265,37 @@ func TestWhileStatementInBlock(t *testing.T) {
 0 putself
 1 getlocal 1 0
 2 send puts 1
-3 jump 15
-4 putnil
-5 pop
-6 jump 15
-7 putself
-8 getlocal 1 0
-9 send puts 1
-10 getlocal 1 0
-11 putobject 1
-12 send + 1
-13 setlocal 1 0
-14 pop
-15 getlocal 1 0
-16 putobject 1000
-17 send <= 1
-18 branchif 7
-19 putnil
-20 pop
-21 leave
+3 pop
+4 jump 17
+5 putnil
+6 pop
+7 jump 17
+8 putself
+9 getlocal 1 0
+10 send puts 1
+11 pop
+12 getlocal 1 0
+13 putobject 1
+14 send + 1
+15 setlocal 1 0
+16 pop
+17 getlocal 1 0
+18 putobject 1000
+19 send <= 1
+20 branchif 8
+21 putnil
+22 pop
+23 leave
 <ProgramStart>
 0 putobject 1
 1 setlocal 0 0
 2 pop
-3 putself
-4 send thread 0 block:0
-5 leave
+3 pop
+4 putself
+5 send thread 0 block:0
+6 pop
+7 pop
+8 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -295,23 +317,27 @@ func TestWhileStatementWithoutMethodCallInCondition(t *testing.T) {
 0 putobject 10
 1 setlocal 0 0
 2 pop
-3 jump 12
-4 putnil
-5 pop
-6 jump 12
-7 getlocal 0 0
-8 putobject 1
-9 send - 1
-10 setlocal 0 0
-11 pop
-12 getlocal 0 0
-13 putobject 0
-14 send > 1
-15 branchif 7
-16 putnil
-17 pop
-18 getlocal 0 0
-19 leave
+3 pop
+4 jump 13
+5 putnil
+6 pop
+7 jump 13
+8 getlocal 0 0
+9 putobject 1
+10 send - 1
+11 setlocal 0 0
+12 pop
+13 getlocal 0 0
+14 putobject 0
+15 send > 1
+16 branchif 8
+17 putnil
+18 pop
+19 pop
+20 getlocal 0 0
+21 pop
+22 pop
+23 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -334,30 +360,35 @@ func TestWhileStatementWithMethodCallInCondition(t *testing.T) {
 0 putobject 10
 1 setlocal 0 0
 2 pop
-3 putobject 1
-4 putobject 2
-5 putobject 3
-6 newarray 3
-7 setlocal 0 1
-8 pop
-9 jump 18
-10 putnil
-11 pop
-12 jump 18
-13 getlocal 0 0
-14 putobject 1
-15 send - 1
-16 setlocal 0 0
-17 pop
-18 getlocal 0 0
-19 getlocal 0 1
-20 send length 0
-21 send > 1
-22 branchif 13
-23 putnil
-24 pop
-25 getlocal 0 0
-26 leave
+3 pop
+4 putobject 1
+5 putobject 2
+6 putobject 3
+7 newarray 3
+8 setlocal 0 1
+9 pop
+10 pop
+11 jump 20
+12 putnil
+13 pop
+14 jump 20
+15 getlocal 0 0
+16 putobject 1
+17 send - 1
+18 setlocal 0 0
+19 pop
+20 getlocal 0 0
+21 getlocal 0 1
+22 send length 0
+23 send > 1
+24 branchif 15
+25 putnil
+26 pop
+27 pop
+28 getlocal 0 0
+29 pop
+30 pop
+31 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -383,35 +414,39 @@ func TestNextStatementCompilation(t *testing.T) {
 0 putobject 0
 1 setlocal 0 0
 2 pop
-3 putobject 0
-4 setlocal 0 1
-5 pop
-6 jump 25
-7 putnil
-8 pop
-9 jump 25
-10 getlocal 0 0
-11 putobject 1
-12 send + 1
-13 setlocal 0 0
-14 pop
-15 getlocal 0 0
-16 putobject 5
-17 send == 1
-18 branchunless 20
-19 jump 25
-20 getlocal 0 1
-21 putobject 1
-22 send + 1
-23 setlocal 0 1
-24 pop
-25 getlocal 0 0
-26 putobject 10
-27 send < 1
-28 branchif 10
-29 putnil
-30 pop
-31 leave
+3 pop
+4 putobject 0
+5 setlocal 0 1
+6 pop
+7 pop
+8 jump 28
+9 putnil
+10 pop
+11 jump 28
+12 getlocal 0 0
+13 putobject 1
+14 send + 1
+15 setlocal 0 0
+16 pop
+17 getlocal 0 0
+18 putobject 5
+19 send == 1
+20 branchunless 22
+21 jump 28
+22 pop
+23 getlocal 0 1
+24 putobject 1
+25 send + 1
+26 setlocal 0 1
+27 pop
+28 getlocal 0 0
+29 putobject 10
+30 send < 1
+31 branchif 12
+32 putnil
+33 pop
+34 pop
+35 leave
 `
 
 	bytecode := compileToBytecode(input)
@@ -445,63 +480,71 @@ a + 100
 0 putobject 0
 1 setlocal 0 0
 2 pop
-3 putobject 0
-4 setlocal 0 1
-5 pop
-6 putobject 0
-7 setlocal 0 2
-8 pop
-9 jump 45
-10 putnil
+3 pop
+4 putobject 0
+5 setlocal 0 1
+6 pop
+7 pop
+8 putobject 0
+9 setlocal 0 2
+10 pop
 11 pop
-12 jump 45
-13 getlocal 0 0
-14 putobject 1
-15 send + 1
-16 setlocal 0 0
-17 pop
-18 jump 39
-19 putnil
+12 jump 49
+13 putnil
+14 pop
+15 jump 49
+16 getlocal 0 0
+17 putobject 1
+18 send + 1
+19 setlocal 0 0
 20 pop
-21 jump 39
-22 getlocal 0 1
-23 putobject 1
-24 send + 1
-25 setlocal 0 1
-26 pop
-27 getlocal 0 1
-28 putobject 3
-29 send == 1
-30 branchunless 32
-31 jump 45
-32 getlocal 0 2
-33 getlocal 0 0
-34 getlocal 0 1
-35 send * 1
-36 send + 1
-37 setlocal 0 2
-38 pop
-39 getlocal 0 1
-40 putobject 5
-41 send < 1
-42 branchif 22
-43 putnil
-44 pop
-45 getlocal 0 0
-46 putobject 10
-47 send < 1
-48 branchif 13
-49 putnil
-50 pop
-51 getlocal 0 2
-52 putobject 10
-53 send * 1
-54 setlocal 0 3
+21 jump 43
+22 putnil
+23 pop
+24 jump 43
+25 getlocal 0 1
+26 putobject 1
+27 send + 1
+28 setlocal 0 1
+29 pop
+30 getlocal 0 1
+31 putobject 3
+32 send == 1
+33 branchunless 35
+34 jump 49
+35 pop
+36 getlocal 0 2
+37 getlocal 0 0
+38 getlocal 0 1
+39 send * 1
+40 send + 1
+41 setlocal 0 2
+42 pop
+43 getlocal 0 1
+44 putobject 5
+45 send < 1
+46 branchif 25
+47 putnil
+48 pop
+49 getlocal 0 0
+50 putobject 10
+51 send < 1
+52 branchif 16
+53 putnil
+54 pop
 55 pop
-56 getlocal 0 3
-57 putobject 100
-58 send + 1
-59 leave
+56 getlocal 0 2
+57 putobject 10
+58 send * 1
+59 setlocal 0 3
+60 pop
+61 pop
+62 getlocal 0 3
+63 putobject 100
+64 send + 1
+65 pop
+66 pop
+67 leave
 `
 	bytecode := compileToBytecode(input)
 	compareBytecode(t, bytecode, expected)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -21,9 +21,10 @@ func CompileToBytecode(input string) (string, error) {
 }
 
 // CompileToInstructions compiles input source code into instruction set data structures
-func CompileToInstructions(input string) ([]*bytecode.InstructionSet, error) {
+func CompileToInstructions(input string, parserMode int) ([]*bytecode.InstructionSet, error) {
 	l := lexer.New(input)
 	p := parser.New(l)
+	p.Mode = parserMode
 	program, err := p.ParseProgram()
 	if err != nil {
 		return nil, fmt.Errorf(err.Message)

--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -481,7 +481,7 @@ func (p *Parser) parseCallExpressionWithoutParenAndReceiver(methodToken token.To
 
 	// Parse block
 	if p.peekTokenIs(token.Do) && p.acceptBlock {
-		p.parseBlockParameters(exp)
+		p.parseBlockArgument(exp)
 	}
 
 	return exp
@@ -509,7 +509,7 @@ func (p *Parser) parseCallExpressionWithParen(receiver ast.Expression) ast.Expre
 
 	// Parse block
 	if p.peekTokenIs(token.Do) && p.acceptBlock {
-		p.parseBlockParameters(exp)
+		p.parseBlockArgument(exp)
 	}
 
 	return exp
@@ -552,13 +552,13 @@ func (p *Parser) parseCallExpressionWithDot(receiver ast.Expression) ast.Express
 
 	// Parse block
 	if p.peekTokenIs(token.Do) && p.acceptBlock {
-		p.parseBlockParameters(exp)
+		p.parseBlockArgument(exp)
 	}
 
 	return exp
 }
 
-func (p *Parser) parseBlockParameters(exp *ast.CallExpression) {
+func (p *Parser) parseBlockArgument(exp *ast.CallExpression) {
 	p.nextToken()
 
 	// Parse block arguments

--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -448,10 +448,12 @@ func (p *Parser) parseIfExpression() ast.Expression {
 	ie.Condition = p.parseExpression(NORMAL)
 
 	ie.Consequence = p.parseBlockStatement()
+	ie.Consequence.KeepLastValue()
 
 	// curToken is now ELSE or RBRACE
 	if p.curTokenIs(token.Else) {
 		ie.Alternative = p.parseBlockStatement()
+		ie.Alternative.KeepLastValue()
 	}
 
 	return ie
@@ -586,6 +588,7 @@ func (p *Parser) parseBlockArgument(exp *ast.CallExpression) {
 	}
 
 	exp.Block = p.parseBlockStatement()
+	exp.Block.KeepLastValue()
 }
 
 func (p *Parser) parseCallArguments() []ast.Expression {

--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -356,10 +356,10 @@ func (p *Parser) parseInfixExpression(left ast.Expression) ast.Expression {
 func (p *Parser) parseAssignExpression(v ast.Expression) ast.Expression {
 	var value ast.Expression
 	var tok token.Token
-	exp := &ast.AssignExpression{IsStmt: true, BaseNode: &ast.BaseNode{}}
+	exp := &ast.AssignExpression{BaseNode: &ast.BaseNode{}}
 
 	if p.fsm.Is(parsingFuncCall) {
-		exp.IsStmt = false
+		exp.MarkAsExp()
 	}
 
 	oldState := p.fsm.Current()
@@ -420,7 +420,7 @@ func (p *Parser) parseAssignExpression(v ast.Expression) ast.Expression {
 	assignExp, ok := value.(*ast.AssignExpression)
 
 	if ok {
-		assignExp.IsStmt = false
+		assignExp.MarkAsExp()
 	}
 
 	exp.Token = tok
@@ -452,7 +452,7 @@ func (p *Parser) parseIfExpression() ast.Expression {
 	assignExp, ok := ie.Condition.(*ast.AssignExpression)
 
 	if ok {
-		assignExp.IsStmt = false
+		assignExp.MarkAsExp()
 	}
 
 	ie.Consequence = p.parseBlockStatement()

--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -156,11 +156,11 @@ func (p *Parser) parseSelfExpression() ast.Expression {
 }
 
 func (p *Parser) parseIdentifier() ast.Expression {
-	return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+	return &ast.Identifier{BaseNode: &ast.BaseNode{Token: p.curToken}, Value: p.curToken.Literal}
 }
 
 func (p *Parser) parseConstant() ast.Expression {
-	c := &ast.Constant{Token: p.curToken, Value: p.curToken.Literal}
+	c := &ast.Constant{BaseNode: &ast.BaseNode{Token: p.curToken}, Value: p.curToken.Literal}
 
 	if p.peekTokenIs(token.ResolutionOperator) {
 		c.IsNamespace = true
@@ -172,7 +172,7 @@ func (p *Parser) parseConstant() ast.Expression {
 }
 
 func (p *Parser) parseInstanceVariable() ast.Expression {
-	return &ast.InstanceVariable{Token: p.curToken, Value: p.curToken.Literal}
+	return &ast.InstanceVariable{BaseNode: &ast.BaseNode{Token: p.curToken}, Value: p.curToken.Literal}
 }
 
 func (p *Parser) parseIntegerLiteral() ast.Expression {
@@ -417,12 +417,7 @@ func (p *Parser) parseAssignExpression(v ast.Expression) ast.Expression {
 		value = p.parseExpression(precedence)
 	}
 
-	assignExp, ok := value.(*ast.AssignExpression)
-
-	if ok {
-		assignExp.MarkAsExp()
-	}
-
+	value.MarkAsExp()
 	exp.Token = tok
 	exp.Value = value
 
@@ -448,12 +443,7 @@ func (p *Parser) parseIfExpression() ast.Expression {
 	ie := &ast.IfExpression{BaseNode: &ast.BaseNode{Token: p.curToken}}
 	p.nextToken()
 	ie.Condition = p.parseExpression(NORMAL)
-
-	assignExp, ok := ie.Condition.(*ast.AssignExpression)
-
-	if ok {
-		assignExp.MarkAsExp()
-	}
+	ie.Condition.MarkAsExp()
 
 	ie.Consequence = p.parseBlockStatement()
 
@@ -562,13 +552,13 @@ func (p *Parser) parseBlockParameters(exp *ast.CallExpression) {
 		p.nextToken()
 		p.nextToken()
 
-		param := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+		param := &ast.Identifier{BaseNode: &ast.BaseNode{Token: p.curToken}, Value: p.curToken.Literal}
 		params = append(params, param)
 
 		for p.peekTokenIs(token.Comma) {
 			p.nextToken()
 			p.nextToken()
-			param := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+			param := &ast.Identifier{BaseNode: &ast.BaseNode{Token: p.curToken}, Value: p.curToken.Literal}
 			params = append(params, param)
 		}
 

--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -148,6 +148,10 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 		leftExp = infixFn(leftExp)
 	}
 
+	if p.peekTokenIs(token.Semicolon) {
+		p.nextToken()
+	}
+
 	return leftExp
 }
 
@@ -358,8 +362,8 @@ func (p *Parser) parseAssignExpression(v ast.Expression) ast.Expression {
 	var tok token.Token
 	exp := &ast.AssignExpression{BaseNode: &ast.BaseNode{}}
 
-	if p.fsm.Is(parsingFuncCall) {
-		exp.MarkAsExp()
+	if !p.fsm.Is(parsingFuncCall) {
+		exp.MarkAsStmt()
 	}
 
 	oldState := p.fsm.Current()
@@ -417,7 +421,6 @@ func (p *Parser) parseAssignExpression(v ast.Expression) ast.Expression {
 		value = p.parseExpression(precedence)
 	}
 
-	value.MarkAsExp()
 	exp.Token = tok
 	exp.Value = value
 
@@ -443,7 +446,6 @@ func (p *Parser) parseIfExpression() ast.Expression {
 	ie := &ast.IfExpression{BaseNode: &ast.BaseNode{Token: p.curToken}}
 	p.nextToken()
 	ie.Condition = p.parseExpression(NORMAL)
-	ie.Condition.MarkAsExp()
 
 	ie.Consequence = p.parseBlockStatement()
 

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -172,7 +172,6 @@ func (p *Parser) ParseProgram() (*ast.Program, *Error) {
 		stmt := p.parseStatement()
 
 		if stmt != nil {
-			stmt.MarkAsStmt()
 			program.Statements = append(program.Statements, stmt)
 		}
 		p.nextToken()

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -61,6 +61,7 @@ type Parser struct {
 	Mode        int
 }
 
+// These are the enums for marking parser's mode, which decides whether it should pop unused values.
 const (
 	NormalMode int = iota
 	REPLMode

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -172,6 +172,7 @@ func (p *Parser) ParseProgram() (*ast.Program, *Error) {
 		stmt := p.parseStatement()
 
 		if stmt != nil {
+			stmt.MarkAsStmt()
 			program.Statements = append(program.Statements, stmt)
 		}
 		p.nextToken()

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -58,7 +58,14 @@ type Parser struct {
 	// However, this is not a very good practice should change it in the future.
 	acceptBlock bool
 	fsm         *fsm.FSM
+	Mode        int
 }
+
+const (
+	NormalMode int = iota
+	REPLMode
+	TestMode
+)
 
 // These are state machine's events
 const (
@@ -171,6 +178,15 @@ func (p *Parser) ParseProgram() (*ast.Program, *Error) {
 
 		if p.error != nil {
 			return nil, p.error
+		}
+	}
+
+	if p.Mode == TestMode {
+		stmt := program.Statements[len(program.Statements)-1]
+		expStmt, ok := stmt.(*ast.ExpressionStatement)
+
+		if ok {
+			expStmt.Expression.MarkAsExp()
 		}
 	}
 

--- a/compiler/parser/parser_test.go
+++ b/compiler/parser/parser_test.go
@@ -80,8 +80,8 @@ func TestOperatorPrecedenceParsing(t *testing.T) {
 			"(((a + (b * c)) + (d / e)) - f)",
 		},
 		{
-			"3 + 4; -5 * 5",
-			"(3 + 4)((-5) * 5)",
+			"-5 * -5",
+			"((-5) * (-5))",
 		},
 		{
 			"5 > 4 == 3 < 4",

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -23,9 +23,9 @@ func (p *Parser) parseStatement() ast.Statement {
 	case token.Module:
 		return p.parseModuleStatement()
 	case token.Next:
-		return &ast.NextStatement{Token: p.curToken}
+		return &ast.NextStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
 	case token.Break:
-		return &ast.BreakStatement{Token: p.curToken}
+		return &ast.BreakStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
 	default:
 		return p.parseExpressionStatement()
 	}
@@ -33,7 +33,7 @@ func (p *Parser) parseStatement() ast.Statement {
 
 func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 	var params []ast.Expression
-	stmt := &ast.DefStatement{Token: p.curToken}
+	stmt := &ast.DefStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
 
 	p.nextToken()
 
@@ -110,7 +110,7 @@ func (p *Parser) parseParameters() []ast.Expression {
 }
 
 func (p *Parser) parseClassStatement() *ast.ClassStatement {
-	stmt := &ast.ClassStatement{Token: p.curToken}
+	stmt := &ast.ClassStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
 
 	if !p.expectPeek(token.Constant) {
 		return nil
@@ -138,7 +138,7 @@ func (p *Parser) parseClassStatement() *ast.ClassStatement {
 }
 
 func (p *Parser) parseModuleStatement() *ast.ModuleStatement {
-	stmt := &ast.ModuleStatement{Token: p.curToken}
+	stmt := &ast.ModuleStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
 
 	if !p.expectPeek(token.Constant) {
 		return nil
@@ -151,7 +151,7 @@ func (p *Parser) parseModuleStatement() *ast.ModuleStatement {
 }
 
 func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
-	stmt := &ast.ReturnStatement{Token: p.curToken}
+	stmt := &ast.ReturnStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
 
 	p.nextToken()
 
@@ -165,7 +165,7 @@ func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 }
 
 func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
-	stmt := &ast.ExpressionStatement{Token: p.curToken}
+	stmt := &ast.ExpressionStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
 
 	if p.curTokenIs(token.Ident) || p.curTokenIs(token.InstanceVariable) {
 		// This is used for identifying method call without parens
@@ -184,8 +184,8 @@ func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 
 func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 
-	// curToken is {
-	bs := &ast.BlockStatement{Token: p.curToken}
+	// curToken is '{'
+	bs := &ast.BlockStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
 	bs.Statements = []ast.Statement{}
 
 	p.nextToken()
@@ -207,7 +207,7 @@ func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 }
 
 func (p *Parser) parseWhileStatement() *ast.WhileStatement {
-	ws := &ast.WhileStatement{Token: p.curToken}
+	ws := &ast.WhileStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
 
 	p.nextToken()
 	// Prevent expression's method call to consume while's block as argument.

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -26,7 +26,10 @@ func (p *Parser) parseStatement() ast.Statement {
 		return &ast.BreakStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
 	default:
 		exp := p.parseExpressionStatement()
-		exp.Expression.MarkAsStmt()
+
+		if p.Mode != REPLMode {
+			exp.Expression.MarkAsStmt()
+		}
 
 		return exp
 	}

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -117,10 +117,6 @@ func (p *Parser) parseParameters() []ast.Expression {
 func (p *Parser) parseClassStatement() *ast.ClassStatement {
 	stmt := &ast.ClassStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
 
-	if !(p.fsm.Is(parsingFuncCall) || p.fsm.Is(parsingAssignment)) {
-		stmt.MarkAsStmt()
-	}
-
 	if !p.expectPeek(token.Constant) {
 		return nil
 	}
@@ -210,16 +206,6 @@ func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 			bs.Statements = append(bs.Statements, stmt)
 		}
 		p.nextToken()
-	}
-
-	if len(bs.Statements) < 1 {
-		return bs
-	}
-
-	stmt := bs.Statements[len(bs.Statements)-1]
-
-	if expStmt, ok := stmt.(*ast.ExpressionStatement); ok {
-		expStmt.Expression.IsExp()
 	}
 
 	return bs

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -26,10 +26,7 @@ func (p *Parser) parseStatement() ast.Statement {
 		return &ast.BreakStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
 	default:
 		exp := p.parseExpressionStatement()
-
-		if exp.Expression != nil && !p.fsm.Is(parsingAssignment) {
-			exp.Expression.MarkAsStmt()
-		}
+		exp.Expression.MarkAsStmt()
 
 		return exp
 	}

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -87,6 +87,7 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 
 	stmt.Parameters = params
 	stmt.BlockStatement = p.parseBlockStatement()
+	stmt.BlockStatement.KeepLastValue()
 
 	return stmt
 }
@@ -179,7 +180,6 @@ func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 		stmt.Expression = p.parseExpression(NORMAL)
 	}
 
-	stmt.Expression.MarkAsStmt()
 	return stmt
 }
 

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -41,7 +41,7 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 	if p.peekTokenIs(token.Dot) {
 		switch p.curToken.Type {
 		case token.Ident:
-			stmt.Receiver = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+			stmt.Receiver = &ast.Identifier{BaseNode: &ast.BaseNode{Token: p.curToken}, Value: p.curToken.Literal}
 		case token.Self:
 			stmt.Receiver = &ast.SelfExpression{BaseNode: &ast.BaseNode{Token: p.curToken}}
 		default:
@@ -54,7 +54,7 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 		}
 	}
 
-	stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+	stmt.Name = &ast.Identifier{BaseNode: &ast.BaseNode{Token: p.curToken}, Value: p.curToken.Literal}
 
 	// Setter method def foo=()
 	if p.peekTokenIs(token.Assign) {
@@ -116,7 +116,7 @@ func (p *Parser) parseClassStatement() *ast.ClassStatement {
 		return nil
 	}
 
-	stmt.Name = &ast.Constant{Token: p.curToken, Value: p.curToken.Literal}
+	stmt.Name = &ast.Constant{BaseNode: &ast.BaseNode{Token: p.curToken}, Value: p.curToken.Literal}
 
 	// See if there is any inheritance
 	if p.peekTokenIs(token.LT) {
@@ -144,7 +144,7 @@ func (p *Parser) parseModuleStatement() *ast.ModuleStatement {
 		return nil
 	}
 
-	stmt.Name = &ast.Constant{Token: p.curToken, Value: p.curToken.Literal}
+	stmt.Name = &ast.Constant{BaseNode: &ast.BaseNode{Token: p.curToken}, Value: p.curToken.Literal}
 	stmt.Body = p.parseBlockStatement()
 
 	return stmt

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -43,7 +43,7 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 		case token.Ident:
 			stmt.Receiver = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 		case token.Self:
-			stmt.Receiver = &ast.SelfExpression{Token: p.curToken}
+			stmt.Receiver = &ast.SelfExpression{BaseNode: &ast.BaseNode{Token: p.curToken}}
 		default:
 			p.error = &Error{Message: fmt.Sprintf("Invalid method receiver: %s. Line: %d", p.curToken.Literal, p.curToken.Line), errType: MethodDefinitionError}
 		}

--- a/goby.go
+++ b/goby.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 
 	"github.com/goby-lang/goby/compiler"
+	"github.com/goby-lang/goby/compiler/parser"
 	"github.com/goby-lang/goby/igb"
 	"github.com/goby-lang/goby/vm"
 	"github.com/pkg/profile"
-	"github.com/goby-lang/goby/compiler/parser"
 )
 
 const Version string = vm.Version

--- a/goby.go
+++ b/goby.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goby-lang/goby/igb"
 	"github.com/goby-lang/goby/vm"
 	"github.com/pkg/profile"
+	"github.com/goby-lang/goby/compiler/parser"
 )
 
 const Version string = vm.Version
@@ -55,7 +56,7 @@ func main() {
 
 	switch fileExt {
 	case "gb", "rb":
-		instructionSets, err := compiler.CompileToInstructions(string(file))
+		instructionSets, err := compiler.CompileToInstructions(string(file), parser.NormalMode)
 
 		if err != nil {
 			fmt.Println(err.Error())

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -259,6 +259,7 @@ func newIVM() iVM {
 	ivm.v.InitForREPL()
 	// Initialize parser, lexer is not important here
 	ivm.p = parser.New(lexer.New(""))
+	ivm.p.Mode = parser.REPLMode
 	program, _ := ivm.p.ParseProgram()
 	// Initialize code generator, and it will behavior a little different in REPL mode.
 	ivm.g = bytecode.NewGenerator()

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -258,6 +258,7 @@ func TestArrayConcatMethodFail(t *testing.T) {
 		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, TypeError, tt.expected)
 		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -329,6 +330,7 @@ func TestArrayCountMethodFail(t *testing.T) {
 		}
 
 		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -432,6 +434,7 @@ func TestArrayFirstMethodFail(t *testing.T) {
 		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, TypeError, tt.expected)
 		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -506,6 +509,7 @@ func TestArrayLengthMethod(t *testing.T) {
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -535,10 +539,11 @@ func TestArrayMapMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -569,6 +574,7 @@ func TestArrayPopMethod(t *testing.T) {
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -610,6 +616,7 @@ func TestArrayPushMethod(t *testing.T) {
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -629,10 +636,11 @@ func TestArrayRotateMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -653,6 +661,7 @@ func TestArrayRotateMethodFail(t *testing.T) {
 		checkError(t, i, evaluated, TypeError, tt.expected)
 
 		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -682,10 +691,11 @@ func TestArraySelectMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -716,6 +726,7 @@ func TestArrayShiftMethod(t *testing.T) {
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -736,5 +747,6 @@ func TestArrayShiftMethodFail(t *testing.T) {
 		checkError(t, i, evaluated, ArgumentError, tt.expected)
 
 		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/boolean_test.go
+++ b/vm/boolean_test.go
@@ -12,10 +12,11 @@ func TestEvalBooleanExpression(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -48,10 +49,11 @@ func TestBooleanComparison(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -75,10 +77,11 @@ func TestBooleanLogicalExpression(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -112,10 +115,11 @@ func TestBooleanAssignmentByOperation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 

--- a/vm/channel_and_thread_test.go
+++ b/vm/channel_and_thread_test.go
@@ -37,10 +37,11 @@ func TestObjectMutationInThread(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -131,9 +132,10 @@ func TestObjectDeliveryBetweenThread(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -70,10 +70,11 @@ func TestAttrReaderAndWriter(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		//v.checkSP(t, i, 1)
 	}
 }
 
@@ -89,8 +90,8 @@ a = Bar.new()
 	`
 	expected := `InternalError: Module inheritance is not supported: Foo`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 
 	if !isError(evaluated) {
 		t.Fatalf("Should return an error when a class inherits a module")
@@ -101,7 +102,8 @@ a = Bar.new()
 	if err.Message != expected {
 		t.Fatalf("Error message should be '%s'. got: %s", expected, err.Message)
 	}
-	vm.checkCFP(t, 0, 1)
+	v.checkCFP(t, 0, 1)
+	v.checkSP(t, 0, 1)
 }
 
 func TestClassInstanceVariable(t *testing.T) {
@@ -128,14 +130,15 @@ func TestClassInstanceVariable(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
-func TestEvalCustomConstructor(t *testing.T) {
+func TestCustomClassConstructor(t *testing.T) {
 	input := `
 		class Foo
 			def initialize(x, y)
@@ -152,13 +155,14 @@ func TestEvalCustomConstructor(t *testing.T) {
 		f.bar
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	checkExpected(t, 0, evaluated, 30)
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
-func TestDefSingletonMethtod(t *testing.T) {
+func TestDefClassMethod(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected int
@@ -184,14 +188,15 @@ func TestDefSingletonMethtod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
-func TestMonkeyPatchBuiltInClass(t *testing.T) {
+func TestBuiltInClassMonkeyPatching(t *testing.T) {
 	input := `
 	class String
 	  def buz
@@ -202,13 +207,14 @@ func TestMonkeyPatchBuiltInClass(t *testing.T) {
 	"123".buz
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	checkExpected(t, 0, evaluated, "buz")
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
-func TestNamespace(t *testing.T) {
+func TestClassNamespace(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected int
@@ -383,10 +389,11 @@ func TestNamespace(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -440,10 +447,11 @@ func TestPrimitiveType(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -458,10 +466,11 @@ func TestRequireRelative(t *testing.T) {
 	end
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	checkExpected(t, 0, evaluated, 160)
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestRequireSuccess(t *testing.T) {
@@ -470,10 +479,11 @@ func TestRequireSuccess(t *testing.T) {
 
 	File.extname("foo.rb")
 	`
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	checkExpected(t, 0, evaluated, ".rb")
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestRequireFail(t *testing.T) {
@@ -482,8 +492,8 @@ func TestRequireFail(t *testing.T) {
 	`
 	expected := `InternalError: Can't require "bar"`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 
 	if !isError(evaluated) {
 		t.Fatalf("Should return an error")
@@ -493,7 +503,8 @@ func TestRequireFail(t *testing.T) {
 	if err.Message != expected {
 		t.Fatalf("Error message should be '%s'. got: %s", expected, err.Message)
 	}
-	vm.checkCFP(t, 0, 1)
+	v.checkCFP(t, 0, 1)
+	v.checkSP(t, 0, 1)
 }
 
 func TestGeneralIsNilMethod(t *testing.T) {
@@ -512,10 +523,11 @@ func TestGeneralIsNilMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -532,10 +544,11 @@ func TestGeneralIsNilMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, ArgumentError, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -571,10 +584,11 @@ func TestClassGeneralComparisonOperation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -599,10 +613,11 @@ func TestGeneralAssignmentByOperation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -645,10 +660,11 @@ func TestGeneralIsAMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -667,10 +683,11 @@ func TestGeneralIsAMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -690,10 +707,11 @@ func TestClassNameClassMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -711,10 +729,11 @@ func TestClassNameClassMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -741,10 +760,11 @@ func TestClassSuperclassClassMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -762,10 +782,11 @@ func TestClassSuperclassClassMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -788,9 +809,10 @@ func TestClassSingletonClassClassMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -364,7 +364,6 @@ func TestClassNamespace(t *testing.T) {
 
 		Object::Foo.bar
 		`, 10},
-
 		{`
 		Foo = 10
 

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -9,6 +9,17 @@ func TestAttrReaderAndWriter(t *testing.T) {
 	}{
 		{`
 		class Foo
+		  attr_writer :bar
+		  attr_reader :bar
+		end
+
+		f = Foo.new
+		f.bar = 10
+		f.bar
+
+		`, 10},
+		{`
+		class Foo
 		  attr_reader :bar
 
 		  def set_bar(bar)
@@ -28,17 +39,6 @@ func TestAttrReaderAndWriter(t *testing.T) {
 		  def bar
 		    @bar
 		  end
-		end
-
-		f = Foo.new
-		f.bar = 10
-		f.bar
-
-		`, 10},
-		{`
-		class Foo
-		  attr_writer :bar
-		  attr_reader :bar
 		end
 
 		f = Foo.new
@@ -74,7 +74,7 @@ func TestAttrReaderAndWriter(t *testing.T) {
 		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
-		//v.checkSP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -34,10 +34,11 @@ func TestUndefinedMethodError(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, UndefinedMethodError, tt.errorMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 
 }
@@ -56,10 +57,11 @@ func TestUnsupportedMethodError(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, UnsupportedMethodError, tt.errorMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -109,10 +111,11 @@ func TestArgumentError(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, ArgumentError, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -1301,8 +1301,8 @@ func TestAssignmentByOperationEvaluation(t *testing.T) {
 
 func TestIfExpressionEvaluation(t *testing.T) {
 	tests := []struct {
-		input      string
-		expected   interface{}
+		input    string
+		expected interface{}
 	}{
 		{
 			`
@@ -1397,80 +1397,80 @@ func TestClassInheritance(t *testing.T) {
 
 func TestMultiVarAssignment(t *testing.T) {
 	tests := []struct {
-		input      string
-		expected   interface{}
+		input    string
+		expected interface{}
 	}{
 		{`
 		a, b = [1, 2]
 		a
 		`,
-			1,},
+			1},
 		{`
 		a, b = [1, 2]
 		b
 		`,
-			2,},
+			2},
 
 		{`
 		a, b, c = [1, 2, 3]
 		c
 		`,
-			3,},
+			3},
 		{`
 		a, b, c = [1]
 		b
 		`,
-			nil,},
+			nil},
 		{`
 		a, b, c = [1]
 		c
 		`,
-			nil,},
+			nil},
 		{`
 		arr = [1, 2, 3]
 		a, b, c = arr
 		b
-		`, 2,},
+		`, 2},
 		{`
 		arr = [1, 2, 3]
 		a, b, c = arr
 		c
-		`, 3,},
+		`, 3},
 		{`
 		arr = [1]
 		a, b, c = arr
 		a
-		`, 1,},
+		`, 1},
 		{`
 		arr = [1]
 		a, b, c = arr
 		b
-		`, nil,},
+		`, nil},
 		{`
 		arr = [1]
 		a, b, c = arr
 		c
-		`, nil,},
+		`, nil},
 		{`
 		arr = [1]
 		a, b, c, d = arr
 		d
-		`, nil,},
+		`, nil},
 		{`
 		arr = [1, 2, 3]
 		@a, @b, c = arr
 		@a
-		`, 1,},
+		`, 1},
 		{`
 		arr = [1, 2, 3]
 		@a, @b, c = arr
 		@b
-		`, 2,},
+		`, 2},
 		{`
 		arr = [1, 2, 3]
 		@a, @b, c = arr
 		c
-		`, 3,},
+		`, 3},
 		{`
 		class Foo
 		  attr_reader :a, :b, :c
@@ -1485,7 +1485,7 @@ func TestMultiVarAssignment(t *testing.T) {
 
 		f.bar([10, 100, 200])
 		f.a
-		`, 10,},
+		`, 10},
 		{`
 		class Foo
 		  attr_reader :a, :b, :c
@@ -1500,7 +1500,7 @@ func TestMultiVarAssignment(t *testing.T) {
 
 		f.bar([10, 100, 200])
 		f.b
-		`, 100,},
+		`, 100},
 		{`
 		class Foo
 		  attr_reader :a, :b, :c
@@ -1515,7 +1515,7 @@ func TestMultiVarAssignment(t *testing.T) {
 
 		f.bar([10, 100, 200])
 		f.c
-		`, 310,},
+		`, 310},
 	}
 
 	for i, tt := range tests {

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -1214,70 +1214,70 @@ func TestInstanceVariableEvaluation(t *testing.T) {
 	}
 }
 
-func TestAssignmentEvaluation(t *testing.T) {
-	tests := []struct {
-		input         string
-		expectedValue int
-	}{
-		{"a = 5; a;", 5},
-		{"a = 5 * 5; a;", 25},
-		{"a = 5; b = a; b;", 5},
-		{"a = 5; b = a; c = a + b + 5; c;", 15},
-		{"a = 5; b = 10; c = if a > b; 100 else 50 end; c", 50},
-		{"Bar = 100; Bar", 100},
-		{`
-		a = 100
-		b = a
-		b = 1000
-		a
-		`, 100},
-		{`
-		a = 100
-		b = a
-		a = 1000
-		b
-		`, 100},
-		{`
-		i = 0
-
-		if a = 10
-		  i = 100
-		end
-
-		i + a
-		`, 110},
-		{`
-		i = 0
-
-		if @a = 10
-		  i = 100
-		end
-
-		i + @a
-		`, 110},
-		{`a = b = 10; a`, 10},
-		{`a = b = c = 10; a`, 10},
-		{`
-		i = 100
-		a = b = i + 10
-		a + b
-		`, 220},
-		{`
-		def foo(x)
-		  x
-		end
-
-		foo(a = b = c = d = 10)
-		`, 10},
-	}
-
-	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
-		testIntegerObject(t, i, evaluated, tt.expectedValue)
-		vm.checkCFP(t, 0, 0)
-	}
-}
+//func TestAssignmentEvaluation(t *testing.T) {
+//	tests := []struct {
+//		input         string
+//		expectedValue int
+//	}{
+//		{"a = 5; a;", 5},
+//		{"a = 5 * 5; a;", 25},
+//		{"a = 5; b = a; b;", 5},
+//		{"a = 5; b = a; c = a + b + 5; c;", 15},
+//		{"a = 5; b = 10; c = if a > b; 100 else 50 end; c", 50},
+//		{"Bar = 100; Bar", 100},
+//		{`
+//		a = 100
+//		b = a
+//		b = 1000
+//		a
+//		`, 100},
+//		{`
+//		a = 100
+//		b = a
+//		a = 1000
+//		b
+//		`, 100},
+//		{`
+//		i = 0
+//
+//		if a = 10
+//		  i = 100
+//		end
+//
+//		i + a
+//		`, 110},
+//		{`
+//		i = 0
+//
+//		if @a = 10
+//		  i = 100
+//		end
+//
+//		i + @a
+//		`, 110},
+//		{`a = b = 10; a`, 10},
+//		{`a = b = c = 10; a`, 10},
+//		{`
+//		i = 100
+//		a = b = i + 10
+//		a + b
+//		`, 220},
+//		{`
+//		def foo(x)
+//		  x
+//		end
+//
+//		foo(a = b = c = d = 10)
+//		`, 10},
+//	}
+//
+//	for i, tt := range tests {
+//		vm := initTestVM()
+//		evaluated := vm.testEval(t, tt.input)
+//		testIntegerObject(t, i, evaluated, tt.expectedValue)
+//		vm.checkCFP(t, 0, 0)
+//	}
+//}
 
 func TestAssignmentByOperationEvaluation(t *testing.T) {
 	tests := []struct {

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -40,10 +40,11 @@ func TestComplexEvaluation(t *testing.T) {
 	Baz::Bar.new.bar + a
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	testIntegerObject(t, 0, evaluated, 310)
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestComment(t *testing.T) {
@@ -66,10 +67,11 @@ func TestComment(t *testing.T) {
 	Foo.new.one #=> Comment
 	# Comment`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	testIntegerObject(t, 0, evaluated, 1)
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestMethodCall(t *testing.T) {
@@ -278,15 +280,16 @@ func TestMethodCall(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 
 		if isError(evaluated) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).Message)
 		}
 
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -333,10 +336,11 @@ func TestMethodCallWithDefaultArgValue(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -483,10 +487,11 @@ func TestMethodCallWithBlockArgument(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -588,10 +593,11 @@ func TestMethodCallWithNestedBlock(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -824,15 +830,16 @@ func TestMethodCallWithoutParens(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 
 		if isError(evaluated) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).Message)
 		}
 
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -945,10 +952,11 @@ func TestClassMethodCall(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -978,8 +986,8 @@ func TestInstanceMethodCall(t *testing.T) {
 		fb.add(10, fb.get)
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 
 	if isError(evaluated) {
 		t.Fatalf("got Error: %s", evaluated.(*Error).Message)
@@ -995,7 +1003,8 @@ func TestInstanceMethodCall(t *testing.T) {
 		t.Errorf("expect result to be 110. got=%d", result.Value)
 	}
 
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestPostfixMethodCall(t *testing.T) {
@@ -1029,10 +1038,11 @@ func TestPostfixMethodCall(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1050,10 +1060,11 @@ func TestBangPrefixMethodCall(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1069,10 +1080,11 @@ func TestMinusPrefixMethodCall(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1130,15 +1142,16 @@ func TestSelfExpressionEvaluation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 
 		if isError(evaluated) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).Message)
 		}
 
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1202,82 +1215,84 @@ func TestInstanceVariableEvaluation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 
 		if isError(evaluated) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).Message)
 		}
 
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
-//func TestAssignmentEvaluation(t *testing.T) {
-//	tests := []struct {
-//		input         string
-//		expectedValue int
-//	}{
-//		{"a = 5; a;", 5},
-//		{"a = 5 * 5; a;", 25},
-//		{"a = 5; b = a; b;", 5},
-//		{"a = 5; b = a; c = a + b + 5; c;", 15},
-//		{"a = 5; b = 10; c = if a > b; 100 else 50 end; c", 50},
-//		{"Bar = 100; Bar", 100},
-//		{`
-//		a = 100
-//		b = a
-//		b = 1000
-//		a
-//		`, 100},
-//		{`
-//		a = 100
-//		b = a
-//		a = 1000
-//		b
-//		`, 100},
-//		{`
-//		i = 0
-//
-//		if a = 10
-//		  i = 100
-//		end
-//
-//		i + a
-//		`, 110},
-//		{`
-//		i = 0
-//
-//		if @a = 10
-//		  i = 100
-//		end
-//
-//		i + @a
-//		`, 110},
-//		{`a = b = 10; a`, 10},
-//		{`a = b = c = 10; a`, 10},
-//		{`
-//		i = 100
-//		a = b = i + 10
-//		a + b
-//		`, 220},
-//		{`
-//		def foo(x)
-//		  x
-//		end
-//
-//		foo(a = b = c = d = 10)
-//		`, 10},
-//	}
-//
-//	for i, tt := range tests {
-//		vm := initTestVM()
-//		evaluated := vm.testEval(t, tt.input)
-//		testIntegerObject(t, i, evaluated, tt.expectedValue)
-//		vm.checkCFP(t, 0, 0)
-//	}
-//}
+func TestAssignmentEvaluation(t *testing.T) {
+	tests := []struct {
+		input         string
+		expectedValue int
+	}{
+		{"a = 5; a;", 5},
+		{"a = 5 * 5; a;", 25},
+		{"a = 5; b = a; b;", 5},
+		{"a = 5; b = a; c = a + b + 5; c;", 15},
+		{"a = 5; b = 10; c = if a > b; 100 else 50 end; c", 50},
+		{"Bar = 100; Bar", 100},
+		{`
+		a = 100
+		b = a
+		b = 1000
+		a
+		`, 100},
+		{`
+		a = 100
+		b = a
+		a = 1000
+		b
+		`, 100},
+		{`
+		i = 0
+
+		if a = 10
+		  i = 100
+		end
+
+		i + a
+		`, 110},
+		{`
+		i = 0
+
+		if @a = 10
+		  i = 100
+		end
+
+		i + @a
+		`, 110},
+		{`a = b = 10; a`, 10},
+		{`a = b = c = 10; a`, 10},
+		{`
+		i = 100
+		a = b = i + 10
+		a + b
+		`, 220},
+		{`
+		def foo(x)
+		  x
+		end
+
+		foo(a = b = c = d = 10)
+		`, 10},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
+		testIntegerObject(t, i, evaluated, tt.expectedValue)
+		v.checkCFP(t, 0, 0)
+		v.checkSP(t, i, 1)
+	}
+}
 
 func TestAssignmentByOperationEvaluation(t *testing.T) {
 	tests := []struct {
@@ -1292,10 +1307,11 @@ func TestAssignmentByOperationEvaluation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expectedValue)
-		vm.checkCFP(t, 0, 0)
+		v.checkCFP(t, 0, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1367,11 +1383,11 @@ func TestIfExpressionEvaluation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
-		vm.checkSP(t, i, 1)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1388,11 +1404,12 @@ func TestClassInheritance(t *testing.T) {
 
 		Foo.superclass.name
 	`
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 
 	testStringObject(t, 0, evaluated, "Bar")
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestMultiVarAssignment(t *testing.T) {
@@ -1519,10 +1536,10 @@ func TestMultiVarAssignment(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
-		vm.checkSP(t, i, 1)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -1303,7 +1303,6 @@ func TestIfExpressionEvaluation(t *testing.T) {
 	tests := []struct {
 		input      string
 		expected   interface{}
-		expectedSP int
 	}{
 		{
 			`
@@ -1314,7 +1313,6 @@ func TestIfExpressionEvaluation(t *testing.T) {
 			end
 			`,
 			100,
-			1,
 		},
 		{
 			`
@@ -1325,29 +1323,27 @@ func TestIfExpressionEvaluation(t *testing.T) {
 			end
 			`,
 			true,
-			1,
 		},
 		{`
 		if true
 		   10
 		end`,
 			10,
-			1,
 		},
-		{"if false; 10 end", nil, 1},
-		{"if 1; 10; end", 10, 1},
-		{"if 1 < 2; 10 end", 10, 1},
-		{"if 1 > 2; 10 end", nil, 1},
-		{"if 1 > 2; 10 else 20 end", 20, 1},
-		{"if 1 < 2; 10 else 20 end", 10, 1},
-		{"if nil; 10 else 20 end", 20, 1},
+		{"if false; 10 end", nil},
+		{"if 1; 10; end", 10},
+		{"if 1 < 2; 10 end", 10},
+		{"if 1 > 2; 10 end", nil},
+		{"if 1 > 2; 10 else 20 end", 20},
+		{"if 1 < 2; 10 else 20 end", 10},
+		{"if nil; 10 else 20 end", 20},
 		{`
 		if false
 		  x = 1
 		end # This pushes nil
 
 		x # This pushes nil too
-		`, nil, 2},
+		`, nil},
 		{`
 		def foo
 		  if false
@@ -1356,7 +1352,7 @@ func TestIfExpressionEvaluation(t *testing.T) {
 		end
 
 		foo # This should push nil
-		`, nil, 1},
+		`, nil},
 		{`
 		def foo
 		  x = 0
@@ -1367,7 +1363,7 @@ func TestIfExpressionEvaluation(t *testing.T) {
 		end
 
 		foo # This should push nil
-		`, 1, 1},
+		`, 1},
 	}
 
 	for i, tt := range tests {
@@ -1375,7 +1371,7 @@ func TestIfExpressionEvaluation(t *testing.T) {
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
-		vm.checkSP(t, i, tt.expectedSP)
+		vm.checkSP(t, i, 1)
 	}
 }
 
@@ -1403,93 +1399,78 @@ func TestMultiVarAssignment(t *testing.T) {
 	tests := []struct {
 		input      string
 		expected   interface{}
-		expectedSP int
 	}{
 		{`
 		a, b = [1, 2]
 		a
 		`,
-			1,
-			1},
+			1,},
 		{`
 		a, b = [1, 2]
 		b
 		`,
-			2,
-			1},
+			2,},
 
 		{`
 		a, b, c = [1, 2, 3]
 		c
 		`,
-			3,
-			1},
+			3,},
 		{`
 		a, b, c = [1]
 		b
 		`,
-			nil,
-			1},
+			nil,},
 		{`
 		a, b, c = [1]
 		c
 		`,
-			nil,
-			1},
+			nil,},
 		{`
 		arr = [1, 2, 3]
 		a, b, c = arr
 		b
-		`, 2,
-			1},
+		`, 2,},
 		{`
 		arr = [1, 2, 3]
 		a, b, c = arr
 		c
-		`, 3,
-			1},
+		`, 3,},
 		{`
 		arr = [1]
 		a, b, c = arr
 		a
-		`, 1,
-			1},
+		`, 1,},
 		{`
 		arr = [1]
 		a, b, c = arr
 		b
-		`, nil,
-			1},
+		`, nil,},
 		{`
 		arr = [1]
 		a, b, c = arr
 		c
-		`, nil,
-			1},
+		`, nil,},
 		{`
 		arr = [1]
 		a, b, c, d = arr
 		d
-		`, nil,
-			1},
+		`, nil,},
 		{`
 		arr = [1, 2, 3]
 		@a, @b, c = arr
 		@a
-		`, 1,
-			1},
+		`, 1,},
 		{`
 		arr = [1, 2, 3]
 		@a, @b, c = arr
 		@b
-		`, 2,
-			1},
+		`, 2,},
 		{`
 		arr = [1, 2, 3]
 		@a, @b, c = arr
 		c
-		`, 3,
-			1},
+		`, 3,},
 		{`
 		class Foo
 		  attr_reader :a, :b, :c
@@ -1504,8 +1485,7 @@ func TestMultiVarAssignment(t *testing.T) {
 
 		f.bar([10, 100, 200])
 		f.a
-		`, 10,
-			3},
+		`, 10,},
 		{`
 		class Foo
 		  attr_reader :a, :b, :c
@@ -1520,8 +1500,7 @@ func TestMultiVarAssignment(t *testing.T) {
 
 		f.bar([10, 100, 200])
 		f.b
-		`, 100,
-			3},
+		`, 100,},
 		{`
 		class Foo
 		  attr_reader :a, :b, :c
@@ -1536,8 +1515,7 @@ func TestMultiVarAssignment(t *testing.T) {
 
 		f.bar([10, 100, 200])
 		f.c
-		`, 310,
-			3},
+		`, 310,},
 	}
 
 	for i, tt := range tests {
@@ -1545,6 +1523,6 @@ func TestMultiVarAssignment(t *testing.T) {
 		evaluated := vm.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
-		vm.checkSP(t, i, tt.expectedSP)
+		vm.checkSP(t, i, 1)
 	}
 }

--- a/vm/file_test.go
+++ b/vm/file_test.go
@@ -46,10 +46,11 @@ func TestFileObject(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -65,10 +66,11 @@ func TestFileBasenameMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -96,10 +98,11 @@ func TestFileDeleteMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -119,10 +122,11 @@ func TestFileExtnameMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -146,10 +150,11 @@ func TestFileJoinMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -192,10 +197,11 @@ func TestFileWriteMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -206,10 +212,11 @@ func TestFileSizeMethod(t *testing.T) {
 	File.size("../test_fixtures/file_test/size.gb")
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	checkExpected(t, 0, evaluated, 22)
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestFileSplitMethod(t *testing.T) {
@@ -224,10 +231,11 @@ func TestFileSplitMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -12,8 +12,8 @@ func TestEvalHashExpression(t *testing.T) {
 	{ foo: 123, bar: "test", baz: true }
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 
 	h, ok := evaluated.(*HashObject)
 	if !ok {
@@ -31,7 +31,8 @@ func TestEvalHashExpression(t *testing.T) {
 		}
 	}
 
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestHashAccessOperation(t *testing.T) {
@@ -100,10 +101,11 @@ func TestHashAccessOperation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -119,42 +121,11 @@ func TestHashAccessOperationFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
-	}
-}
-
-func JSONBytesEqual(a, b []byte) (bool, error) {
-	var j, j2 interface{}
-	if err := json.Unmarshal(a, &j); err != nil {
-		return false, err
-	}
-	if err := json.Unmarshal(b, &j2); err != nil {
-		return false, err
-	}
-	return reflect.DeepEqual(j2, j), nil
-}
-
-// We can't compare string directly because the key/value's order might change and we can't control it.
-func compareJSONResult(t *testing.T, evaluated Object, exp interface{}) {
-	expected, err := json.Marshal(exp)
-
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	s := evaluated.(*StringObject).Value
-
-	r, err := JSONBytesEqual([]byte(s), expected)
-
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	if !r {
-		t.Fatalf("Expect json:\n%s \n\n got: %s", string(expected), s)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -194,10 +165,11 @@ func TestHashComparisonOperation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -206,8 +178,8 @@ func TestHashClearMethod(t *testing.T) {
 	{ foo: 123, bar: "test", baz: true }.clear
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 
 	h, ok := evaluated.(*HashObject)
 	if !ok {
@@ -216,7 +188,8 @@ func TestHashClearMethod(t *testing.T) {
 		t.Fatalf("Expect length of pairs of hash to be 0. got: %v", h.length())
 	}
 
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestHashClearMethodFail(t *testing.T) {
@@ -230,10 +203,11 @@ func TestHashClearMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -267,10 +241,11 @@ func TestHashEachKeyMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -292,10 +267,11 @@ func TestHashEachKeyMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, tt.expectedCfp)
+		v.checkCFP(t, i, tt.expectedCfp)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -322,10 +298,11 @@ func TestHashEachValueMethod(t *testing.T) {
 	}
 
 	for i, tt := range hashTests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 
 	normalTests := []struct {
@@ -356,10 +333,11 @@ func TestHashEachValueMethod(t *testing.T) {
 	}
 
 	for i, tt := range normalTests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -381,10 +359,11 @@ func TestHashEachValueMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, tt.expectedCfp)
+		v.checkCFP(t, i, tt.expectedCfp)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -398,10 +377,11 @@ func TestHashEmptyMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -416,10 +396,11 @@ func TestHashEmptyMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -443,10 +424,11 @@ func TestHashEqualMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -461,10 +443,11 @@ func TestHashEqualMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -512,10 +495,11 @@ func TestHashDeleteMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -532,10 +516,11 @@ func TestHashDeleteMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -549,10 +534,11 @@ func TestHashHasKeyMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -569,10 +555,11 @@ func TestHashHasKeyMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -591,10 +578,11 @@ func TestHashHasValueMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -609,10 +597,11 @@ func TestHashHasValueMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -621,8 +610,8 @@ func TestHashKeysMethod(t *testing.T) {
 	{ foo: 123, bar: "test", baz: true }.keys
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 
 	arr, ok := evaluated.(*ArrayObject)
 	if !ok {
@@ -640,7 +629,8 @@ func TestHashKeysMethod(t *testing.T) {
 		t.Fatalf("Expect evaluated array to be [\"bar\", \"baz\", \"foo\". got: %v", evaluatedArr)
 	}
 
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestHashKeysMethodFail(t *testing.T) {
@@ -654,10 +644,11 @@ func TestHashKeysMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -675,10 +666,11 @@ func TestHashLengthMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -693,10 +685,11 @@ func TestHashLengthMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -750,10 +743,11 @@ func TestHashMapValuesMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -775,10 +769,11 @@ func TestHashMapValuesMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, tt.expectedCfp)
+		v.checkCFP(t, i, tt.expectedCfp)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -788,9 +783,9 @@ func TestHashMergeMethod(t *testing.T) {
 		`{ b: 123, d: false }.merge({ a: "Hello", c: 123 }, { b: true, d: ["World"] }, { d: ["World", 456, false] })`,
 	}
 
-	for i, v := range input {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, v)
+	for i, value := range input {
+		v := initTestVM()
+		evaluated := v.testEval(t, value)
 
 		h, ok := evaluated.(*HashObject)
 		if !ok {
@@ -810,7 +805,8 @@ func TestHashMergeMethod(t *testing.T) {
 			}
 		}
 
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -826,10 +822,11 @@ func TestHashMergeMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -846,10 +843,11 @@ func TestHashSortedKeysMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -864,10 +862,11 @@ func TestHashSortedKeysMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -885,18 +884,19 @@ func TestHashToArrayMethod(t *testing.T) {
 	}
 
 	for i, tt := range testsSortedArray {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		testArrayObject(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 
 	input := `
 	{ a: 123, b: "test", c: true, d: [1, "Goby", false] }.to_a
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 
 	arr, ok := evaluated.(*ArrayObject)
 	if !ok {
@@ -923,7 +923,7 @@ func TestHashToArrayMethod(t *testing.T) {
 			testArrayObject(t, 0, v, []interface{}{1, "Goby", false})
 		}
 	}
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
 }
 
 func TestHashToArrayMethodFail(t *testing.T) {
@@ -937,10 +937,11 @@ func TestHashToArrayMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -976,10 +977,11 @@ func TestHashToJSONMethodWithArray(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		compareJSONResult(t, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1025,10 +1027,11 @@ func TestHashToJSONMethodWithNestedHash(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		compareJSONResult(t, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1085,10 +1088,11 @@ func TestHashToJSONMethodWithBasicTypes(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		compareJSONResult(t, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1103,10 +1107,11 @@ func TestHashToJSONMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1121,10 +1126,11 @@ func TestHashToStringMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1139,10 +1145,11 @@ func TestHashToStringMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1196,10 +1203,11 @@ func TestHashTransformValuesMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1221,10 +1229,11 @@ func TestHashTransformValuesMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, tt.expectedCfp)
+		v.checkCFP(t, i, tt.expectedCfp)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -1233,8 +1242,8 @@ func TestHashValuesMethod(t *testing.T) {
 	{ a: 123, b: "test", c: true, d: [1, "Goby", false] }.values
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 
 	arr, ok := evaluated.(*ArrayObject)
 	if !ok {
@@ -1255,7 +1264,8 @@ func TestHashValuesMethod(t *testing.T) {
 			testArrayObject(t, 0, v, []interface{}{1, "Goby", false})
 		}
 	}
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestHashValuesMethodFail(t *testing.T) {
@@ -1269,9 +1279,42 @@ func TestHashValuesMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func JSONBytesEqual(a, b []byte) (bool, error) {
+	var j, j2 interface{}
+	if err := json.Unmarshal(a, &j); err != nil {
+		return false, err
+	}
+	if err := json.Unmarshal(b, &j2); err != nil {
+		return false, err
+	}
+	return reflect.DeepEqual(j2, j), nil
+}
+
+// We can't compare string directly because the key/value's order might change and we can't control it.
+func compareJSONResult(t *testing.T, evaluated Object, exp interface{}) {
+	expected, err := json.Marshal(exp)
+
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	s := evaluated.(*StringObject).Value
+
+	r, err := JSONBytesEqual([]byte(s), expected)
+
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if !r {
+		t.Fatalf("Expect json:\n%s \n\n got: %s", string(expected), s)
 	}
 }

--- a/vm/http_request_test.go
+++ b/vm/http_request_test.go
@@ -31,9 +31,10 @@ func TestHTTPRequestObject(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/http_response_test.go
+++ b/vm/http_response_test.go
@@ -19,10 +19,11 @@ func TestHTTPResponseObject(t *testing.T) {
 	res.body
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	checkExpected(t, 0, evaluated, "test")
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestNormalGetResponse(t *testing.T) {
@@ -39,10 +40,11 @@ require "net/http"
 Net::HTTP.get("%s")
 `, ts.URL)
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, testScript)
+	v := initTestVM()
+	evaluated := v.testEval(t, testScript)
 	checkExpected(t, 0, evaluated, expected)
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestNormalGetResponseWithPath(t *testing.T) {
@@ -64,8 +66,9 @@ require "net/http"
 Net::HTTP.get("%s", "path")
 `, ts.URL)
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, testScript)
+	v := initTestVM()
+	evaluated := v.testEval(t, testScript)
 	checkExpected(t, 0, evaluated, expected)
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -369,7 +369,8 @@ var builtInActions = map[operationType]*action{
 			method = receiver.findMethod(methodName)
 
 			if method == nil {
-				t.UndefinedMethodError(methodName, receiver)
+
+				t.UndefinedMethodError(methodName, receiver, receiverPr)
 				return
 			}
 

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -33,10 +33,11 @@ func TestIntegerArithmeticOperation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -60,10 +61,11 @@ func TestIntegerArithmeticOperationFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, TypeError, tt.expected)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -104,10 +106,11 @@ func TestIntegerComparison(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -134,10 +137,11 @@ func TestIntegerComparisonFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, TypeError, tt.expected)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -151,10 +155,11 @@ func TestIntegerConversion(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -168,10 +173,11 @@ func TestIntegerEvenMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -185,10 +191,11 @@ func TestIntegerNextMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -202,10 +209,11 @@ func TestIntegerOddMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -219,10 +227,11 @@ func TestIntegerPredMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -240,10 +249,11 @@ func TestIntegerTimesMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -261,8 +271,8 @@ func TestIntegerTimesMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		err, ok := evaluated.(*Error)
 		if !ok {
 			t.Errorf("Expect error. got=%T (%+v)", err, err)
@@ -270,6 +280,7 @@ func TestIntegerTimesMethodFail(t *testing.T) {
 		if err.Message != tt.expected.Message {
 			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
 		}
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/null_test.go
+++ b/vm/null_test.go
@@ -5,10 +5,11 @@ import "testing"
 func TestEvalNil(t *testing.T) {
 	input := `nil`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	checkExpected(t, 0, evaluated, nil)
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestBangPrefix(t *testing.T) {
@@ -17,10 +18,11 @@ func TestBangPrefix(t *testing.T) {
 	!a
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	checkExpected(t, 0, evaluated, true)
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestNullComparisonOperation(t *testing.T) {
@@ -37,10 +39,11 @@ func TestNullComparisonOperation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -60,10 +63,11 @@ func TestNullIsNilMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -87,10 +91,11 @@ func TestNullAssignmentByOperation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -104,9 +109,10 @@ func TestNullIsNilMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/plugin_test.go
+++ b/vm/plugin_test.go
@@ -16,12 +16,13 @@ func TestCallingPluginFunction(t *testing.T) {
 	p.send("Baz")
 	`
 
-	vm := initTestVM()
+	v := initTestVM()
 	// We don't test the result here for two reasons:
 	// - If it doesn't work it'll returns error or panic
 	// - It's hard to test a plugin obj
-	vm.testEval(t, input)
-	vm.checkCFP(t, 0, 0)
+	v.testEval(t, input)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestCallingPluginFunctionWithReturnValue(t *testing.T) {
@@ -32,10 +33,11 @@ func TestCallingPluginFunctionWithReturnValue(t *testing.T) {
 	p.send("Bar")
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	checkExpected(t, 0, evaluated, "Bar")
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func skipPluginTestIfEnvNotSet(t *testing.T) {

--- a/vm/range_test.go
+++ b/vm/range_test.go
@@ -28,10 +28,11 @@ func TestRangeComparisonOperation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -169,15 +170,16 @@ func TestRangeBsearchMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
 func TestRangeBsearchMethodFail(t *testing.T) {
-	vm := initTestVM()
+	v := initTestVM()
 	testsFail := []struct {
 		input    string
 		errorMsg string
@@ -191,9 +193,10 @@ func TestRangeBsearchMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		evaluated := vm.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, TypeError, tt.errorMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -248,10 +251,11 @@ func TestRangeEachMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -275,10 +279,11 @@ func TestRangeFirstMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -323,10 +328,11 @@ func TestRangeIncludeMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -350,10 +356,11 @@ func TestRangeLastMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -377,10 +384,11 @@ func TestRangeSizeMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -436,10 +444,11 @@ func TestRangeStepMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -463,10 +472,11 @@ func TestRangeToStringMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -496,9 +506,10 @@ func TestRangeToArrayMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/simple_server_test.go
+++ b/vm/simple_server_test.go
@@ -20,10 +20,11 @@ func TestServerInitialization(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -25,10 +25,11 @@ func TestReturnStatementEvaluation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 
 	}
 }
@@ -51,8 +52,8 @@ func TestDefStatement(t *testing.T) {
 		Foo
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	class := evaluated.(*RClass)
 
 	expectedMethods := []struct {
@@ -80,7 +81,8 @@ func TestDefStatement(t *testing.T) {
 		}
 	}
 
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestModuleStatement(t *testing.T) {
@@ -191,10 +193,11 @@ func TestModuleStatement(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -256,11 +259,11 @@ func TestWhileStatement(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
-		vm.checkSP(t, i, 1)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -306,10 +309,11 @@ i
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -356,9 +360,10 @@ a + 100
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -14,10 +14,11 @@ func TestEvalStringExpression(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -58,10 +59,11 @@ func TestStringConversion(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -101,10 +103,11 @@ func TestStringComparison(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -118,10 +121,11 @@ func TestStringConparisonFail(t *testing.T) {
 		{`"a" <=> 1`, "TypeError: Expect argument to be String. got: Integer"},
 	}
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, TypeError, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -153,10 +157,11 @@ func TestStringOperation(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -176,10 +181,11 @@ func TestStringOperationFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -199,10 +205,11 @@ func TestStringCapitalizeMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -217,10 +224,11 @@ func TestStringChopMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -234,10 +242,11 @@ func TestStringConcatenateMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -255,10 +264,11 @@ func TestStringConcatenateMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -274,10 +284,11 @@ func TestStringCountMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -291,10 +302,11 @@ func TestStringDeleteMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -311,10 +323,11 @@ func TestStringDeleteMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -330,10 +343,11 @@ func TestStringDowncaseMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -353,10 +367,11 @@ func TestStringEndWithMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -373,10 +388,11 @@ func TestStringEndWithMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -390,10 +406,11 @@ func TestStringEmptyMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -412,10 +429,11 @@ func TestStringEqualMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -429,10 +447,11 @@ func TestStringEqualMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, ArgumentError, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -448,10 +467,11 @@ func TestStringGlobalSubstituteMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -468,10 +488,11 @@ func TestStringGlobalSubstituteMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -490,10 +511,11 @@ func TestStringIncludeMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -511,10 +533,11 @@ func TestStringIncludeMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -536,10 +559,11 @@ func TestStringInsertMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -558,10 +582,11 @@ func TestStringInsertMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -577,10 +602,11 @@ func TestStringLeftJustifyMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -601,10 +627,11 @@ func TestStringLeftJustifyMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -619,10 +646,11 @@ func TestStringLengthMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -638,10 +666,11 @@ func TestStringReplaceMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -657,10 +686,11 @@ func TestStringReplaceMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -677,10 +707,11 @@ func TestStringReverseMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -696,10 +727,11 @@ func TestStringRightJustifyMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -720,10 +752,11 @@ func TestStringRightJustifyFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -738,10 +771,11 @@ func TestStringSizeMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -784,10 +818,11 @@ func TestStringSliceMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -803,10 +838,11 @@ func TestStringSliceMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -882,10 +918,11 @@ func TestStringSplitMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -902,10 +939,11 @@ func TestStringSplitMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -925,10 +963,11 @@ func TestStringStartWithMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -945,10 +984,11 @@ func TestStringStartWithMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkError(t, i, evaluated, tt.errType, tt.errMsg)
-		vm.checkCFP(t, i, 1)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -963,10 +1003,11 @@ func TestStringStripMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -982,10 +1023,11 @@ func TestStringUpcaseMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }
 
@@ -998,9 +1040,10 @@ func TestChainingStringMethods(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/struct_test.go
+++ b/vm/struct_test.go
@@ -14,10 +14,11 @@ func TestCallingStructFunctionWithReturnValue(t *testing.T) {
 	result
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	checkExpected(t, 0, evaluated, "xyz!")
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestCallingStructFunctionWithReturnError(t *testing.T) {
@@ -30,10 +31,11 @@ func TestCallingStructFunctionWithReturnError(t *testing.T) {
 	err
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	checkExpected(t, 0, evaluated, nil)
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }
 
 func TestCallingStructFuncWithDifferentType(t *testing.T) {
@@ -45,8 +47,9 @@ func TestCallingStructFuncWithDifferentType(t *testing.T) {
 	bar.send("Add", 10, 100.to_int64) # Add is func(int, int64) int64
 	`
 
-	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	v := initTestVM()
+	evaluated := v.testEval(t, input)
 	checkExpected(t, 0, evaluated, 110)
-	vm.checkCFP(t, 0, 0)
+	v.checkCFP(t, 0, 0)
+	v.checkSP(t, 0, 1)
 }

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -177,9 +177,10 @@ func (t *thread) returnError(errorType, format string, args ...interface{}) {
 	t.stack.push(&Pointer{Target: err})
 }
 
-func (t *thread) UndefinedMethodError(methodName string, receiver Object) {
+func (t *thread) UndefinedMethodError(methodName string, receiver Object, receiverPtr int) {
 	err := t.vm.initErrorObject(UndefinedMethodError, "Undefined Method '%+v' for %+v", methodName, receiver.toString())
-	t.stack.push(&Pointer{Target: err})
+	t.stack.Data[receiverPtr] = &Pointer{Target: err}
+	t.sp = receiverPtr + 1
 }
 
 func (t *thread) UnsupportedMethodError(methodName string, receiver Object) *Error {

--- a/vm/uri_test.go
+++ b/vm/uri_test.go
@@ -83,9 +83,10 @@ func TestURIParsing(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input)
 		checkExpected(t, i, evaluated, tt.expected)
-		vm.checkCFP(t, i, 0)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/goby-lang/goby/compiler"
 	"github.com/goby-lang/goby/compiler/bytecode"
+	"github.com/goby-lang/goby/compiler/parser"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -303,7 +304,7 @@ func (vm *VM) execGobyLib(libName string) {
 }
 
 func (vm *VM) execRequiredFile(filepath string, file []byte) {
-	instructionSets, err := compiler.CompileToInstructions(string(file))
+	instructionSets, err := compiler.CompileToInstructions(string(file), parser.NormalMode)
 
 	if err != nil {
 		fmt.Println(err.Error())

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -117,6 +117,7 @@ foo
 
 		for _, input := range test.inputs {
 			p := parser.New(lexer.New(input))
+			p.Mode = parser.REPLMode
 
 			program, _ := p.ParseProgram()
 			sets := g.GenerateInstructions(program.Statements)

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -106,6 +106,7 @@ foo
 
 		// Initialize parser, lexer is not important here
 		p := parser.New(lexer.New(""))
+		p.Mode = parser.REPLMode
 
 		program, _ := p.ParseProgram()
 
@@ -135,7 +136,7 @@ func initTestVM() *VM {
 }
 
 func (v *VM) testEval(t *testing.T, input string) Object {
-	iss, err := compiler.CompileToInstructions(input)
+	iss, err := compiler.CompileToInstructions(input, parser.TestMode)
 
 	if err != nil {
 		t.Errorf("Error when compiling input: %s", input)


### PR DESCRIPTION
## Goal
Currently parser and code generator both have state machine to determine if an expression should be popped or not. I want to move all these logic into parser, which should make code generator far more cleaner.

### Changes
- Make parser's logic more readable.
- Successfully make all unused expression's value to be popped.
- Add stack pointer check to all VM tests to prevent above optimization's regression.
- Rename all the `vm` variable in vm tests to `v`.

This closes #221 