### PR TITLE
Remove mutation methods like ++ and --

### DIFF
--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -137,29 +137,6 @@ func (ie *InfixExpression) String() string {
 	return out.String()
 }
 
-// MultiVariableExpression is not really an expression, it's just a container that holds multiple Variables
-type MultiVariableExpression struct {
-	*BaseNode
-	Variables []Variable
-}
-
-func (m *MultiVariableExpression) expressionNode() {}
-func (m *MultiVariableExpression) TokenLiteral() string {
-	return ""
-}
-func (m *MultiVariableExpression) String() string {
-	var out bytes.Buffer
-	var variables []string
-
-	for _, v := range m.Variables {
-		variables = append(variables, v.String())
-	}
-
-	out.WriteString(strings.Join(variables, ", "))
-
-	return out.String()
-}
-
 // AssignExpression represents variable assignment in Goby.
 type AssignExpression struct {
 	*BaseNode

--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -163,7 +163,7 @@ func (m *MultiVariableExpression) String() string {
 // AssignExpression represents variable assignment in Goby.
 type AssignExpression struct {
 	*BaseNode
-	Variables []Variable
+	Variables []Expression
 	Value     Expression
 	// Optioned attribute is only used when infix expression is local assignment in params.
 	// For example: `foo(x = 10)`'s `x = 10` is an optioned assign expression

--- a/compiler/ast/variables.go
+++ b/compiler/ast/variables.go
@@ -1,10 +1,38 @@
 package ast
 
+import (
+	"bytes"
+	"strings"
+)
+
 // Variable interface represents assignable nodes in Goby, currently are Identifier, InstanceVariable and Constant
 type Variable interface {
 	variableNode()
 	ReturnValue() string
 	Expression
+}
+
+// MultiVariableExpression is not really an expression, it's just a container that holds multiple Variables
+type MultiVariableExpression struct {
+	*BaseNode
+	Variables []Expression
+}
+
+func (m *MultiVariableExpression) expressionNode() {}
+func (m *MultiVariableExpression) TokenLiteral() string {
+	return ""
+}
+func (m *MultiVariableExpression) String() string {
+	var out bytes.Buffer
+	var variables []string
+
+	for _, v := range m.Variables {
+		variables = append(variables, v.String())
+	}
+
+	out.WriteString(strings.Join(variables, ", "))
+
+	return out.String()
 }
 
 type Identifier struct {

--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -94,11 +94,6 @@ func (g *Generator) compileCallExpression(is *InstructionSet, exp *ast.CallExpre
 		return
 	}
 	is.define(Send, exp.Method, len(exp.Arguments))
-
-	if exp.Method == "++" || exp.Method == "--" {
-		// ++ and -- are methods with side effect and shouldn't return anything
-		is.define(Pop)
-	}
 }
 
 func (g *Generator) compileAssignExpression(is *InstructionSet, exp *ast.AssignExpression, scope *scope, table *localTable) {

--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -373,13 +373,7 @@ func (p *Parser) parseAssignExpression(v ast.Expression) ast.Expression {
 	case ast.Variable:
 		exp.Variables = []ast.Expression{v}
 	case *ast.MultiVariableExpression:
-		exps := []ast.Expression{}
-
-		for _, variable := range v.Variables {
-			exps = append(exps, variable)
-		}
-
-		exp.Variables = exps
+		exp.Variables = v.Variables
 	case *ast.CallExpression:
 		/*
 			for cases like: `a[i] += b`
@@ -526,7 +520,7 @@ func (p *Parser) parseMultiVariables(left ast.Expression) ast.Expression {
 		p.noPrefixParseFnError(p.curToken.Type)
 	}
 
-	vars := []ast.Variable{var1}
+	vars := []ast.Expression{var1}
 
 	p.nextToken()
 

--- a/vm/channel_and_thread_test.go
+++ b/vm/channel_and_thread_test.go
@@ -29,9 +29,11 @@ func TestObjectMutationInThread(t *testing.T) {
 		  c.deliver(i)
 		end
 
-		i += 1
+		# if we put i += 1 here than it will execute along with other thread,
+		# which will cause raise condition
 		# Used to block main process until thread is finished
 		c.receive
+		i += 1
 		i
 		`, 2},
 	}

--- a/vm/channel_and_thread_test.go
+++ b/vm/channel_and_thread_test.go
@@ -12,7 +12,7 @@ func TestObjectMutationInThread(t *testing.T) {
 
 		i = 0
 		thread do
-		  i++
+		  i += 1
 		  c.deliver(i)
 		end
 
@@ -25,11 +25,11 @@ func TestObjectMutationInThread(t *testing.T) {
 
 		i = 0
 		thread do
-		  i++
+		  i += 1
 		  c.deliver(i)
 		end
 
-		i++
+		i += 1
 		# Used to block main process until thread is finished
 		c.receive
 		i

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -1324,6 +1324,36 @@ func TestAssignmentEvaluation(t *testing.T) {
 		@b[1] = 10
 		@a[1]
 		`, 2},
+		{`
+		a = [1, 2]
+		a[1] += 2
+		a[1]
+		`, 4},
+		{`
+		a = [1, 2]
+		a[1] -= 2
+		a[1]
+		`, 0},
+		{`
+		a = []
+		a[0] ||= 2
+		a[0]
+		`, 2},
+		{`
+		h = { foo: 2 }
+		h[:foo] += 2
+		h[:foo]
+		`, 4},
+		{`
+		h = { foo: 2 }
+		h[:foo] -= 2
+		h[:foo]
+		`, 0},
+		{`
+		h = {}
+		h[:foo] ||= 2
+		h[:foo]
+		`, 2},
 	}
 
 	for i, tt := range tests {

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -1015,24 +1015,24 @@ func TestPostfixMethodCall(t *testing.T) {
 	}{
 		{`
 		a = 1
-		a++
+		a += 1
 		a
 		`, 2},
 		{`
 		a = 10
-		a--
+		a -= 1
 		a
 		`,
 			9},
 		{`
 		a = 0
-		a--
+		a -= 1
 		a
 		`,
 			-1},
 		{`
 		a = -5
-		a++
+		a += 1
 		a
 		`,
 			-4},

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -434,47 +434,6 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 			},
 		},
 		{
-			// Adds 1 to self and returns.
-			//
-			// ```Ruby
-			// 1++ # => 2
-			// ```
-			// @return [Integer]
-			Name: "++",
-			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					int := receiver.(*IntegerObject)
-
-					t.vm.Lock()
-					defer t.vm.Unlock()
-
-					int.value++
-					return int
-				}
-			},
-		},
-		{
-			// Substracts 1 from self and returns.
-			//
-			// ```Ruby
-			// 0-- # => -1
-			// ```
-			// @return [Integer]
-			Name: "--",
-			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					int := receiver.(*IntegerObject)
-
-					t.vm.Lock()
-					defer t.vm.Unlock()
-
-					int.value--
-					return int
-				}
-			},
-		},
-		{
 			// Returns if self is even.
 			//
 			// ```Ruby
@@ -586,7 +545,7 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 			// ```Ruby
 			// a = 0
 			// 3.times do
-			//    a++
+			//    a += 1
 			// end
 			// a # => 3
 			// ```

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -242,7 +242,7 @@ func TestIntegerTimesMethod(t *testing.T) {
 	}{
 		{`	a = 0
 		  	3.times do
-		  		a++
+		  		a += 1
 			end
 			a
 			`, 3},

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -242,7 +242,7 @@ func TestWhileStatement(t *testing.T) {
 			`
 		i = 10
 		while i > 0 do
-		  i--
+		  i -= 1
 		end
 		i
 		`, 0},
@@ -251,8 +251,8 @@ func TestWhileStatement(t *testing.T) {
 		a = [1, 2, 3, 4, 5]
 		i = 0
 		while i < a.length do
-			a[i]++
-			i++
+			a[i] += 1
+			i += 1
 		end
 		a[4]
 		`, 6},


### PR DESCRIPTION
Also supported syntactic sugar like `||=` for indexing operations.