### PR TITLE
Show more debugging info when error occurs

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -11,6 +11,11 @@ type BaseNode struct {
 	isStmt bool
 }
 
+// Line returns node's token's line number
+func (b *BaseNode) Line() int {
+	return b.Token.Line
+}
+
 // IsExp returns if current node should be considered as an expression
 func (b *BaseNode) IsExp() bool {
 	return !b.isStmt
@@ -34,6 +39,7 @@ func (b *BaseNode) MarkAsExp() {
 type node interface {
 	TokenLiteral() string
 	String() string
+	Line() int
 	IsExp() bool
 	IsStmt() bool
 	MarkAsStmt()

--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -6,36 +6,37 @@ import (
 )
 
 func (g *Generator) compileExpression(is *InstructionSet, exp ast.Expression, scope *scope, table *localTable) {
+	sourceLine := exp.Line()
 	switch exp := exp.(type) {
 	case *ast.Constant:
-		is.define(GetConstant, exp.Value, fmt.Sprint(exp.IsNamespace))
+		is.define(GetConstant, sourceLine, exp.Value, fmt.Sprint(exp.IsNamespace))
 	case *ast.InstanceVariable:
-		is.define(GetInstanceVariable, exp.Value)
+		is.define(GetInstanceVariable, sourceLine, exp.Value)
 	case *ast.IntegerLiteral:
-		is.define(PutObject, fmt.Sprint(exp.Value))
+		is.define(PutObject, sourceLine, fmt.Sprint(exp.Value))
 	case *ast.StringLiteral:
-		is.define(PutString, exp.Value)
+		is.define(PutString, sourceLine, exp.Value)
 	case *ast.BooleanExpression:
-		is.define(PutObject, fmt.Sprint(exp.Value))
+		is.define(PutObject, sourceLine, fmt.Sprint(exp.Value))
 	case *ast.NilExpression:
-		is.define(PutNull)
+		is.define(PutNull, sourceLine)
 	case *ast.RangeExpression:
 		g.compileExpression(is, exp.Start, scope, table)
 		g.compileExpression(is, exp.End, scope, table)
-		is.define(NewRange, 0)
+		is.define(NewRange, sourceLine, 0)
 	case *ast.ArrayExpression:
 		for _, elem := range exp.Elements {
 			g.compileExpression(is, elem, scope, table)
 		}
-		is.define(NewArray, len(exp.Elements))
+		is.define(NewArray, sourceLine, len(exp.Elements))
 	case *ast.HashExpression:
 		for key, value := range exp.Data {
-			is.define(PutString, key)
+			is.define(PutString, sourceLine, key)
 			g.compileExpression(is, value, scope, table)
 		}
-		is.define(NewHash, len(exp.Data)*2)
+		is.define(NewHash, sourceLine, len(exp.Data)*2)
 	case *ast.SelfExpression:
-		is.define(PutSelf)
+		is.define(PutSelf, sourceLine)
 	case *ast.PrefixExpression:
 		g.compilePrefixExpression(is, exp, scope, table)
 	case *ast.InfixExpression:
@@ -57,23 +58,23 @@ func (g *Generator) compileIdentifier(is *InstructionSet, exp *ast.Identifier, s
 	index, depth, ok := table.getLCL(exp.Value, table.depth)
 
 	if ok {
-		is.define(GetLocal, depth, index)
+		is.define(GetLocal, exp.Line(), depth, index)
 		return
 	}
 
 	// otherwise it's a method call
-	is.define(PutSelf)
-	is.define(Send, exp.Value, 0)
+	is.define(PutSelf, exp.Line())
+	is.define(Send, exp.Line(), exp.Value, 0)
 }
 
 func (g *Generator) compileYieldExpression(is *InstructionSet, exp *ast.YieldExpression, scope *scope, table *localTable) {
-	is.define(PutSelf)
+	is.define(PutSelf, exp.Line())
 
 	for _, arg := range exp.Arguments {
 		g.compileExpression(is, arg, scope, table)
 	}
 
-	is.define(InvokeBlock, len(exp.Arguments))
+	is.define(InvokeBlock, exp.Line(), len(exp.Arguments))
 }
 
 func (g *Generator) compileCallExpression(is *InstructionSet, exp *ast.CallExpression, scope *scope, table *localTable) {
@@ -90,17 +91,17 @@ func (g *Generator) compileCallExpression(is *InstructionSet, exp *ast.CallExpre
 		blockIndex := g.blockCounter
 		g.blockCounter++
 		g.compileBlockArgExpression(blockIndex, exp, scope, newTable)
-		is.define(Send, exp.Method, len(exp.Arguments), fmt.Sprintf("block:%d", blockIndex))
+		is.define(Send, exp.Line(), exp.Method, len(exp.Arguments), fmt.Sprintf("block:%d", blockIndex))
 		return
 	}
-	is.define(Send, exp.Method, len(exp.Arguments))
+	is.define(Send, exp.Line(), exp.Method, len(exp.Arguments))
 }
 
 func (g *Generator) compileAssignExpression(is *InstructionSet, exp *ast.AssignExpression, scope *scope, table *localTable) {
 	g.compileExpression(is, exp.Value, scope, table)
 
 	if len(exp.Variables) > 1 {
-		is.define(ExpandArray, len(exp.Variables))
+		is.define(ExpandArray, exp.Line(), len(exp.Variables))
 	}
 
 	for i, v := range exp.Variables {
@@ -109,15 +110,15 @@ func (g *Generator) compileAssignExpression(is *InstructionSet, exp *ast.AssignE
 			index, depth := table.setLCL(name.Value, table.depth)
 
 			if exp.Optioned != 0 {
-				is.define(SetLocal, depth, index, exp.Optioned)
+				is.define(SetLocal, exp.Line(), depth, index, exp.Optioned)
 				return
 			}
 
-			is.define(SetLocal, depth, index)
+			is.define(SetLocal, exp.Line(), depth, index)
 		case *ast.InstanceVariable:
-			is.define(SetInstanceVariable, name.Value)
+			is.define(SetInstanceVariable, exp.Line(), name.Value)
 		case *ast.Constant:
-			is.define(SetConstant, name.Value)
+			is.define(SetConstant, exp.Line(), name.Value)
 		}
 
 		/*
@@ -129,7 +130,7 @@ func (g *Generator) compileAssignExpression(is *InstructionSet, exp *ast.AssignE
 			Here we only pop '2', and the statement compilation will add another pop to pop '1'
 		*/
 		if exp.IsStmt() && !g.REPL && i != len(exp.Variables)-1 {
-			is.define(Pop)
+			is.define(Pop, exp.Line())
 		}
 	}
 }
@@ -144,7 +145,7 @@ func (g *Generator) compileBlockArgExpression(index int, exp *ast.CallExpression
 	}
 
 	g.compileCodeBlock(is, exp.Block, scope, table)
-	g.endInstructions(is)
+	g.endInstructions(is, exp.Line())
 	g.instructionSets = append(g.instructionSets, is)
 }
 
@@ -155,17 +156,17 @@ func (g *Generator) compileIfExpression(is *InstructionSet, exp *ast.IfExpressio
 		anchorConditional := &anchor{}
 
 		g.compileExpression(is, c.Condition, scope, table)
-		is.define(BranchUnless, anchorConditional)
+		is.define(BranchUnless, exp.Line(), anchorConditional)
 
 		g.compileCodeBlock(is, c.Consequence, scope, table)
 		anchorConditional.line = is.count + 1
-		is.define(Jump, anchorLast)
+		is.define(Jump, exp.Line(), anchorLast)
 	}
 
 	if exp.Alternative == nil {
 		// jump over the `putnil` in false case
 		anchorLast.line = is.count + 1
-		is.define(PutNull)
+		is.define(PutNull, exp.Line())
 
 		return
 	}
@@ -179,11 +180,11 @@ func (g *Generator) compilePrefixExpression(is *InstructionSet, exp *ast.PrefixE
 	switch exp.Operator {
 	case "!":
 		g.compileExpression(is, exp.Right, scope, table)
-		is.define(Send, exp.Operator, 0)
+		is.define(Send, exp.Line(), exp.Operator, 0)
 	case "-":
-		is.define(PutObject, 0)
+		is.define(PutObject, exp.Line(), 0)
 		g.compileExpression(is, exp.Right, scope, table)
-		is.define(Send, exp.Operator, 1)
+		is.define(Send, exp.Line(), exp.Operator, 1)
 	}
 }
 
@@ -192,6 +193,6 @@ func (g *Generator) compileInfixExpression(is *InstructionSet, node *ast.InfixEx
 	g.compileExpression(is, node.Right, scope, table)
 
 	if node.Operator != "::" {
-		is.define(Send, node.Operator, "1")
+		is.define(Send, node.Line(), node.Operator, "1")
 	}
 }

--- a/compiler/bytecode/generator.go
+++ b/compiler/bytecode/generator.go
@@ -74,9 +74,9 @@ func (g *Generator) compileCodeBlock(is *InstructionSet, stmt *ast.BlockStatemen
 	}
 }
 
-func (g *Generator) endInstructions(is *InstructionSet) {
+func (g *Generator) endInstructions(is *InstructionSet, sourceLine int) {
 	if g.REPL && is.name == Program {
 		return
 	}
-	is.define(Leave)
+	is.define(Leave, sourceLine)
 }

--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -44,10 +44,11 @@ const (
 
 // Instruction represents compiled bytecode instruction
 type Instruction struct {
-	Action string
-	Params []string
-	line   int
-	anchor *anchor
+	Action     string
+	Params     []string
+	line       int
+	anchor     *anchor
+	sourceLine int
 }
 
 // AnchorLine returns instruction anchor's line number if it has an anchor
@@ -62,6 +63,11 @@ func (i *Instruction) AnchorLine() (int, error) {
 // Line returns instruction's line number
 func (i *Instruction) Line() int {
 	return i.line
+}
+
+// SourceLine returns instruction's source line number
+func (i *Instruction) SourceLine() int {
+	return i.sourceLine
 }
 
 func (i *Instruction) compile() string {
@@ -103,9 +109,9 @@ func (is *InstructionSet) SetType() string {
 	return is.isType
 }
 
-func (is *InstructionSet) define(action string, params ...interface{}) {
+func (is *InstructionSet) define(action string, sourceLine int, params ...interface{}) {
 	ps := []string{}
-	i := &Instruction{Action: action, Params: ps, line: is.count}
+	i := &Instruction{Action: action, Params: ps, line: is.count, sourceLine: sourceLine}
 	for _, param := range params {
 		switch p := param.(type) {
 		case string:

--- a/vm/array.go
+++ b/vm/array.go
@@ -415,7 +415,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					arr := receiver.(*ArrayObject)
 
 					if blockFrame == nil {
-						t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
 					}
 
 					for _, obj := range arr.Elements {
@@ -432,7 +432,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					arr := receiver.(*ArrayObject)
 
 					if blockFrame == nil {
-						t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
 					}
 
 					for i := range arr.Elements {
@@ -611,7 +611,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					var elements = make([]Object, len(arr.Elements))
 
 					if blockFrame == nil {
-						t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
 					}
 
 					for i, obj := range arr.Elements {
@@ -715,7 +715,7 @@ func builtinArrayInstanceMethods() []*BuiltInMethodObject {
 					var elements []Object
 
 					if blockFrame == nil {
-						t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
 					}
 
 					for _, obj := range arr.Elements {

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -15,7 +15,7 @@ func TestArrayClassSuperclass(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -28,7 +28,7 @@ func TestArrayEvaluation(t *testing.T) {
 	`
 
 	vm := initTestVM()
-	evaluated := vm.testEval(t, input)
+	evaluated := vm.testEval(t, input, getFilename())
 	vm.checkCFP(t, 0, 0)
 
 	arr, ok := evaluated.(*ArrayObject)
@@ -76,7 +76,7 @@ func TestArrayComparisonOperation(t *testing.T) {
 
 	for i, tt := range tests {
 		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		evaluated := vm.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 	}
@@ -153,7 +153,7 @@ func TestArrayIndex(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 	}
@@ -200,7 +200,7 @@ func TestArrayAtMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 	}
@@ -223,7 +223,7 @@ func TestArrayClearMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		evaluated := vm.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 	}
@@ -250,7 +250,7 @@ func TestArrayConcatMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		evaluated := vm.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 	}
@@ -273,8 +273,8 @@ func TestArrayConcatMethodFail(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, TypeError, tt.expected)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -321,7 +321,7 @@ func TestArrayCountMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 	}
@@ -340,7 +340,7 @@ func TestArrayCountMethodFail(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 
 		err, ok := evaluated.(*Error)
 		if !ok || err.Class().ReturnName() != ArgumentError {
@@ -368,7 +368,7 @@ func TestArrayEachMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 	}
@@ -390,7 +390,7 @@ func TestArrayEachIndexMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 	}
@@ -422,7 +422,7 @@ func TestArrayEmptyMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -442,7 +442,7 @@ func TestArrayFirstMethod(t *testing.T) {
 
 	for i, tt := range testsInt {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 	}
@@ -463,7 +463,7 @@ func TestArrayFirstMethod(t *testing.T) {
 
 	for i, tt := range testsArray {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 	}
@@ -482,8 +482,8 @@ func TestArrayFirstMethodFail(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, TypeError, tt.expected)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -510,7 +510,7 @@ func TestArrayFlattenMethod(t *testing.T) {
 
 	for i, tt := range testsArray {
 		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		evaluated := vm.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 	}
@@ -529,8 +529,8 @@ func TestArrayFlattenMethodFail(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, ArgumentError, tt.expected)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -557,7 +557,7 @@ func TestArrayJoinMethod(t *testing.T) {
 
 	for i, tt := range testsInt {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 	}
@@ -576,8 +576,8 @@ func TestArrayJoinMethodFailWithArgumentError(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, ArgumentError, tt.expected)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -596,8 +596,8 @@ func TestArrayJoinMethodFailWithTypeError(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, TypeError, tt.expected)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -620,7 +620,7 @@ func TestArrayLastMethod(t *testing.T) {
 
 	for i, tt := range testsArray {
 		vm := initTestVM()
-		evaluated := vm.testEval(t, tt.input)
+		evaluated := vm.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 	}
@@ -639,8 +639,8 @@ func TestArrayLastMethodFail(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, TypeError, tt.expected)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename())
 		v.checkCFP(t, i, 1)
 	}
 }
@@ -671,7 +671,7 @@ func TestArrayLengthMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -705,7 +705,7 @@ func TestArrayMapMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -736,7 +736,7 @@ func TestArrayPopMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -778,7 +778,7 @@ func TestArrayPushMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -802,7 +802,7 @@ func TestArrayRotateMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -822,8 +822,8 @@ func TestArrayRotateMethodFail(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, TypeError, tt.expected)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename())
 
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
@@ -857,7 +857,7 @@ func TestArraySelectMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -888,7 +888,7 @@ func TestArrayShiftMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -908,8 +908,8 @@ func TestArrayShiftMethodFail(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, ArgumentError, tt.expected)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename())
 
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -258,12 +258,10 @@ func TestArrayConcatMethod(t *testing.T) {
 
 func TestArrayConcatMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`
-		a = [1, 2]
+		{`a = [1, 2]
 		a.concat(3)
 		`, "TypeError: Expect argument to be Array. got: Integer", 2},
-		{`
-		a = []
+		{`a = []
 		a.concat("a")
 		`, "TypeError: Expect argument to be Array. got: String", 2},
 	}
@@ -326,8 +324,8 @@ func TestArrayCountMethod(t *testing.T) {
 
 func TestArrayCountMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`
-		a = [1, 2]
+		{
+			`a = [1, 2]
 		a.count(3, 3)
 		`, "ArgumentError: Expect 1 argument, got=2", 2},
 	}
@@ -460,8 +458,7 @@ func TestArrayFirstMethod(t *testing.T) {
 
 func TestArrayFirstMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`
-		a = [1, 2]
+		{`a = [1, 2]
 		a.first("a")
 		`, "TypeError: Expect argument to be Integer. got: String", 2},
 	}
@@ -504,8 +501,7 @@ func TestArrayFlattenMethod(t *testing.T) {
 
 func TestArrayFlattenMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`
-		a = [1, 2]
+		{`a = [1, 2]
 		a.flatten(1)
 		`, "ArgumentError: Expect 0 argument. got=1", 2},
 	}
@@ -548,8 +544,7 @@ func TestArrayJoinMethod(t *testing.T) {
 
 func TestArrayJoinMethodFailWithArgumentError(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`
-		a = [1, 2]
+		{`a = [1, 2]
 		a.join(",", "-")
 		`, "ArgumentError: Expect 0 or 1 argument. got=2", 2},
 	}
@@ -565,8 +560,7 @@ func TestArrayJoinMethodFailWithArgumentError(t *testing.T) {
 
 func TestArrayJoinMethodFailWithTypeError(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`
-		a = [1, 2]
+		{`a = [1, 2]
 		a.join(1)
 		`, "TypeError: Expect argument to be String. got: Integer", 2},
 	}
@@ -605,8 +599,7 @@ func TestArrayLastMethod(t *testing.T) {
 
 func TestArrayLastMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`
-		a = [1, 2]
+		{`a = [1, 2]
 		a.last("l")
 		`, "TypeError: Expect argument to be Integer. got: String", 2},
 	}
@@ -785,8 +778,7 @@ func TestArrayRotateMethod(t *testing.T) {
 
 func TestArrayRotateMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`
-		a = [1, 2]
+		{`a = [1, 2]
 		a.rotate("a")
 		`,
 			"TypeError: Expect argument to be Integer. got: String",
@@ -870,8 +862,7 @@ func TestArrayShiftMethod(t *testing.T) {
 
 func TestArrayShiftMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`
-		a = [1, 2]
+		{`a = [1, 2]
 		a.shift(3, 3, 4, 5)
 		`,
 			"ArgumentError: Expect 0 argument. got=4",

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -257,24 +257,21 @@ func TestArrayConcatMethod(t *testing.T) {
 }
 
 func TestArrayConcatMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input    string
-		expected string
-	}{
+	testsFail := []errorTestCase{
 		{`
 		a = [1, 2]
 		a.concat(3)
-		`, "TypeError: Expect argument to be Array. got: Integer"},
+		`, "TypeError: Expect argument to be Array. got: Integer", 2},
 		{`
 		a = []
 		a.concat("a")
-		`, "TypeError: Expect argument to be Array. got: String"},
+		`, "TypeError: Expect argument to be Array. got: String", 2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -328,25 +325,17 @@ func TestArrayCountMethod(t *testing.T) {
 }
 
 func TestArrayCountMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input    string
-		expected *Error
-	}{
+	testsFail := []errorTestCase{
 		{`
 		a = [1, 2]
 		a.count(3, 3)
-		`, newError("Expect one argument. got=2")},
+		`, "ArgumentError: Expect 1 argument, got=2", 2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-
-		err, ok := evaluated.(*Error)
-		if !ok || err.Class().ReturnName() != ArgumentError {
-			t.Errorf("Expect ArgumentError. got=%T (%+v)", err, err)
-		}
-
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -470,20 +459,17 @@ func TestArrayFirstMethod(t *testing.T) {
 }
 
 func TestArrayFirstMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input    string
-		expected string
-	}{
+	testsFail := []errorTestCase{
 		{`
 		a = [1, 2]
 		a.first("a")
-		`, "TypeError: Expect argument to be Integer. got: String"},
+		`, "TypeError: Expect argument to be Integer. got: String", 2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -517,20 +503,17 @@ func TestArrayFlattenMethod(t *testing.T) {
 }
 
 func TestArrayFlattenMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input    string
-		expected string
-	}{
+	testsFail := []errorTestCase{
 		{`
 		a = [1, 2]
 		a.flatten(1)
-		`, "ArgumentError: Expect 0 argument. got=1"},
+		`, "ArgumentError: Expect 0 argument. got=1", 2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -564,40 +547,34 @@ func TestArrayJoinMethod(t *testing.T) {
 }
 
 func TestArrayJoinMethodFailWithArgumentError(t *testing.T) {
-	testsFail := []struct {
-		input    string
-		expected string
-	}{
+	testsFail := []errorTestCase{
 		{`
 		a = [1, 2]
 		a.join(",", "-")
-		`, "ArgumentError: Expect 0 or 1 argument. got=2"},
+		`, "ArgumentError: Expect 0 or 1 argument. got=2", 2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
 }
 
 func TestArrayJoinMethodFailWithTypeError(t *testing.T) {
-	testsFail := []struct {
-		input    string
-		expected string
-	}{
+	testsFail := []errorTestCase{
 		{`
 		a = [1, 2]
 		a.join(1)
-		`, "TypeError: Expect argument to be String. got: Integer"},
+		`, "TypeError: Expect argument to be String. got: Integer", 2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -627,20 +604,17 @@ func TestArrayLastMethod(t *testing.T) {
 }
 
 func TestArrayLastMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input    string
-		expected string
-	}{
+	testsFail := []errorTestCase{
 		{`
 		a = [1, 2]
 		a.last("l")
-		`, "TypeError: Expect argument to be Integer. got: String"},
+		`, "TypeError: Expect argument to be Integer. got: String", 2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 	}
 }
@@ -810,20 +784,19 @@ func TestArrayRotateMethod(t *testing.T) {
 }
 
 func TestArrayRotateMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input    string
-		expected string
-	}{
+	testsFail := []errorTestCase{
 		{`
 		a = [1, 2]
 		a.rotate("a")
-		`, "TypeError: Expect argument to be Integer. got: String"},
+		`,
+			"TypeError: Expect argument to be Integer. got: String",
+			2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
@@ -896,20 +869,19 @@ func TestArrayShiftMethod(t *testing.T) {
 }
 
 func TestArrayShiftMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input    string
-		expected string
-	}{
+	testsFail := []errorTestCase{
 		{`
 		a = [1, 2]
 		a.shift(3, 3, 4, 5)
-		`, "ArgumentError: Expect 0 argument. got=4"},
+		`,
+			"ArgumentError: Expect 0 argument. got=4",
+			2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)

--- a/vm/boolean_test.go
+++ b/vm/boolean_test.go
@@ -13,7 +13,7 @@ func TestBooleanClassSuperclass(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -31,7 +31,7 @@ func TestEvalBooleanExpression(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -68,7 +68,7 @@ func TestBooleanComparison(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -96,7 +96,7 @@ func TestBooleanLogicalExpression(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -134,7 +134,7 @@ func TestBooleanAssignmentByOperation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/channel_and_thread_test.go
+++ b/vm/channel_and_thread_test.go
@@ -13,7 +13,7 @@ func TestChannelClassSuperclass(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -58,7 +58,7 @@ func TestObjectMutationInThread(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -153,7 +153,7 @@ func TestObjectDeliveryBetweenThread(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/class.go
+++ b/vm/class.go
@@ -1032,10 +1032,6 @@ func builtinClassClassMethods() []*BuiltInMethodObject {
 						return t.unsupportedMethodError("#new", receiver)
 					}
 
-					if class.pseudoSuperClass.isModule {
-						return t.vm.initErrorObject(InternalError, "Module inheritance is not supported: %s", class.pseudoSuperClass.Name)
-					}
-
 					instance := class.initializeInstance()
 					initMethod := class.lookupMethod("initialize")
 

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -97,8 +97,7 @@ func TestAttrReaderAndWriter(t *testing.T) {
 }
 
 func TestClassInheritModule(t *testing.T) {
-	input := `
-module Foo
+	input := `module Foo
 end
 
 class Bar < Foo
@@ -505,14 +504,12 @@ func TestRequireSuccess(t *testing.T) {
 }
 
 func TestRequireFail(t *testing.T) {
-	input := `
-	require "bar"
-	`
+	input := `require "bar"`
 	expected := `InternalError: Can't require "bar"`
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkError(t, 0, evaluated, expected, getFilename(), 0)
+	checkError(t, 0, evaluated, expected, getFilename(), 1)
 	v.checkCFP(t, 0, 1)
 	v.checkSP(t, 0, 1)
 }
@@ -542,21 +539,18 @@ func TestGeneralIsNilMethod(t *testing.T) {
 }
 
 func TestGeneralIsNilMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`123.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`"Fail".nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`[1, 2, 3].nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2, c: 3 }.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`(1..10).nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1"},
+	testsFail := []errorTestCase{
+		{`123.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`"Fail".nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`[1, 2, 3].nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2, c: 3 }.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`(1..10).nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -679,22 +673,19 @@ func TestGeneralIsAMethod(t *testing.T) {
 }
 
 func TestGeneralIsAMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`123.is_a?`, "ArgumentError: Expect 1 argument. got: 0"},
-		{`Class.is_a?`, "ArgumentError: Expect 1 argument. got: 0"},
-		{`123.is_a?(123, 456)`, "ArgumentError: Expect 1 argument. got: 2"},
-		{`123.is_a?(Integer, String)`, "ArgumentError: Expect 1 argument. got: 2"},
-		{`123.is_a?(true)`, "TypeError: Expect argument to be Class. got: Boolean"},
-		{`Class.is_a?(true)`, "TypeError: Expect argument to be Class. got: Boolean"},
+	testsFail := []errorTestCase{
+		{`123.is_a?`, "ArgumentError: Expect 1 argument. got: 0", 1},
+		{`Class.is_a?`, "ArgumentError: Expect 1 argument. got: 0", 1},
+		{`123.is_a?(123, 456)`, "ArgumentError: Expect 1 argument. got: 2", 1},
+		{`123.is_a?(Integer, String)`, "ArgumentError: Expect 1 argument. got: 2", 1},
+		{`123.is_a?(true)`, "TypeError: Expect argument to be Class. got: Boolean", 1},
+		{`Class.is_a?(true)`, "TypeError: Expect argument to be Class. got: Boolean", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -725,21 +716,18 @@ func TestClassNameClassMethod(t *testing.T) {
 }
 
 func TestClassNameClassMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Taipei".name`, "UndefinedMethodError: Undefined Method 'name' for Taipei"},
-		{`123.name`, "UndefinedMethodError: Undefined Method 'name' for 123"},
-		{`true.name`, "UndefinedMethodError: Undefined Method 'name' for true"},
-		{`Integer.name(Integer)`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`String.name(Hash, Array)`, "ArgumentError: Expect 0 argument. got: 2"},
+	testsFail := []errorTestCase{
+		{`"Taipei".name`, "UndefinedMethodError: Undefined Method 'name' for Taipei", 1},
+		{`123.name`, "UndefinedMethodError: Undefined Method 'name' for 123", 1},
+		{`true.name`, "UndefinedMethodError: Undefined Method 'name' for true", 1},
+		{`Integer.name(Integer)`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`String.name(Hash, Array)`, "ArgumentError: Expect 0 argument. got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -777,21 +765,18 @@ func TestClassSuperclassClassMethod(t *testing.T) {
 }
 
 func TestClassSuperclassClassMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Taipei".superclass`, "UndefinedMethodError: Undefined Method 'superclass' for Taipei"},
-		{`123.superclass`, "UndefinedMethodError: Undefined Method 'superclass' for 123"},
-		{`true.superclass`, "UndefinedMethodError: Undefined Method 'superclass' for true"},
-		{`Integer.superclass(Integer)`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`String.superclass(Hash, Array)`, "ArgumentError: Expect 0 argument. got: 2"},
+	testsFail := []errorTestCase{
+		{`"Taipei".superclass`, "UndefinedMethodError: Undefined Method 'superclass' for Taipei", 1},
+		{`123.superclass`, "UndefinedMethodError: Undefined Method 'superclass' for 123", 1},
+		{`true.superclass`, "UndefinedMethodError: Undefined Method 'superclass' for true", 1},
+		{`Integer.superclass(Integer)`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`String.superclass(Hash, Array)`, "ArgumentError: Expect 0 argument. got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -110,9 +110,9 @@ a = Bar.new()
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkError(t, 0, evaluated, expected, getFilename(), 0)
+	checkError(t, 0, evaluated, expected, getFilename(), 4)
 	v.checkCFP(t, 0, 1)
-	v.checkSP(t, 0, 1)
+	v.checkSP(t, 0, 3)
 }
 
 func TestClassInstanceVariable(t *testing.T) {

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -13,7 +13,7 @@ func TestClassClassSuperclass(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -89,7 +89,7 @@ func TestAttrReaderAndWriter(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -109,17 +109,8 @@ a = Bar.new()
 	expected := `InternalError: Module inheritance is not supported: Foo`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
-
-	if !isError(evaluated) {
-		t.Fatalf("Should return an error when a class inherits a module")
-	}
-
-	err := evaluated.(*Error)
-
-	if err.Message != expected {
-		t.Fatalf("Error message should be '%s'. got: %s", expected, err.Message)
-	}
+	evaluated := v.testEval(t, input, getFilename())
+	checkError(t, 0, evaluated, expected, getFilename())
 	v.checkCFP(t, 0, 1)
 	v.checkSP(t, 0, 1)
 }
@@ -149,7 +140,7 @@ func TestClassInstanceVariable(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -174,7 +165,7 @@ func TestCustomClassConstructor(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, 30)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -207,7 +198,7 @@ func TestDefClassMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -226,7 +217,7 @@ func TestBuiltInClassMonkeyPatching(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, "buz")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -407,7 +398,7 @@ func TestClassNamespace(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -475,7 +466,7 @@ func TestPrimitiveType(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -494,7 +485,7 @@ func TestRequireRelative(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, 160)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -507,7 +498,7 @@ func TestRequireSuccess(t *testing.T) {
 	File.extname("foo.rb")
 	`
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, ".rb")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -520,16 +511,8 @@ func TestRequireFail(t *testing.T) {
 	expected := `InternalError: Can't require "bar"`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
-
-	if !isError(evaluated) {
-		t.Fatalf("Should return an error")
-	}
-
-	err := evaluated.(*Error)
-	if err.Message != expected {
-		t.Fatalf("Error message should be '%s'. got: %s", expected, err.Message)
-	}
+	evaluated := v.testEval(t, input, getFilename())
+	checkError(t, 0, evaluated, expected, getFilename())
 	v.checkCFP(t, 0, 1)
 	v.checkSP(t, 0, 1)
 }
@@ -551,7 +534,7 @@ func TestGeneralIsNilMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -572,8 +555,8 @@ func TestGeneralIsNilMethodFail(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, ArgumentError, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -612,7 +595,7 @@ func TestClassGeneralComparisonOperation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -641,7 +624,7 @@ func TestGeneralAssignmentByOperation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -688,7 +671,7 @@ func TestGeneralIsAMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -697,22 +680,21 @@ func TestGeneralIsAMethod(t *testing.T) {
 
 func TestGeneralIsAMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`123.is_a?`, ArgumentError, "ArgumentError: Expect 1 argument. got: 0"},
-		{`Class.is_a?`, ArgumentError, "ArgumentError: Expect 1 argument. got: 0"},
-		{`123.is_a?(123, 456)`, ArgumentError, "ArgumentError: Expect 1 argument. got: 2"},
-		{`123.is_a?(Integer, String)`, ArgumentError, "ArgumentError: Expect 1 argument. got: 2"},
-		{`123.is_a?(true)`, TypeError, "TypeError: Expect argument to be Class. got: Boolean"},
-		{`Class.is_a?(true)`, TypeError, "TypeError: Expect argument to be Class. got: Boolean"},
+		{`123.is_a?`, "ArgumentError: Expect 1 argument. got: 0"},
+		{`Class.is_a?`, "ArgumentError: Expect 1 argument. got: 0"},
+		{`123.is_a?(123, 456)`, "ArgumentError: Expect 1 argument. got: 2"},
+		{`123.is_a?(Integer, String)`, "ArgumentError: Expect 1 argument. got: 2"},
+		{`123.is_a?(true)`, "TypeError: Expect argument to be Class. got: Boolean"},
+		{`Class.is_a?(true)`, "TypeError: Expect argument to be Class. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -735,7 +717,7 @@ func TestClassNameClassMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -744,21 +726,20 @@ func TestClassNameClassMethod(t *testing.T) {
 
 func TestClassNameClassMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Taipei".name`, UndefinedMethodError, "UndefinedMethodError: Undefined Method 'name' for Taipei"},
-		{`123.name`, UndefinedMethodError, "UndefinedMethodError: Undefined Method 'name' for 123"},
-		{`true.name`, UndefinedMethodError, "UndefinedMethodError: Undefined Method 'name' for true"},
-		{`Integer.name(Integer)`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1"},
-		{`String.name(Hash, Array)`, ArgumentError, "ArgumentError: Expect 0 argument. got: 2"},
+		{`"Taipei".name`, "UndefinedMethodError: Undefined Method 'name' for Taipei"},
+		{`123.name`, "UndefinedMethodError: Undefined Method 'name' for 123"},
+		{`true.name`, "UndefinedMethodError: Undefined Method 'name' for true"},
+		{`Integer.name(Integer)`, "ArgumentError: Expect 0 argument. got: 1"},
+		{`String.name(Hash, Array)`, "ArgumentError: Expect 0 argument. got: 2"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -788,7 +769,7 @@ func TestClassSuperclassClassMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -797,21 +778,20 @@ func TestClassSuperclassClassMethod(t *testing.T) {
 
 func TestClassSuperclassClassMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Taipei".superclass`, UndefinedMethodError, "UndefinedMethodError: Undefined Method 'superclass' for Taipei"},
-		{`123.superclass`, UndefinedMethodError, "UndefinedMethodError: Undefined Method 'superclass' for 123"},
-		{`true.superclass`, UndefinedMethodError, "UndefinedMethodError: Undefined Method 'superclass' for true"},
-		{`Integer.superclass(Integer)`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1"},
-		{`String.superclass(Hash, Array)`, ArgumentError, "ArgumentError: Expect 0 argument. got: 2"},
+		{`"Taipei".superclass`, "UndefinedMethodError: Undefined Method 'superclass' for Taipei"},
+		{`123.superclass`, "UndefinedMethodError: Undefined Method 'superclass' for 123"},
+		{`true.superclass`, "UndefinedMethodError: Undefined Method 'superclass' for true"},
+		{`Integer.superclass(Integer)`, "ArgumentError: Expect 0 argument. got: 1"},
+		{`String.superclass(Hash, Array)`, "ArgumentError: Expect 0 argument. got: 2"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -837,7 +817,7 @@ func TestClassSingletonClassClassMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -110,7 +110,7 @@ a = Bar.new()
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkError(t, 0, evaluated, expected, getFilename())
+	checkError(t, 0, evaluated, expected, getFilename(), 0)
 	v.checkCFP(t, 0, 1)
 	v.checkSP(t, 0, 1)
 }
@@ -512,7 +512,7 @@ func TestRequireFail(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkError(t, 0, evaluated, expected, getFilename())
+	checkError(t, 0, evaluated, expected, getFilename(), 0)
 	v.checkCFP(t, 0, 1)
 	v.checkSP(t, 0, 1)
 }
@@ -556,7 +556,7 @@ func TestGeneralIsNilMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -694,7 +694,7 @@ func TestGeneralIsAMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -739,7 +739,7 @@ func TestClassNameClassMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -791,7 +791,7 @@ func TestClassSuperclassClassMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/db_test.go
+++ b/vm/db_test.go
@@ -51,7 +51,7 @@ func TestPGConnectionPing(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -79,7 +79,7 @@ func TestDBClose(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -130,7 +130,7 @@ func TestDBExec(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/error.go
+++ b/vm/error.go
@@ -26,10 +26,12 @@ func (vm *VM) initErrorObject(errorType, format string, args ...interface{}) *Er
 
 	t := vm.mainThread
 	cf := t.callFrameStack.callFrames[t.cfp-1]
+	i := cf.instructionSet.instructions[cf.pc-1]
 
 	return &Error{
 		baseObj: &baseObj{class: errClass},
-		Message: fmt.Sprintf("%s. At %s:%d", fmt.Sprintf(errorType+": "+format, args...), cf.instructionSet.filename, 0),
+		// Add 1 to source line because it's zero indexed
+		Message: fmt.Sprintf("%s. At %s:%d", fmt.Sprintf(errorType+": "+format, args...), cf.instructionSet.filename, i.sourceLine+1),
 	}
 }
 

--- a/vm/error.go
+++ b/vm/error.go
@@ -24,9 +24,12 @@ const (
 func (vm *VM) initErrorObject(errorType, format string, args ...interface{}) *Error {
 	errClass := vm.objectClass.getClassConstant(errorType)
 
+	t := vm.mainThread
+	cf := t.callFrameStack.callFrames[t.cfp-1]
+
 	return &Error{
 		baseObj: &baseObj{class: errClass},
-		Message: fmt.Sprintf(errorType+": "+format, args...),
+		Message: fmt.Sprintf("%s. At %s:%d", fmt.Sprintf(errorType+": "+format, args...), cf.instructionSet.filename, 0),
 	}
 }
 

--- a/vm/error.go
+++ b/vm/error.go
@@ -25,7 +25,14 @@ func (vm *VM) initErrorObject(errorType, format string, args ...interface{}) *Er
 	errClass := vm.objectClass.getClassConstant(errorType)
 
 	t := vm.mainThread
-	cf := t.callFrameStack.callFrames[t.cfp-1]
+	cf := t.callFrameStack.top()
+
+	// If program counter is 0 means we need to trace back to previous call frame
+	if cf.pc == 0 {
+		t.callFrameStack.pop()
+		cf = t.callFrameStack.top()
+	}
+
 	i := cf.instructionSet.instructions[cf.pc-1]
 
 	return &Error{

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -39,7 +39,7 @@ func TestUndefinedMethodError(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errorMsg, getFilename())
+		checkError(t, i, evaluated, tt.errorMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -62,7 +62,7 @@ func TestUnsupportedMethodError(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errorMsg, getFilename())
+		checkError(t, i, evaluated, tt.errorMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -116,7 +116,7 @@ func TestArgumentError(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -144,19 +144,19 @@ func TestConstantAlreadyInitializedError(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
 }
 
-func checkError(t *testing.T, index int, evaluated Object, expectedErrMsg, fn string) {
+func checkError(t *testing.T, index int, evaluated Object, expectedErrMsg, fn string, line int) {
 	err, ok := evaluated.(*Error)
 	if !ok {
 		t.Errorf("At test case %d: Expect Error. got=%T (%+v)", index, evaluated, evaluated)
 	}
 
-	expectedErrMsg = fmt.Sprintf("%s. At %s:%d", expectedErrMsg, fn, 0)
+	expectedErrMsg = fmt.Sprintf("%s. At %s:%d", expectedErrMsg, fn, line)
 	if err.Message != expectedErrMsg {
 		t.Fatalf("At test case %d: Expect error message to be:\n  %s. got: \n%s", index, expectedErrMsg, err.Message)
 	}

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -1,6 +1,9 @@
 package vm
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestUndefinedMethodError(t *testing.T) {
 	tests := []struct {
@@ -35,8 +38,8 @@ func TestUndefinedMethodError(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, UndefinedMethodError, tt.errorMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errorMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -58,8 +61,8 @@ func TestUnsupportedMethodError(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, UnsupportedMethodError, tt.errorMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errorMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -112,8 +115,8 @@ func TestArgumentError(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, ArgumentError, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -140,21 +143,20 @@ func TestConstantAlreadyInitializedError(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, ConstantAlreadyInitializedError, tt.expected)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
 }
 
-func checkError(t *testing.T, index int, evaluated Object, expectedErrType, expectedErrMsg string) {
+func checkError(t *testing.T, index int, evaluated Object, expectedErrMsg, fn string) {
 	err, ok := evaluated.(*Error)
 	if !ok {
 		t.Errorf("At test case %d: Expect Error. got=%T (%+v)", index, evaluated, evaluated)
 	}
-	if err.class.Name != expectedErrType {
-		t.Errorf("At test case %d: Expect %s. got=%T (%+v)", index, expectedErrType, evaluated, err)
-	}
+
+	expectedErrMsg = fmt.Sprintf("%s. At %s:%d", expectedErrMsg, fn, 0)
 	if err.Message != expectedErrMsg {
 		t.Fatalf("At test case %d: Expect error message to be:\n  %s. got: \n%s", index, expectedErrMsg, err.Message)
 	}

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -41,7 +41,7 @@ func TestComplexEvaluation(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	testIntegerObject(t, 0, evaluated, 310)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -69,7 +69,7 @@ func TestComment(t *testing.T) {
 	# Comment`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	testIntegerObject(t, 0, evaluated, 123)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -282,7 +282,7 @@ func TestMethodCall(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 
 		if isError(evaluated) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).Message)
@@ -338,7 +338,7 @@ func TestMethodCallWithDefaultArgValue(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -489,7 +489,7 @@ func TestMethodCallWithBlockArgument(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -595,7 +595,7 @@ func TestMethodCallWithNestedBlock(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -832,7 +832,7 @@ func TestMethodCallWithoutParens(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 
 		if isError(evaluated) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).Message)
@@ -954,7 +954,7 @@ func TestClassMethodCall(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -988,7 +988,7 @@ func TestInstanceMethodCall(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 
 	if isError(evaluated) {
 		t.Fatalf("got Error: %s", evaluated.(*Error).Message)
@@ -1040,7 +1040,7 @@ func TestPostfixMethodCall(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1062,7 +1062,7 @@ func TestBangPrefixMethodCall(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1082,7 +1082,7 @@ func TestMinusPrefixMethodCall(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1144,7 +1144,7 @@ func TestSelfExpressionEvaluation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 
 		if isError(evaluated) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).Message)
@@ -1217,7 +1217,7 @@ func TestInstanceVariableEvaluation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 
 		if isError(evaluated) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).Message)
@@ -1358,7 +1358,7 @@ func TestAssignmentEvaluation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		testIntegerObject(t, i, evaluated, tt.expectedValue)
 		v.checkCFP(t, 0, 0)
 		v.checkSP(t, i, 1)
@@ -1379,7 +1379,7 @@ func TestAssignmentByOperationEvaluation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expectedValue)
 		v.checkCFP(t, 0, 0)
 		v.checkSP(t, i, 1)
@@ -1547,7 +1547,7 @@ func TestIfExpressionEvaluation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1568,7 +1568,7 @@ func TestClassInheritance(t *testing.T) {
 		Foo.superclass.name
 	`
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 
 	testStringObject(t, 0, evaluated, "Bar")
 	v.checkCFP(t, 0, 0)
@@ -1700,7 +1700,7 @@ func TestMultiVarAssignment(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1735,7 +1735,7 @@ func TestRemoveUnusedExpression(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/file_test.go
+++ b/vm/file_test.go
@@ -47,7 +47,7 @@ func TestFileObject(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -67,7 +67,7 @@ func TestFileBasenameMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -99,7 +99,7 @@ func TestFileDeleteMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -123,7 +123,7 @@ func TestFileExtnameMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -151,7 +151,7 @@ func TestFileJoinMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -198,7 +198,7 @@ func TestFileWriteMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -213,7 +213,7 @@ func TestFileSizeMethod(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, 22)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -232,7 +232,7 @@ func TestFileSplitMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/go_object_test.go
+++ b/vm/go_object_test.go
@@ -17,7 +17,7 @@ func TestCallingGoObjectFunctionWithReturnValue(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, "xyz!")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -36,7 +36,7 @@ func TestCallingGoObjectFunctionWithReturnError(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, nil)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -54,7 +54,7 @@ func TestCallingGoObjectFuncWithInt64(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, 110)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -72,7 +72,7 @@ func TestCallingGoObjectFuncWithGoObject(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, "xyz")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -140,7 +140,7 @@ func TestHashAccessOperationFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -221,7 +221,7 @@ func TestHashClearMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -284,7 +284,7 @@ func TestHashEachKeyMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, tt.expectedCfp)
 		v.checkSP(t, i, 1)
 	}
@@ -375,7 +375,7 @@ func TestHashEachValueMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, tt.expectedCfp)
 		v.checkSP(t, i, 1)
 	}
@@ -411,7 +411,7 @@ func TestHashEmptyMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -457,7 +457,7 @@ func TestHashEqualMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -529,7 +529,7 @@ func TestHashDeleteMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -567,7 +567,7 @@ func TestHashHasKeyMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -608,7 +608,7 @@ func TestHashHasValueMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -654,7 +654,7 @@ func TestHashKeysMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -694,7 +694,7 @@ func TestHashLengthMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -777,7 +777,7 @@ func TestHashMapValuesMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, tt.expectedCfp)
 		v.checkSP(t, i, 1)
 	}
@@ -829,7 +829,7 @@ func TestHashMergeMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -868,7 +868,7 @@ func TestHashSortedKeysMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -942,7 +942,7 @@ func TestHashToArrayMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -1111,7 +1111,7 @@ func TestHashToJSONMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -1148,7 +1148,7 @@ func TestHashToStringMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -1231,7 +1231,7 @@ func TestHashTransformValuesMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, tt.expectedCfp)
 		v.checkSP(t, i, 1)
 	}
@@ -1280,7 +1280,7 @@ func TestHashValuesMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -18,7 +18,7 @@ func TestHashClassSuperclass(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -31,7 +31,7 @@ func TestEvalHashExpression(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 
 	h, ok := evaluated.(*HashObject)
 	if !ok {
@@ -120,7 +120,7 @@ func TestHashAccessOperation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -129,19 +129,18 @@ func TestHashAccessOperation(t *testing.T) {
 
 func TestHashAccessOperationFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }[]`, ArgumentError, "ArgumentError: Expect 1 argument. got: 0"},
-		{`{ a: 1, b: 2 }[true]`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
-		{`{ a: 1, b: 2 }[true] = 1`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
+		{`{ a: 1, b: 2 }[]`, "ArgumentError: Expect 1 argument. got: 0"},
+		{`{ a: 1, b: 2 }[true]`, "TypeError: Expect argument to be String. got: Boolean"},
+		{`{ a: 1, b: 2 }[true] = 1`, "TypeError: Expect argument to be String. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -184,7 +183,7 @@ func TestHashComparisonOperation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -197,7 +196,7 @@ func TestHashClearMethod(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 
 	h, ok := evaluated.(*HashObject)
 	if !ok {
@@ -212,18 +211,17 @@ func TestHashClearMethod(t *testing.T) {
 
 func TestHashClearMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.clear(123)`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.clear(true, { hello: "World" })`, ArgumentError, "ArgumentError: Expect 0 argument. got: 2"},
+		{`{ a: 1, b: 2 }.clear(123)`, "ArgumentError: Expect 0 argument. got: 1"},
+		{`{ a: 1, b: 2 }.clear(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -260,7 +258,7 @@ func TestHashEachKeyMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -270,7 +268,6 @@ func TestHashEachKeyMethod(t *testing.T) {
 func TestHashEachKeyMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input       string
-		errType     string
 		errMsg      string
 		expectedCfp int
 	}{
@@ -278,16 +275,16 @@ func TestHashEachKeyMethodFail(t *testing.T) {
 		{ a: 1, b: 2, c: 3 }.each_key("Hello") do |key|
 		  puts key
 		end
-		`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1", 2},
+		`, "ArgumentError: Expect 0 argument. got: 1", 2},
 		{`
 		{ a: 1, b: 2, c: 3 }.each_key
-		`, InternalError, "InternalError: Can't yield without a block", 1},
+		`, "InternalError: Can't yield without a block", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, tt.expectedCfp)
 		v.checkSP(t, i, 1)
 	}
@@ -317,7 +314,7 @@ func TestHashEachValueMethod(t *testing.T) {
 
 	for i, tt := range hashTests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -352,7 +349,7 @@ func TestHashEachValueMethod(t *testing.T) {
 
 	for i, tt := range normalTests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -362,7 +359,6 @@ func TestHashEachValueMethod(t *testing.T) {
 func TestHashEachValueMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input       string
-		errType     string
 		errMsg      string
 		expectedCfp int
 	}{
@@ -370,16 +366,16 @@ func TestHashEachValueMethodFail(t *testing.T) {
 		{ a: 1, b: 2, c: 3 }.each_value("Hello") do |value|
 		  puts value
 		end
-		`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1", 2},
+		`, "ArgumentError: Expect 0 argument. got: 1", 2},
 		{`
 		{ a: 1, b: 2, c: 3 }.each_value
-		`, InternalError, "InternalError: Can't yield without a block", 1},
+		`, "InternalError: Can't yield without a block", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, tt.expectedCfp)
 		v.checkSP(t, i, 1)
 	}
@@ -396,7 +392,7 @@ func TestHashEmptyMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -405,18 +401,17 @@ func TestHashEmptyMethod(t *testing.T) {
 
 func TestHashEmptyMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.empty?(123)`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.empty?(true, { hello: "World" })`, ArgumentError, "ArgumentError: Expect 0 argument. got: 2"},
+		{`{ a: 1, b: 2 }.empty?(123)`, "ArgumentError: Expect 0 argument. got: 1"},
+		{`{ a: 1, b: 2 }.empty?(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -443,7 +438,7 @@ func TestHashEqualMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -452,18 +447,17 @@ func TestHashEqualMethod(t *testing.T) {
 
 func TestHashEqualMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.eql?`, ArgumentError, "ArgumentError: Expect 1 argument. got: 0"},
-		{`{ a: 1, b: 2 }.eql?(true, { hello: "World" })`, ArgumentError, "ArgumentError: Expect 1 argument. got: 2"},
+		{`{ a: 1, b: 2 }.eql?`, "ArgumentError: Expect 1 argument. got: 0"},
+		{`{ a: 1, b: 2 }.eql?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -514,7 +508,7 @@ func TestHashDeleteMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -523,20 +517,19 @@ func TestHashDeleteMethod(t *testing.T) {
 
 func TestHashDeleteMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: "Hello", c: true }.delete`, ArgumentError, "ArgumentError: Expect 1 argument. got: 0"},
-		{`{ a: 1, b: "Hello", c: true }.delete("a", "b")`, ArgumentError, "ArgumentError: Expect 1 argument. got: 2"},
-		{`{ a: 1, b: "Hello", c: true }.delete(123)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
-		{`{ a: 1, b: "Hello", c: true }.delete(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
+		{`{ a: 1, b: "Hello", c: true }.delete`, "ArgumentError: Expect 1 argument. got: 0"},
+		{`{ a: 1, b: "Hello", c: true }.delete("a", "b")`, "ArgumentError: Expect 1 argument. got: 2"},
+		{`{ a: 1, b: "Hello", c: true }.delete(123)`, "TypeError: Expect argument to be String. got: Integer"},
+		{`{ a: 1, b: "Hello", c: true }.delete(true)`, "TypeError: Expect argument to be String. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -553,7 +546,7 @@ func TestHashHasKeyMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -562,20 +555,19 @@ func TestHashHasKeyMethod(t *testing.T) {
 
 func TestHashHasKeyMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.has_key?`, ArgumentError, "ArgumentError: Expect 1 argument. got: 0"},
-		{`{ a: 1, b: 2 }.has_key?(true, { hello: "World" })`, ArgumentError, "ArgumentError: Expect 1 argument. got: 2"},
-		{`{ a: 1, b: 2 }.has_key?(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
-		{`{ a: 1, b: 2 }.has_key?(123)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
+		{`{ a: 1, b: 2 }.has_key?`, "ArgumentError: Expect 1 argument. got: 0"},
+		{`{ a: 1, b: 2 }.has_key?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2"},
+		{`{ a: 1, b: 2 }.has_key?(true)`, "TypeError: Expect argument to be String. got: Boolean"},
+		{`{ a: 1, b: 2 }.has_key?(123)`, "TypeError: Expect argument to be String. got: Integer"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -597,7 +589,7 @@ func TestHashHasValueMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -606,18 +598,17 @@ func TestHashHasValueMethod(t *testing.T) {
 
 func TestHashHasValueMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.has_value?`, ArgumentError, "ArgumentError: Expect 1 argument. got: 0"},
-		{`{ a: 1, b: 2 }.has_value?(true, { hello: "World" })`, ArgumentError, "ArgumentError: Expect 1 argument. got: 2"},
+		{`{ a: 1, b: 2 }.has_value?`, "ArgumentError: Expect 1 argument. got: 0"},
+		{`{ a: 1, b: 2 }.has_value?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -629,7 +620,7 @@ func TestHashKeysMethod(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 
 	arr, ok := evaluated.(*ArrayObject)
 	if !ok {
@@ -653,18 +644,17 @@ func TestHashKeysMethod(t *testing.T) {
 
 func TestHashKeysMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.keys(123)`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.keys(true, { hello: "World" })`, ArgumentError, "ArgumentError: Expect 0 argument. got: 2"},
+		{`{ a: 1, b: 2 }.keys(123)`, "ArgumentError: Expect 0 argument. got: 1"},
+		{`{ a: 1, b: 2 }.keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -685,7 +675,7 @@ func TestHashLengthMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -694,18 +684,17 @@ func TestHashLengthMethod(t *testing.T) {
 
 func TestHashLengthMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.length(123)`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.length(true, { hello: "World" })`, ArgumentError, "ArgumentError: Expect 0 argument. got: 2"},
+		{`{ a: 1, b: 2 }.length(123)`, "ArgumentError: Expect 0 argument. got: 1"},
+		{`{ a: 1, b: 2 }.length(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -762,7 +751,7 @@ func TestHashMapValuesMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -772,7 +761,6 @@ func TestHashMapValuesMethod(t *testing.T) {
 func TestHashMapValuesMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input       string
-		errType     string
 		errMsg      string
 		expectedCfp int
 	}{
@@ -780,16 +768,16 @@ func TestHashMapValuesMethodFail(t *testing.T) {
 		{ a: 1, b: 2, c: 3 }.map_values("Hello") do |value|
 		  value * 3
 		end
-		`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1", 2},
+		`, "ArgumentError: Expect 0 argument. got: 1", 2},
 		{`
 		{ a: 1, b: 2, c: 3 }.map_values
-		`, InternalError, "InternalError: Can't yield without a block", 1},
+		`, "InternalError: Can't yield without a block", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, tt.expectedCfp)
 		v.checkSP(t, i, 1)
 	}
@@ -803,7 +791,7 @@ func TestHashMergeMethod(t *testing.T) {
 
 	for i, value := range input {
 		v := initTestVM()
-		evaluated := v.testEval(t, value)
+		evaluated := v.testEval(t, value, getFilename())
 
 		h, ok := evaluated.(*HashObject)
 		if !ok {
@@ -830,19 +818,18 @@ func TestHashMergeMethod(t *testing.T) {
 
 func TestHashMergeMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.merge`, ArgumentError, "ArgumentError: Expect at least 1 argument. got: 0"},
-		{`{ a: 1, b: 2 }.merge(true, { hello: "World" })`, TypeError, "TypeError: Expect argument to be Hash. got: Boolean"},
-		{`{ a: 1, b: 2 }.merge({ hello: "World" }, 123, "Hello")`, TypeError, "TypeError: Expect argument to be Hash. got: Integer"},
+		{`{ a: 1, b: 2 }.merge`, "ArgumentError: Expect at least 1 argument. got: 0"},
+		{`{ a: 1, b: 2 }.merge(true, { hello: "World" })`, "TypeError: Expect argument to be Hash. got: Boolean"},
+		{`{ a: 1, b: 2 }.merge({ hello: "World" }, 123, "Hello")`, "TypeError: Expect argument to be Hash. got: Integer"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -862,7 +849,7 @@ func TestHashSortedKeysMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -871,18 +858,17 @@ func TestHashSortedKeysMethod(t *testing.T) {
 
 func TestHashSortedKeysMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.sorted_keys(123)`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.sorted_keys(true, { hello: "World" })`, ArgumentError, "ArgumentError: Expect 0 argument. got: 2"},
+		{`{ a: 1, b: 2 }.sorted_keys(123)`, "ArgumentError: Expect 0 argument. got: 1"},
+		{`{ a: 1, b: 2 }.sorted_keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -903,7 +889,7 @@ func TestHashToArrayMethod(t *testing.T) {
 
 	for i, tt := range testsSortedArray {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		testArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -914,7 +900,7 @@ func TestHashToArrayMethod(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 
 	arr, ok := evaluated.(*ArrayObject)
 	if !ok {
@@ -946,18 +932,17 @@ func TestHashToArrayMethod(t *testing.T) {
 
 func TestHashToArrayMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.to_a(true, { hello: "World" })`, ArgumentError, "ArgumentError: Expect 0..1 argument. got: 2"},
-		{`{ a: 1, b: 2 }.to_a(123)`, TypeError, "TypeError: Expect argument to be Boolean. got: Integer"},
+		{`{ a: 1, b: 2 }.to_a(true, { hello: "World" })`, "ArgumentError: Expect 0..1 argument. got: 2"},
+		{`{ a: 1, b: 2 }.to_a(123)`, "TypeError: Expect argument to be Boolean. got: Integer"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -996,7 +981,7 @@ func TestHashToJSONMethodWithArray(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		compareJSONResult(t, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1046,7 +1031,7 @@ func TestHashToJSONMethodWithNestedHash(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		compareJSONResult(t, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1107,7 +1092,7 @@ func TestHashToJSONMethodWithBasicTypes(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		compareJSONResult(t, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1116,18 +1101,17 @@ func TestHashToJSONMethodWithBasicTypes(t *testing.T) {
 
 func TestHashToJSONMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.to_json(123)`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.to_json(true, { hello: "World" })`, ArgumentError, "ArgumentError: Expect 0 argument. got: 2"},
+		{`{ a: 1, b: 2 }.to_json(123)`, "ArgumentError: Expect 0 argument. got: 1"},
+		{`{ a: 1, b: 2 }.to_json(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -1145,7 +1129,7 @@ func TestHashToStringMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1154,18 +1138,17 @@ func TestHashToStringMethod(t *testing.T) {
 
 func TestHashToStringMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.to_s(123)`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.to_s(true, { hello: "World" })`, ArgumentError, "ArgumentError: Expect 0 argument. got: 2"},
+		{`{ a: 1, b: 2 }.to_s(123)`, "ArgumentError: Expect 0 argument. got: 1"},
+		{`{ a: 1, b: 2 }.to_s(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -1222,7 +1205,7 @@ func TestHashTransformValuesMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1232,7 +1215,6 @@ func TestHashTransformValuesMethod(t *testing.T) {
 func TestHashTransformValuesMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input       string
-		errType     string
 		errMsg      string
 		expectedCfp int
 	}{
@@ -1240,16 +1222,16 @@ func TestHashTransformValuesMethodFail(t *testing.T) {
 		{ a: 1, b: 2, c: 3 }.transform_values("Hello") do |value|
 		  value * 3
 		end
-		`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1", 2},
+		`, "ArgumentError: Expect 0 argument. got: 1", 2},
 		{`
 		{ a: 1, b: 2, c: 3 }.transform_values
-		`, InternalError, "InternalError: Can't yield without a block", 1},
+		`, "InternalError: Can't yield without a block", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, tt.expectedCfp)
 		v.checkSP(t, i, 1)
 	}
@@ -1261,7 +1243,7 @@ func TestHashValuesMethod(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 
 	arr, ok := evaluated.(*ArrayObject)
 	if !ok {
@@ -1288,18 +1270,17 @@ func TestHashValuesMethod(t *testing.T) {
 
 func TestHashValuesMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`{ a: 1, b: 2 }.values(123)`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.values(true, { hello: "World" })`, ArgumentError, "ArgumentError: Expect 0 argument. got: 2"},
+		{`{ a: 1, b: 2 }.values(123)`, "ArgumentError: Expect 0 argument. got: 1"},
+		{`{ a: 1, b: 2 }.values(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -128,19 +128,16 @@ func TestHashAccessOperation(t *testing.T) {
 }
 
 func TestHashAccessOperationFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }[]`, "ArgumentError: Expect 1 argument. got: 0"},
-		{`{ a: 1, b: 2 }[true]`, "TypeError: Expect argument to be String. got: Boolean"},
-		{`{ a: 1, b: 2 }[true] = 1`, "TypeError: Expect argument to be String. got: Boolean"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }[]`, "ArgumentError: Expect 1 argument. got: 0", 1},
+		{`{ a: 1, b: 2 }[true]`, "TypeError: Expect argument to be String. got: Boolean", 1},
+		{`{ a: 1, b: 2 }[true] = 1`, "TypeError: Expect argument to be String. got: Boolean", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -210,18 +207,15 @@ func TestHashClearMethod(t *testing.T) {
 }
 
 func TestHashClearMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.clear(123)`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.clear(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.clear(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2 }.clear(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -266,26 +260,19 @@ func TestHashEachKeyMethod(t *testing.T) {
 }
 
 func TestHashEachKeyMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input       string
-		errMsg      string
-		expectedCfp int
-	}{
-		{`
-		{ a: 1, b: 2, c: 3 }.each_key("Hello") do |key|
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2, c: 3 }.each_key("Hello") do |key|
 		  puts key
 		end
-		`, "ArgumentError: Expect 0 argument. got: 1", 2},
-		{`
-		{ a: 1, b: 2, c: 3 }.each_key
-		`, "InternalError: Can't yield without a block", 1},
+		`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2, c: 3 }.each_key`, "InternalError: Can't yield without a block", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
-		v.checkCFP(t, i, tt.expectedCfp)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -357,26 +344,19 @@ func TestHashEachValueMethod(t *testing.T) {
 }
 
 func TestHashEachValueMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input       string
-		errMsg      string
-		expectedCfp int
-	}{
-		{`
-		{ a: 1, b: 2, c: 3 }.each_value("Hello") do |value|
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2, c: 3 }.each_value("Hello") do |value|
 		  puts value
 		end
-		`, "ArgumentError: Expect 0 argument. got: 1", 2},
-		{`
-		{ a: 1, b: 2, c: 3 }.each_value
-		`, "InternalError: Can't yield without a block", 1},
+		`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2, c: 3 }.each_value`, "InternalError: Can't yield without a block", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
-		v.checkCFP(t, i, tt.expectedCfp)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -400,18 +380,15 @@ func TestHashEmptyMethod(t *testing.T) {
 }
 
 func TestHashEmptyMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.empty?(123)`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.empty?(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.empty?(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2 }.empty?(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -446,18 +423,15 @@ func TestHashEqualMethod(t *testing.T) {
 }
 
 func TestHashEqualMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.eql?`, "ArgumentError: Expect 1 argument. got: 0"},
-		{`{ a: 1, b: 2 }.eql?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.eql?`, "ArgumentError: Expect 1 argument. got: 0", 1},
+		{`{ a: 1, b: 2 }.eql?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -516,20 +490,17 @@ func TestHashDeleteMethod(t *testing.T) {
 }
 
 func TestHashDeleteMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: "Hello", c: true }.delete`, "ArgumentError: Expect 1 argument. got: 0"},
-		{`{ a: 1, b: "Hello", c: true }.delete("a", "b")`, "ArgumentError: Expect 1 argument. got: 2"},
-		{`{ a: 1, b: "Hello", c: true }.delete(123)`, "TypeError: Expect argument to be String. got: Integer"},
-		{`{ a: 1, b: "Hello", c: true }.delete(true)`, "TypeError: Expect argument to be String. got: Boolean"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: "Hello", c: true }.delete`, "ArgumentError: Expect 1 argument. got: 0", 1},
+		{`{ a: 1, b: "Hello", c: true }.delete("a", "b")`, "ArgumentError: Expect 1 argument. got: 2", 1},
+		{`{ a: 1, b: "Hello", c: true }.delete(123)`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`{ a: 1, b: "Hello", c: true }.delete(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -554,20 +525,17 @@ func TestHashHasKeyMethod(t *testing.T) {
 }
 
 func TestHashHasKeyMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.has_key?`, "ArgumentError: Expect 1 argument. got: 0"},
-		{`{ a: 1, b: 2 }.has_key?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2"},
-		{`{ a: 1, b: 2 }.has_key?(true)`, "TypeError: Expect argument to be String. got: Boolean"},
-		{`{ a: 1, b: 2 }.has_key?(123)`, "TypeError: Expect argument to be String. got: Integer"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.has_key?`, "ArgumentError: Expect 1 argument. got: 0", 1},
+		{`{ a: 1, b: 2 }.has_key?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.has_key?(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
+		{`{ a: 1, b: 2 }.has_key?(123)`, "TypeError: Expect argument to be String. got: Integer", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -597,18 +565,15 @@ func TestHashHasValueMethod(t *testing.T) {
 }
 
 func TestHashHasValueMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.has_value?`, "ArgumentError: Expect 1 argument. got: 0"},
-		{`{ a: 1, b: 2 }.has_value?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.has_value?`, "ArgumentError: Expect 1 argument. got: 0", 1},
+		{`{ a: 1, b: 2 }.has_value?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -643,18 +608,15 @@ func TestHashKeysMethod(t *testing.T) {
 }
 
 func TestHashKeysMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.keys(123)`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.keys(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2 }.keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -683,18 +645,15 @@ func TestHashLengthMethod(t *testing.T) {
 }
 
 func TestHashLengthMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.length(123)`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.length(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.length(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2 }.length(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -759,26 +718,19 @@ func TestHashMapValuesMethod(t *testing.T) {
 }
 
 func TestHashMapValuesMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input       string
-		errMsg      string
-		expectedCfp int
-	}{
-		{`
-		{ a: 1, b: 2, c: 3 }.map_values("Hello") do |value|
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2, c: 3 }.map_values("Hello") do |value|
 		  value * 3
 		end
-		`, "ArgumentError: Expect 0 argument. got: 1", 2},
-		{`
-		{ a: 1, b: 2, c: 3 }.map_values
-		`, "InternalError: Can't yield without a block", 1},
+		`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2, c: 3 }.map_values`, "InternalError: Can't yield without a block", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
-		v.checkCFP(t, i, tt.expectedCfp)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -817,19 +769,16 @@ func TestHashMergeMethod(t *testing.T) {
 }
 
 func TestHashMergeMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.merge`, "ArgumentError: Expect at least 1 argument. got: 0"},
-		{`{ a: 1, b: 2 }.merge(true, { hello: "World" })`, "TypeError: Expect argument to be Hash. got: Boolean"},
-		{`{ a: 1, b: 2 }.merge({ hello: "World" }, 123, "Hello")`, "TypeError: Expect argument to be Hash. got: Integer"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.merge`, "ArgumentError: Expect at least 1 argument. got: 0", 1},
+		{`{ a: 1, b: 2 }.merge(true, { hello: "World" })`, "TypeError: Expect argument to be Hash. got: Boolean", 1},
+		{`{ a: 1, b: 2 }.merge({ hello: "World" }, 123, "Hello")`, "TypeError: Expect argument to be Hash. got: Integer", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -857,18 +806,15 @@ func TestHashSortedKeysMethod(t *testing.T) {
 }
 
 func TestHashSortedKeysMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.sorted_keys(123)`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.sorted_keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.sorted_keys(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2 }.sorted_keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -931,18 +877,15 @@ func TestHashToArrayMethod(t *testing.T) {
 }
 
 func TestHashToArrayMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.to_a(true, { hello: "World" })`, "ArgumentError: Expect 0..1 argument. got: 2"},
-		{`{ a: 1, b: 2 }.to_a(123)`, "TypeError: Expect argument to be Boolean. got: Integer"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.to_a(true, { hello: "World" })`, "ArgumentError: Expect 0..1 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.to_a(123)`, "TypeError: Expect argument to be Boolean. got: Integer", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -1100,18 +1043,15 @@ func TestHashToJSONMethodWithBasicTypes(t *testing.T) {
 }
 
 func TestHashToJSONMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.to_json(123)`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.to_json(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.to_json(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2 }.to_json(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -1137,18 +1077,15 @@ func TestHashToStringMethod(t *testing.T) {
 }
 
 func TestHashToStringMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.to_s(123)`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.to_s(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.to_s(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2 }.to_s(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -1213,26 +1150,19 @@ func TestHashTransformValuesMethod(t *testing.T) {
 }
 
 func TestHashTransformValuesMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input       string
-		errMsg      string
-		expectedCfp int
-	}{
-		{`
-		{ a: 1, b: 2, c: 3 }.transform_values("Hello") do |value|
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2, c: 3 }.transform_values("Hello") do |value|
 		  value * 3
 		end
-		`, "ArgumentError: Expect 0 argument. got: 1", 2},
-		{`
-		{ a: 1, b: 2, c: 3 }.transform_values
-		`, "InternalError: Can't yield without a block", 1},
+		`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2, c: 3 }.transform_values`, "InternalError: Can't yield without a block", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
-		v.checkCFP(t, i, tt.expectedCfp)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1269,18 +1199,15 @@ func TestHashValuesMethod(t *testing.T) {
 }
 
 func TestHashValuesMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`{ a: 1, b: 2 }.values(123)`, "ArgumentError: Expect 0 argument. got: 1"},
-		{`{ a: 1, b: 2 }.values(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2"},
+	testsFail := []errorTestCase{
+		{`{ a: 1, b: 2 }.values(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ a: 1, b: 2 }.values(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/http_request_test.go
+++ b/vm/http_request_test.go
@@ -32,7 +32,7 @@ func TestHTTPRequestObject(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/http_response_test.go
+++ b/vm/http_response_test.go
@@ -20,7 +20,7 @@ func TestHTTPResponseObject(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, "test")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -41,7 +41,7 @@ Net::HTTP.get("%s")
 `, ts.URL)
 
 	v := initTestVM()
-	evaluated := v.testEval(t, testScript)
+	evaluated := v.testEval(t, testScript, getFilename())
 	checkExpected(t, 0, evaluated, expected)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -67,7 +67,7 @@ Net::HTTP.get("%s", "path")
 `, ts.URL)
 
 	v := initTestVM()
-	evaluated := v.testEval(t, testScript)
+	evaluated := v.testEval(t, testScript, getFilename())
 	checkExpected(t, 0, evaluated, expected)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)

--- a/vm/inspection_methods.go
+++ b/vm/inspection_methods.go
@@ -14,7 +14,7 @@ func (i *instruction) inspect() string {
 	for _, param := range i.Params {
 		params = append(params, fmt.Sprint(param))
 	}
-	return fmt.Sprintf("%s: %s", i.action.name, strings.Join(params, ", "))
+	return fmt.Sprintf("%s: %s. source line: %d", i.action.name, strings.Join(params, ", "), i.sourceLine)
 }
 
 func (is *instructionSet) inspect() string {

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -17,9 +17,10 @@ type action struct {
 }
 
 type instruction struct {
-	action *action
-	Params []interface{}
-	Line   int
+	action     *action
+	Params     []interface{}
+	Line       int
+	sourceLine int
 }
 
 type instructionSet struct {
@@ -29,9 +30,10 @@ type instructionSet struct {
 	argTypes     []int
 }
 
-func (is *instructionSet) define(line int, a *action, params ...interface{}) {
+func (is *instructionSet) define(line int, a *action, params ...interface{}) *instruction {
 	i := &instruction{action: a, Params: params, Line: line}
 	is.instructions = append(is.instructions, i)
+	return i
 }
 
 var builtInActions = map[operationType]*action{

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -210,6 +210,7 @@ var builtInActions = map[operationType]*action{
 
 			if !ok {
 				t.returnError(TypeError, "Expect stack top's value to be an Array when executing 'expandarray' instruction.")
+				return
 			}
 
 			elems := []Object{}
@@ -322,6 +323,7 @@ var builtInActions = map[operationType]*action{
 
 			if !ok {
 				t.returnError(InternalError, "Can't get method %s's instruction set.", methodName)
+				return
 			}
 
 			method := &MethodObject{Name: methodName, argc: argCount, instructionSet: is, baseObj: &baseObj{class: t.vm.topLevelClass(methodClass)}}
@@ -373,6 +375,12 @@ var builtInActions = map[operationType]*action{
 
 					if !ok {
 						t.returnError(InternalError, "Constant %s is not a class. got=%s", superClassName, string(superClass.Target.Class().ReturnName()))
+						return
+					}
+
+					if inheritedClass.isModule {
+						t.returnError(InternalError, "Module inheritance is not supported: %s", inheritedClass.Name)
+						return
 					}
 
 					class.inherits(inheritedClass)
@@ -432,6 +440,7 @@ var builtInActions = map[operationType]*action{
 
 			if cf.blockFrame == nil {
 				t.returnError(InternalError, "Can't yield without a block")
+				return
 			}
 
 			blockFrame := cf.blockFrame

--- a/vm/instruction_translator.go
+++ b/vm/instruction_translator.go
@@ -106,5 +106,6 @@ func (it *instructionTranslator) transferInstruction(is *instructionSet, i *byte
 		}
 	}
 
-	is.define(i.Line(), action, params...)
+	vmI := is.define(i.Line(), action, params...)
+	vmI.sourceLine = i.SourceLine()
 }

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -555,11 +555,11 @@ func builtinIntegerInstanceMethods() []*BuiltInMethodObject {
 					n := receiver.(*IntegerObject)
 
 					if n.value < 0 {
-						return newError("Expect paramentr to be greater 0. got=%d", n.value)
+						return t.vm.initErrorObject(InternalError, "Expect integer greater than or equal 0. got: %d", n.value)
 					}
 
 					if blockFrame == nil {
-						return newError("Can't yield without a block")
+						return t.vm.initErrorObject(InternalError, CantYieldWithoutBlockFormat)
 					}
 
 					for i := 0; i < n.value; i++ {

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -60,28 +60,17 @@ func TestIntegerArithmeticOperation(t *testing.T) {
 }
 
 func TestIntegerArithmeticOperationFail(t *testing.T) {
-	testsFail := []struct {
-		input    string
-		expected string
-	}{
-		{`
-		1 + "p"
-		`, "TypeError: Expect argument to be Integer. got: String"},
-		{`
-		1 - "m"
-		`, "TypeError: Expect argument to be Integer. got: String"},
-		{`
-		1 ** "p"
-		`, "TypeError: Expect argument to be Integer. got: String"},
-		{`
-		1 / "t"
-		`, "TypeError: Expect argument to be Integer. got: String"},
+	testsFail := []errorTestCase{
+		{`1 + "p"`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`1 - "m"`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`1 ** "p"`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`1 / "t"`, "TypeError: Expect argument to be Integer. got: String", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -133,31 +122,18 @@ func TestIntegerComparison(t *testing.T) {
 }
 
 func TestIntegerComparisonFail(t *testing.T) {
-	testsFail := []struct {
-		input    string
-		expected string
-	}{
-		{`
-		1 > "m"
-		`, "TypeError: Expect argument to be Integer. got: String"},
-		{`
-		1 >= "m"
-		`, "TypeError: Expect argument to be Integer. got: String"},
-		{`
-		1 < "m"
-		`, "TypeError: Expect argument to be Integer. got: String"},
-		{`
-		1 <= "m"
-		`, "TypeError: Expect argument to be Integer. got: String"},
-		{`
-		1 <=> "m"
-		`, "TypeError: Expect argument to be Integer. got: String"},
+	testsFail := []errorTestCase{
+		{`1 > "m"`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`1 >= "m"`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`1 < "m"`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`1 <= "m"`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`1 <=> "m"`, "TypeError: Expect argument to be Integer. got: String", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -276,22 +252,15 @@ func TestIntegerTimesMethod(t *testing.T) {
 }
 
 func TestIntegerTimesMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`
-		(-2).times
-		`, "InternalError: Expect integer greater than or equal 0. got: -2"},
-		{`
-		2.times
-		`, "InternalError: Can't yield without a block"},
+	testsFail := []errorTestCase{
+		{`(-2).times`, "InternalError: Expect integer greater than or equal 0. got: -2", 1},
+		{`2.times`, "InternalError: Can't yield without a block", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -81,7 +81,7 @@ func TestIntegerArithmeticOperationFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -157,7 +157,7 @@ func TestIntegerComparisonFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.expected, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -291,7 +291,7 @@ func TestIntegerTimesMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -15,7 +15,7 @@ func TestIntegerClassSuperclass(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -52,7 +52,7 @@ func TestIntegerArithmeticOperation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -80,8 +80,8 @@ func TestIntegerArithmeticOperationFail(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, TypeError, tt.expected)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -125,7 +125,7 @@ func TestIntegerComparison(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -156,8 +156,8 @@ func TestIntegerComparisonFail(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, TypeError, tt.expected)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -174,7 +174,7 @@ func TestIntegerConversion(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -192,7 +192,7 @@ func TestIntegerEvenMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -210,7 +210,7 @@ func TestIntegerNextMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -228,7 +228,7 @@ func TestIntegerOddMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -246,7 +246,7 @@ func TestIntegerPredMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -268,7 +268,7 @@ func TestIntegerTimesMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -277,27 +277,21 @@ func TestIntegerTimesMethod(t *testing.T) {
 
 func TestIntegerTimesMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input    string
-		expected *Error
+		input  string
+		errMsg string
 	}{
 		{`
 		(-2).times
-		`, newError("Expect paramentr to be greater 0. got=-2")},
+		`, "InternalError: Expect integer greater than or equal 0. got: -2"},
 		{`
 		2.times
-		`, newError("Can't yield without a block")},
+		`, "InternalError: Can't yield without a block"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		err, ok := evaluated.(*Error)
-		if !ok {
-			t.Errorf("Expect error. got=%T (%+v)", err, err)
-		}
-		if err.Message != tt.expected.Message {
-			t.Errorf("Expect error message \"%s\". got=\"%s\"", tt.expected.Message, err.Message)
-		}
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/json_test.go
+++ b/vm/json_test.go
@@ -40,7 +40,7 @@ func TestJSONObjectParsing(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -89,7 +89,7 @@ func TestJSONObjectArrayParsing(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/null_test.go
+++ b/vm/null_test.go
@@ -13,7 +13,7 @@ func TestNullClassSuperclass(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -24,7 +24,7 @@ func TestEvalNil(t *testing.T) {
 	input := `nil`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, nil)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -37,7 +37,7 @@ func TestBangPrefix(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, true)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -58,7 +58,7 @@ func TestNullComparisonOperation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -82,7 +82,7 @@ func TestNullIsNilMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -110,7 +110,7 @@ func TestNullAssignmentByOperation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -119,17 +119,16 @@ func TestNullAssignmentByOperation(t *testing.T) {
 
 func TestNullIsNilMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`nil.nil?("Hello")`, ArgumentError, "ArgumentError: Expect 0 argument. got: 1"},
+		{`nil.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/null_test.go
+++ b/vm/null_test.go
@@ -118,17 +118,14 @@ func TestNullAssignmentByOperation(t *testing.T) {
 }
 
 func TestNullIsNilMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`nil.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1"},
+	testsFail := []errorTestCase{
+		{`nil.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/null_test.go
+++ b/vm/null_test.go
@@ -128,7 +128,7 @@ func TestNullIsNilMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/object_test.go
+++ b/vm/object_test.go
@@ -13,7 +13,7 @@ func TestObjectClassSuperclass(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/plugin_integration_test.go
+++ b/vm/plugin_integration_test.go
@@ -22,7 +22,7 @@ func TestCallingPluginFunction(t *testing.T) {
 	// We don't test the result here for two reasons:
 	// - If it doesn't work it'll returns error or panic
 	// - It's hard to test a plugin obj
-	v.testEval(t, input)
+	v.testEval(t, input, getFilename())
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -38,7 +38,7 @@ func TestCallingPluginFunctionWithReturnValue(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, "Bar")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -55,7 +55,7 @@ func TestCallingLibFuncFromPlugin(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, "lib")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
@@ -79,7 +79,7 @@ func TestPluginGeneration(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	checkExpected(t, 0, evaluated, true)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)

--- a/vm/plugin_test.go
+++ b/vm/plugin_test.go
@@ -46,7 +46,7 @@ func TestPluginInitialization(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/range_test.go
+++ b/vm/range_test.go
@@ -15,7 +15,7 @@ func TestRangeClassSuperclass(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -47,7 +47,7 @@ func TestRangeComparisonOperation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -189,7 +189,7 @@ func TestRangeBsearchMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -211,8 +211,8 @@ func TestRangeBsearchMethodFail(t *testing.T) {
 	}
 
 	for i, tt := range testsFail {
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, TypeError, tt.errorMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errorMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -270,7 +270,7 @@ func TestRangeEachMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -298,7 +298,7 @@ func TestRangeFirstMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -347,7 +347,7 @@ func TestRangeIncludeMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -375,7 +375,7 @@ func TestRangeLastMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -403,7 +403,7 @@ func TestRangeSizeMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -463,7 +463,7 @@ func TestRangeStepMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -491,7 +491,7 @@ func TestRangeToStringMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -525,7 +525,7 @@ func TestRangeToArrayMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/range_test.go
+++ b/vm/range_test.go
@@ -198,21 +198,17 @@ func TestRangeBsearchMethod(t *testing.T) {
 
 func TestRangeBsearchMethodFail(t *testing.T) {
 	v := initTestVM()
-	testsFail := []struct {
-		input    string
-		errorMsg string
-	}{
-		{`
-		ary = [0, 4, 7, 10, 12]
+	testsFail := []errorTestCase{
+		{`ary = [0, 4, 7, 10, 12]
 		(0..4).bsearch do |i|
 			"Binary Search"
 		end
-		`, "TypeError: Expect Integer or Boolean type. got=String"},
+		`, "TypeError: Expect Integer or Boolean type. got=String", 2},
 	}
 
 	for i, tt := range testsFail {
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errorMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/range_test.go
+++ b/vm/range_test.go
@@ -212,7 +212,7 @@ func TestRangeBsearchMethodFail(t *testing.T) {
 
 	for i, tt := range testsFail {
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errorMsg, getFilename())
+		checkError(t, i, evaluated, tt.errorMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/repl.go
+++ b/vm/repl.go
@@ -13,6 +13,7 @@ func (vm *VM) InitForREPL() {
 	// REPL should maintain a base call frame so that the whole program won't exit
 	cf := newCallFrame(&instructionSet{name: "REPL base"})
 	cf.self = vm.mainObj
+	vm.mode = REPLMode
 	vm.mainThread.callFrameStack.push(cf)
 }
 

--- a/vm/simple_server_test.go
+++ b/vm/simple_server_test.go
@@ -21,7 +21,7 @@ func TestServerInitialization(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/stack.go
+++ b/vm/stack.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+	"os"
 	"sync"
 )
 
@@ -29,9 +31,14 @@ func (s *stack) push(v *Pointer) {
 		s.Data[s.thread.sp] = v
 	}
 
-	if _, ok := v.Target.(*Error); ok {
+	if err, ok := v.Target.(*Error); ok {
 		cf := s.thread.callFrameStack.top()
 		cf.pc = len(cf.instructionSet.instructions)
+
+		if s.thread.vm.mode == NormalMode {
+			fmt.Println(err.Message)
+			os.Exit(1)
+		}
 	}
 
 	s.thread.sp++

--- a/vm/stack.go
+++ b/vm/stack.go
@@ -1,6 +1,8 @@
 package vm
 
-import "sync"
+import (
+	"sync"
+)
 
 type stack struct {
 	Data   []*Pointer
@@ -25,6 +27,11 @@ func (s *stack) push(v *Pointer) {
 		s.Data = append(s.Data, v)
 	} else {
 		s.Data[s.thread.sp] = v
+	}
+
+	if _, ok := v.Target.(*Error); ok {
+		cf := s.thread.callFrameStack.top()
+		cf.pc = len(cf.instructionSet.instructions)
 	}
 
 	s.thread.sp++

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -26,7 +26,7 @@ func TestReturnStatementEvaluation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -53,7 +53,7 @@ func TestDefStatement(t *testing.T) {
 	`
 
 	v := initTestVM()
-	evaluated := v.testEval(t, input)
+	evaluated := v.testEval(t, input, getFilename())
 	class := evaluated.(*RClass)
 
 	expectedMethods := []struct {
@@ -194,7 +194,7 @@ func TestModuleStatement(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -260,7 +260,7 @@ func TestWhileStatement(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -310,7 +310,7 @@ i
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -361,7 +361,7 @@ a + 100
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -129,19 +129,16 @@ func TestStringComparison(t *testing.T) {
 	}
 }
 
-func TestStringConparisonFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"a" < 1`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"a" > 1`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"a" <=> 1`, "TypeError: Expect argument to be String. got: Integer"},
+func TestStringComparisonFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`"a" < 1`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`"a" > 1`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`"a" <=> 1`, "TypeError: Expect argument to be String. got: Integer", 1},
 	}
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -184,23 +181,20 @@ func TestStringOperation(t *testing.T) {
 }
 
 func TestStringOperationFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Taipei" + 101`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Taipei" * "101"`, "TypeError: Expect argument to be Integer. got: String"},
-		{`"Taipei" * (-101)`, "ArgumentError: Second argument must be greater than or equal to 0. got=-101"},
-		{`"Taipei"[1] = 1`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Taipei"[1] = true`, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"Taipei"[]`, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Taipei"[true] = 101`, "TypeError: Expect argument to be Integer. got: Boolean"},
+	testsFail := []errorTestCase{
+		{`"Taipei" + 101`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`"Taipei" * "101"`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`"Taipei" * (-101)`, "ArgumentError: Second argument must be greater than or equal to 0. got=-101", 1},
+		{`"Taipei"[1] = 1`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`"Taipei"[1] = true`, "TypeError: Expect argument to be String. got: Boolean", 1},
+		{`"Taipei"[]`, "ArgumentError: Expect 1 argument. got=0", 1},
+		{`"Taipei"[true] = 101`, "TypeError: Expect argument to be Integer. got: Boolean", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -268,21 +262,18 @@ func TestStringConcatenateMethod(t *testing.T) {
 }
 
 func TestStringConcatenateMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"a".concat`, "ArgumentError: Expect 1 argument. got=0"},
-		{`"a".concat("Hello", "World")`, "ArgumentError: Expect 1 argument. got=2"},
-		{`"a".concat(1)`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"a".concat(true)`, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"a".concat(nil)`, "TypeError: Expect argument to be String. got: Null"},
+	testsFail := []errorTestCase{
+		{`"a".concat`, "ArgumentError: Expect 1 argument. got=0", 1},
+		{`"a".concat("Hello", "World")`, "ArgumentError: Expect 1 argument. got=2", 1},
+		{`"a".concat(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`"a".concat(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
+		{`"a".concat(nil)`, "TypeError: Expect argument to be String. got: Null", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -327,20 +318,17 @@ func TestStringDeleteMethod(t *testing.T) {
 }
 
 func TestStringDeleteMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Hello hello HeLlo".delete`, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Hello hello HeLlo".delete(1)`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Hello hello HeLlo".delete(true)`, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"Hello hello HeLlo".delete(nil)`, "TypeError: Expect argument to be String. got: Null"},
+	testsFail := []errorTestCase{
+		{`"Hello hello HeLlo".delete`, "ArgumentError: Expect 1 argument. got=0", 1},
+		{`"Hello hello HeLlo".delete(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`"Hello hello HeLlo".delete(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
+		{`"Hello hello HeLlo".delete(nil)`, "TypeError: Expect argument to be String. got: Null", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -391,20 +379,17 @@ func TestStringEndWithMethod(t *testing.T) {
 }
 
 func TestStringEndWithMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Taipei".end_with?("1", "0", "1")`, "ArgumentError: Expect 1 argument. got=3"},
-		{`"Taipei".end_with?(101)`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Hello".end_with?(true)`, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"Hello".end_with?(1..5)`, "TypeError: Expect argument to be String. got: Range"},
+	testsFail := []errorTestCase{
+		{`"Taipei".end_with?("1", "0", "1")`, "ArgumentError: Expect 1 argument. got=3", 1},
+		{`"Taipei".end_with?(101)`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`"Hello".end_with?(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
+		{`"Hello".end_with?(1..5)`, "TypeError: Expect argument to be String. got: Range", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -452,18 +437,15 @@ func TestStringEqualMethod(t *testing.T) {
 }
 
 func TestStringEqualMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Hello".eql?`, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Hello".eql?("Hello", "World")`, "ArgumentError: Expect 1 argument. got=2"},
+	testsFail := []errorTestCase{
+		{`"Hello".eql?`, "ArgumentError: Expect 1 argument. got=0", 1},
+		{`"Hello".eql?("Hello", "World")`, "ArgumentError: Expect 1 argument. got=2", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -490,20 +472,17 @@ func TestStringGlobalSubstituteMethod(t *testing.T) {
 }
 
 func TestStringGlobalSubstituteMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Ruby".gsub()`, "ArgumentError: Expect 2 arguments. got=0"},
-		{`"Ruby".gsub("Ru")`, "ArgumentError: Expect 2 arguments. got=1"},
-		{`"Ruby".gsub(123, "Go")`, "TypeError: Expect pattern to be String. got: Integer"},
-		{`"Ruby".gsub("Ru", 456)`, "TypeError: Expect replacement to be String. got: Integer"},
+	testsFail := []errorTestCase{
+		{`"Ruby".gsub()`, "ArgumentError: Expect 2 arguments. got=0", 1},
+		{`"Ruby".gsub("Ru")`, "ArgumentError: Expect 2 arguments. got=1", 1},
+		{`"Ruby".gsub(123, "Go")`, "TypeError: Expect pattern to be String. got: Integer", 1},
+		{`"Ruby".gsub("Ru", 456)`, "TypeError: Expect replacement to be String. got: Integer", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -533,21 +512,18 @@ func TestStringIncludeMethod(t *testing.T) {
 }
 
 func TestStringIncludeMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Goby".include?`, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Goby".include?("Ruby", "Lang")`, "ArgumentError: Expect 1 argument. got=2"},
-		{`"Goby".include?(2)`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Goby".include?(true)`, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"Goby".include?(nil)`, "TypeError: Expect argument to be String. got: Null"},
+	testsFail := []errorTestCase{
+		{`"Goby".include?`, "ArgumentError: Expect 1 argument. got=0", 1},
+		{`"Goby".include?("Ruby", "Lang")`, "ArgumentError: Expect 1 argument. got=2", 1},
+		{`"Goby".include?(2)`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`"Goby".include?(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
+		{`"Goby".include?(nil)`, "TypeError: Expect argument to be String. got: Null", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -580,22 +556,19 @@ func TestStringInsertMethod(t *testing.T) {
 }
 
 func TestStringInsertMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Goby Lang".insert`, "ArgumentError: Expect 2 arguments. got=0"},
-		{`"Taipei".insert(6, " ", "101")`, "ArgumentError: Expect 2 arguments. got=3"},
-		{`"Taipei".insert("6", " 101")`, "TypeError: Expect argument to be Integer. got: String"},
-		{`"Taipei".insert(6, 101)`, "TypeError: Expect insert string to be String. got: Integer"},
-		{`"Taipei".insert(-8, "101")`, "ArgumentError: Index value out of range. got=-8"},
-		{`"Taipei".insert(7, "101")`, "ArgumentError: Index value out of range. got=7"},
+	testsFail := []errorTestCase{
+		{`"Goby Lang".insert`, "ArgumentError: Expect 2 arguments. got=0", 1},
+		{`"Taipei".insert(6, " ", "101")`, "ArgumentError: Expect 2 arguments. got=3", 1},
+		{`"Taipei".insert("6", " 101")`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`"Taipei".insert(6, 101)`, "TypeError: Expect insert string to be String. got: Integer", 1},
+		{`"Taipei".insert(-8, "101")`, "ArgumentError: Index value out of range. got=-8", 1},
+		{`"Taipei".insert(7, "101")`, "ArgumentError: Index value out of range. got=7", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -622,24 +595,21 @@ func TestStringLeftJustifyMethod(t *testing.T) {
 }
 
 func TestStringLeftJustifyMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Hello".ljust`, "ArgumentError: Expect 1..2 arguments. got=0"},
-		{`"Hello".ljust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1..2 arguments. got=5"},
-		{`"Hello".ljust(true)`, "TypeError: Expect justify width to be Integer. got: Boolean"},
-		{`"Hello".ljust("World")`, "TypeError: Expect justify width to be Integer. got: String"},
-		{`"Hello".ljust(2..5)`, "TypeError: Expect justify width to be Integer. got: Range"},
-		{`"Hello".ljust(10, 10)`, "TypeError: Expect padding string to be String. got: Integer"},
-		{`"Hello".ljust(10, 2..5)`, "TypeError: Expect padding string to be String. got: Range"},
-		{`"Hello".ljust(10, true)`, "TypeError: Expect padding string to be String. got: Boolean"},
+	testsFail := []errorTestCase{
+		{`"Hello".ljust`, "ArgumentError: Expect 1..2 arguments. got=0", 1},
+		{`"Hello".ljust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1..2 arguments. got=5", 1},
+		{`"Hello".ljust(true)`, "TypeError: Expect justify width to be Integer. got: Boolean", 1},
+		{`"Hello".ljust("World")`, "TypeError: Expect justify width to be Integer. got: String", 1},
+		{`"Hello".ljust(2..5)`, "TypeError: Expect justify width to be Integer. got: Range", 1},
+		{`"Hello".ljust(10, 10)`, "TypeError: Expect padding string to be String. got: Integer", 1},
+		{`"Hello".ljust(10, 2..5)`, "TypeError: Expect padding string to be String. got: Range", 1},
+		{`"Hello".ljust(10, true)`, "TypeError: Expect padding string to be String. got: Boolean", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -685,19 +655,16 @@ func TestStringReplaceMethod(t *testing.T) {
 }
 
 func TestStringReplaceMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Taipei".replace`, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Taipei".replace(101)`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Taipei".replace(true)`, "TypeError: Expect argument to be String. got: Boolean"},
+	testsFail := []errorTestCase{
+		{`"Taipei".replace`, "ArgumentError: Expect 1 argument. got=0", 1},
+		{`"Taipei".replace(101)`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`"Taipei".replace(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -745,24 +712,21 @@ func TestStringRightJustifyMethod(t *testing.T) {
 }
 
 func TestStringRightJustifyFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Hello".rjust`, "ArgumentError: Expect 1..2 arguments. got=0"},
-		{`"Hello".rjust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1..2 arguments. got=5"},
-		{`"Hello".rjust(true)`, "TypeError: Expect justify width to be Integer. got: Boolean"},
-		{`"Hello".rjust("World")`, "TypeError: Expect justify width to be Integer. got: String"},
-		{`"Hello".rjust(2..5)`, "TypeError: Expect justify width to be Integer. got: Range"},
-		{`"Hello".rjust(10, 10)`, "TypeError: Expect padding string to be String. got: Integer"},
-		{`"Hello".rjust(10, 2..5)`, "TypeError: Expect padding string to be String. got: Range"},
-		{`"Hello".rjust(10, true)`, "TypeError: Expect padding string to be String. got: Boolean"},
+	testsFail := []errorTestCase{
+		{`"Hello".rjust`, "ArgumentError: Expect 1..2 arguments. got=0", 1},
+		{`"Hello".rjust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1..2 arguments. got=5", 1},
+		{`"Hello".rjust(true)`, "TypeError: Expect justify width to be Integer. got: Boolean", 1},
+		{`"Hello".rjust("World")`, "TypeError: Expect justify width to be Integer. got: String", 1},
+		{`"Hello".rjust(2..5)`, "TypeError: Expect justify width to be Integer. got: Range", 1},
+		{`"Hello".rjust(10, 10)`, "TypeError: Expect padding string to be String. got: Integer", 1},
+		{`"Hello".rjust(10, 2..5)`, "TypeError: Expect padding string to be String. got: Range", 1},
+		{`"Hello".rjust(10, true)`, "TypeError: Expect padding string to be String. got: Boolean", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -835,19 +799,16 @@ func TestStringSliceMethod(t *testing.T) {
 }
 
 func TestStringSliceMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Goby Lang".slice`, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Goby Lang".slice("Hello")`, "TypeError: Expect slice range to be Range or Integer. got: String"},
-		{`"Goby Lang".slice(true)`, "TypeError: Expect slice range to be Range or Integer. got: Boolean"},
+	testsFail := []errorTestCase{
+		{`"Goby Lang".slice`, "ArgumentError: Expect 1 argument. got=0", 1},
+		{`"Goby Lang".slice("Hello")`, "TypeError: Expect slice range to be Range or Integer. got: String", 1},
+		{`"Goby Lang".slice(true)`, "TypeError: Expect slice range to be Range or Integer. got: Boolean", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -934,20 +895,17 @@ func TestStringSplitMethod(t *testing.T) {
 }
 
 func TestStringSplitMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Hello World".split`, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Hello World".split(true)`, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"Hello World".split(123)`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Hello World".split(1..2)`, "TypeError: Expect argument to be String. got: Range"},
+	testsFail := []errorTestCase{
+		{`"Hello World".split`, "ArgumentError: Expect 1 argument. got=0", 1},
+		{`"Hello World".split(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
+		{`"Hello World".split(123)`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`"Hello World".split(1..2)`, "TypeError: Expect argument to be String. got: Range", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -978,20 +936,17 @@ func TestStringStartWithMethod(t *testing.T) {
 }
 
 func TestStringStartWithMethodFail(t *testing.T) {
-	testsFail := []struct {
-		input  string
-		errMsg string
-	}{
-		{`"Taipei".start_with("1", "0", "1")`, "ArgumentError: Expect 1 argument. got=3"},
-		{`"Taipei".start_with(101)`, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Hello".start_with(true)`, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"Hello".start_with(1..5)`, "TypeError: Expect argument to be String. got: Range"},
+	testsFail := []errorTestCase{
+		{`"Taipei".start_with("1", "0", "1")`, "ArgumentError: Expect 1 argument. got=3", 1},
+		{`"Taipei".start_with(101)`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`"Hello".start_with(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
+		{`"Hello".start_with(1..5)`, "TypeError: Expect argument to be String. got: Range", 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -15,7 +15,7 @@ func TestStringClassSuperclass(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -33,7 +33,7 @@ func TestEvalStringExpression(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -78,7 +78,7 @@ func TestStringConversion(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -122,7 +122,7 @@ func TestStringComparison(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -140,8 +140,8 @@ func TestStringConparisonFail(t *testing.T) {
 	}
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, TypeError, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -176,7 +176,7 @@ func TestStringOperation(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -185,23 +185,22 @@ func TestStringOperation(t *testing.T) {
 
 func TestStringOperationFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Taipei" + 101`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Taipei" * "101"`, TypeError, "TypeError: Expect argument to be Integer. got: String"},
-		{`"Taipei" * (-101)`, ArgumentError, "ArgumentError: Second argument must be greater than or equal to 0. got=-101"},
-		{`"Taipei"[1] = 1`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Taipei"[1] = true`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"Taipei"[]`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Taipei"[true] = 101`, TypeError, "TypeError: Expect argument to be Integer. got: Boolean"},
+		{`"Taipei" + 101`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Taipei" * "101"`, "TypeError: Expect argument to be Integer. got: String"},
+		{`"Taipei" * (-101)`, "ArgumentError: Second argument must be greater than or equal to 0. got=-101"},
+		{`"Taipei"[1] = 1`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Taipei"[1] = true`, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"Taipei"[]`, "ArgumentError: Expect 1 argument. got=0"},
+		{`"Taipei"[true] = 101`, "TypeError: Expect argument to be Integer. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -224,7 +223,7 @@ func TestStringCapitalizeMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -243,7 +242,7 @@ func TestStringChopMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -261,7 +260,7 @@ func TestStringConcatenateMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -270,21 +269,20 @@ func TestStringConcatenateMethod(t *testing.T) {
 
 func TestStringConcatenateMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"a".concat`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
-		{`"a".concat("Hello", "World")`, ArgumentError, "ArgumentError: Expect 1 argument. got=2"},
-		{`"a".concat(1)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
-		{`"a".concat(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"a".concat(nil)`, TypeError, "TypeError: Expect argument to be String. got: Null"},
+		{`"a".concat`, "ArgumentError: Expect 1 argument. got=0"},
+		{`"a".concat("Hello", "World")`, "ArgumentError: Expect 1 argument. got=2"},
+		{`"a".concat(1)`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"a".concat(true)`, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"a".concat(nil)`, "TypeError: Expect argument to be String. got: Null"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -303,7 +301,7 @@ func TestStringCountMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -321,7 +319,7 @@ func TestStringDeleteMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -330,20 +328,19 @@ func TestStringDeleteMethod(t *testing.T) {
 
 func TestStringDeleteMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Hello hello HeLlo".delete`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Hello hello HeLlo".delete(1)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Hello hello HeLlo".delete(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"Hello hello HeLlo".delete(nil)`, TypeError, "TypeError: Expect argument to be String. got: Null"},
+		{`"Hello hello HeLlo".delete`, "ArgumentError: Expect 1 argument. got=0"},
+		{`"Hello hello HeLlo".delete(1)`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Hello hello HeLlo".delete(true)`, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"Hello hello HeLlo".delete(nil)`, "TypeError: Expect argument to be String. got: Null"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -362,7 +359,7 @@ func TestStringDowncaseMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -386,7 +383,7 @@ func TestStringEndWithMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -395,20 +392,19 @@ func TestStringEndWithMethod(t *testing.T) {
 
 func TestStringEndWithMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Taipei".end_with?("1", "0", "1")`, ArgumentError, "ArgumentError: Expect 1 argument. got=3"},
-		{`"Taipei".end_with?(101)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Hello".end_with?(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"Hello".end_with?(1..5)`, TypeError, "TypeError: Expect argument to be String. got: Range"},
+		{`"Taipei".end_with?("1", "0", "1")`, "ArgumentError: Expect 1 argument. got=3"},
+		{`"Taipei".end_with?(101)`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Hello".end_with?(true)`, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"Hello".end_with?(1..5)`, "TypeError: Expect argument to be String. got: Range"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -425,7 +421,7 @@ func TestStringEmptyMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -448,7 +444,7 @@ func TestStringEqualMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -466,8 +462,8 @@ func TestStringEqualMethodFail(t *testing.T) {
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, ArgumentError, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -486,7 +482,7 @@ func TestStringGlobalSubstituteMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -495,20 +491,19 @@ func TestStringGlobalSubstituteMethod(t *testing.T) {
 
 func TestStringGlobalSubstituteMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Ruby".gsub()`, ArgumentError, "ArgumentError: Expect 2 arguments. got=0"},
-		{`"Ruby".gsub("Ru")`, ArgumentError, "ArgumentError: Expect 2 arguments. got=1"},
-		{`"Ruby".gsub(123, "Go")`, TypeError, "TypeError: Expect pattern to be String. got: Integer"},
-		{`"Ruby".gsub("Ru", 456)`, TypeError, "TypeError: Expect replacement to be String. got: Integer"},
+		{`"Ruby".gsub()`, "ArgumentError: Expect 2 arguments. got=0"},
+		{`"Ruby".gsub("Ru")`, "ArgumentError: Expect 2 arguments. got=1"},
+		{`"Ruby".gsub(123, "Go")`, "TypeError: Expect pattern to be String. got: Integer"},
+		{`"Ruby".gsub("Ru", 456)`, "TypeError: Expect replacement to be String. got: Integer"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -530,7 +525,7 @@ func TestStringIncludeMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -539,21 +534,20 @@ func TestStringIncludeMethod(t *testing.T) {
 
 func TestStringIncludeMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Goby".include?`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Goby".include?("Ruby", "Lang")`, ArgumentError, "ArgumentError: Expect 1 argument. got=2"},
-		{`"Goby".include?(2)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Goby".include?(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"Goby".include?(nil)`, TypeError, "TypeError: Expect argument to be String. got: Null"},
+		{`"Goby".include?`, "ArgumentError: Expect 1 argument. got=0"},
+		{`"Goby".include?("Ruby", "Lang")`, "ArgumentError: Expect 1 argument. got=2"},
+		{`"Goby".include?(2)`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Goby".include?(true)`, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"Goby".include?(nil)`, "TypeError: Expect argument to be String. got: Null"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -578,7 +572,7 @@ func TestStringInsertMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -587,22 +581,21 @@ func TestStringInsertMethod(t *testing.T) {
 
 func TestStringInsertMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Goby Lang".insert`, ArgumentError, "ArgumentError: Expect 2 arguments. got=0"},
-		{`"Taipei".insert(6, " ", "101")`, ArgumentError, "ArgumentError: Expect 2 arguments. got=3"},
-		{`"Taipei".insert("6", " 101")`, TypeError, "TypeError: Expect argument to be Integer. got: String"},
-		{`"Taipei".insert(6, 101)`, TypeError, "TypeError: Expect insert string to be String. got: Integer"},
-		{`"Taipei".insert(-8, "101")`, ArgumentError, "ArgumentError: Index value out of range. got=-8"},
-		{`"Taipei".insert(7, "101")`, ArgumentError, "ArgumentError: Index value out of range. got=7"},
+		{`"Goby Lang".insert`, "ArgumentError: Expect 2 arguments. got=0"},
+		{`"Taipei".insert(6, " ", "101")`, "ArgumentError: Expect 2 arguments. got=3"},
+		{`"Taipei".insert("6", " 101")`, "TypeError: Expect argument to be Integer. got: String"},
+		{`"Taipei".insert(6, 101)`, "TypeError: Expect insert string to be String. got: Integer"},
+		{`"Taipei".insert(-8, "101")`, "ArgumentError: Index value out of range. got=-8"},
+		{`"Taipei".insert(7, "101")`, "ArgumentError: Index value out of range. got=7"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -621,7 +614,7 @@ func TestStringLeftJustifyMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -630,24 +623,23 @@ func TestStringLeftJustifyMethod(t *testing.T) {
 
 func TestStringLeftJustifyMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Hello".ljust`, ArgumentError, "ArgumentError: Expect 1..2 arguments. got=0"},
-		{`"Hello".ljust(1, 2, 3, 4, 5)`, ArgumentError, "ArgumentError: Expect 1..2 arguments. got=5"},
-		{`"Hello".ljust(true)`, TypeError, "TypeError: Expect justify width to be Integer. got: Boolean"},
-		{`"Hello".ljust("World")`, TypeError, "TypeError: Expect justify width to be Integer. got: String"},
-		{`"Hello".ljust(2..5)`, TypeError, "TypeError: Expect justify width to be Integer. got: Range"},
-		{`"Hello".ljust(10, 10)`, TypeError, "TypeError: Expect padding string to be String. got: Integer"},
-		{`"Hello".ljust(10, 2..5)`, TypeError, "TypeError: Expect padding string to be String. got: Range"},
-		{`"Hello".ljust(10, true)`, TypeError, "TypeError: Expect padding string to be String. got: Boolean"},
+		{`"Hello".ljust`, "ArgumentError: Expect 1..2 arguments. got=0"},
+		{`"Hello".ljust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1..2 arguments. got=5"},
+		{`"Hello".ljust(true)`, "TypeError: Expect justify width to be Integer. got: Boolean"},
+		{`"Hello".ljust("World")`, "TypeError: Expect justify width to be Integer. got: String"},
+		{`"Hello".ljust(2..5)`, "TypeError: Expect justify width to be Integer. got: Range"},
+		{`"Hello".ljust(10, 10)`, "TypeError: Expect padding string to be String. got: Integer"},
+		{`"Hello".ljust(10, 2..5)`, "TypeError: Expect padding string to be String. got: Range"},
+		{`"Hello".ljust(10, true)`, "TypeError: Expect padding string to be String. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -665,7 +657,7 @@ func TestStringLengthMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -685,7 +677,7 @@ func TestStringReplaceMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -694,19 +686,18 @@ func TestStringReplaceMethod(t *testing.T) {
 
 func TestStringReplaceMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Taipei".replace`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Taipei".replace(101)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Taipei".replace(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"Taipei".replace`, "ArgumentError: Expect 1 argument. got=0"},
+		{`"Taipei".replace(101)`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Taipei".replace(true)`, "TypeError: Expect argument to be String. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -726,7 +717,7 @@ func TestStringReverseMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -746,7 +737,7 @@ func TestStringRightJustifyMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -755,24 +746,23 @@ func TestStringRightJustifyMethod(t *testing.T) {
 
 func TestStringRightJustifyFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Hello".rjust`, ArgumentError, "ArgumentError: Expect 1..2 arguments. got=0"},
-		{`"Hello".rjust(1, 2, 3, 4, 5)`, ArgumentError, "ArgumentError: Expect 1..2 arguments. got=5"},
-		{`"Hello".rjust(true)`, TypeError, "TypeError: Expect justify width to be Integer. got: Boolean"},
-		{`"Hello".rjust("World")`, TypeError, "TypeError: Expect justify width to be Integer. got: String"},
-		{`"Hello".rjust(2..5)`, TypeError, "TypeError: Expect justify width to be Integer. got: Range"},
-		{`"Hello".rjust(10, 10)`, TypeError, "TypeError: Expect padding string to be String. got: Integer"},
-		{`"Hello".rjust(10, 2..5)`, TypeError, "TypeError: Expect padding string to be String. got: Range"},
-		{`"Hello".rjust(10, true)`, TypeError, "TypeError: Expect padding string to be String. got: Boolean"},
+		{`"Hello".rjust`, "ArgumentError: Expect 1..2 arguments. got=0"},
+		{`"Hello".rjust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1..2 arguments. got=5"},
+		{`"Hello".rjust(true)`, "TypeError: Expect justify width to be Integer. got: Boolean"},
+		{`"Hello".rjust("World")`, "TypeError: Expect justify width to be Integer. got: String"},
+		{`"Hello".rjust(2..5)`, "TypeError: Expect justify width to be Integer. got: Range"},
+		{`"Hello".rjust(10, 10)`, "TypeError: Expect padding string to be String. got: Integer"},
+		{`"Hello".rjust(10, 2..5)`, "TypeError: Expect padding string to be String. got: Range"},
+		{`"Hello".rjust(10, true)`, "TypeError: Expect padding string to be String. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -790,7 +780,7 @@ func TestStringSizeMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -837,7 +827,7 @@ func TestStringSliceMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -846,19 +836,18 @@ func TestStringSliceMethod(t *testing.T) {
 
 func TestStringSliceMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Goby Lang".slice`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Goby Lang".slice("Hello")`, TypeError, "TypeError: Expect slice range to be Range or Integer. got: String"},
-		{`"Goby Lang".slice(true)`, TypeError, "TypeError: Expect slice range to be Range or Integer. got: Boolean"},
+		{`"Goby Lang".slice`, "ArgumentError: Expect 1 argument. got=0"},
+		{`"Goby Lang".slice("Hello")`, "TypeError: Expect slice range to be Range or Integer. got: String"},
+		{`"Goby Lang".slice(true)`, "TypeError: Expect slice range to be Range or Integer. got: Boolean"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -937,7 +926,7 @@ func TestStringSplitMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -946,20 +935,19 @@ func TestStringSplitMethod(t *testing.T) {
 
 func TestStringSplitMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Hello World".split`, ArgumentError, "ArgumentError: Expect 1 argument. got=0"},
-		{`"Hello World".split(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"Hello World".split(123)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Hello World".split(1..2)`, TypeError, "TypeError: Expect argument to be String. got: Range"},
+		{`"Hello World".split`, "ArgumentError: Expect 1 argument. got=0"},
+		{`"Hello World".split(true)`, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"Hello World".split(123)`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Hello World".split(1..2)`, "TypeError: Expect argument to be String. got: Range"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -982,7 +970,7 @@ func TestStringStartWithMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -991,20 +979,19 @@ func TestStringStartWithMethod(t *testing.T) {
 
 func TestStringStartWithMethodFail(t *testing.T) {
 	testsFail := []struct {
-		input   string
-		errType string
-		errMsg  string
+		input  string
+		errMsg string
 	}{
-		{`"Taipei".start_with("1", "0", "1")`, ArgumentError, "ArgumentError: Expect 1 argument. got=3"},
-		{`"Taipei".start_with(101)`, TypeError, "TypeError: Expect argument to be String. got: Integer"},
-		{`"Hello".start_with(true)`, TypeError, "TypeError: Expect argument to be String. got: Boolean"},
-		{`"Hello".start_with(1..5)`, TypeError, "TypeError: Expect argument to be String. got: Range"},
+		{`"Taipei".start_with("1", "0", "1")`, "ArgumentError: Expect 1 argument. got=3"},
+		{`"Taipei".start_with(101)`, "TypeError: Expect argument to be String. got: Integer"},
+		{`"Hello".start_with(true)`, "TypeError: Expect argument to be String. got: Boolean"},
+		{`"Hello".start_with(1..5)`, "TypeError: Expect argument to be String. got: Range"},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
-		checkError(t, i, evaluated, tt.errType, tt.errMsg)
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename())
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -1022,7 +1009,7 @@ func TestStringStripMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1042,7 +1029,7 @@ func TestStringUpcaseMethod(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1059,7 +1046,7 @@ func TestChainingStringMethods(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
@@ -1078,7 +1065,7 @@ func TestFormattedString(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -141,7 +141,7 @@ func TestStringConparisonFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -200,7 +200,7 @@ func TestStringOperationFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -282,7 +282,7 @@ func TestStringConcatenateMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -340,7 +340,7 @@ func TestStringDeleteMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -404,7 +404,7 @@ func TestStringEndWithMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -463,7 +463,7 @@ func TestStringEqualMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -503,7 +503,7 @@ func TestStringGlobalSubstituteMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -547,7 +547,7 @@ func TestStringIncludeMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -595,7 +595,7 @@ func TestStringInsertMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -639,7 +639,7 @@ func TestStringLeftJustifyMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -697,7 +697,7 @@ func TestStringReplaceMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -762,7 +762,7 @@ func TestStringRightJustifyFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -847,7 +847,7 @@ func TestStringSliceMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -947,7 +947,7 @@ func TestStringSplitMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
@@ -991,7 +991,7 @@ func TestStringStartWithMethodFail(t *testing.T) {
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkError(t, i, evaluated, tt.errMsg, getFilename())
+		checkError(t, i, evaluated, tt.errMsg, getFilename(), 0)
 		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -161,7 +161,7 @@ func (t *thread) evalMethodObject(receiver Object, method *MethodObject, receive
 }
 
 func (t *thread) returnError(errorType, format string, args ...interface{}) {
-	err := t.vm.initErrorObject(errorType, format, args)
+	err := t.vm.initErrorObject(errorType, format, args...)
 	t.stack.push(&Pointer{Target: err})
 }
 

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -1,7 +1,6 @@
 package vm
 
 import (
-	"fmt"
 	"github.com/goby-lang/goby/compiler/bytecode"
 	"strings"
 )
@@ -60,16 +59,6 @@ func (t *thread) hasError() (string, bool) {
 
 func (t *thread) execInstruction(cf *callFrame, i *instruction) {
 	cf.pc++
-
-	defer func() {
-		if p := recover(); p != nil {
-			if t.vm.stackTraceCount == 0 {
-				fmt.Printf("Internal Error: %s\n", p)
-			}
-			t.vm.stackTraceCount++
-			panic(p)
-		}
-	}()
 
 	i.action.operation(t, cf, i.Params...)
 }

--- a/vm/uri_test.go
+++ b/vm/uri_test.go
@@ -84,7 +84,7 @@ func TestURIParsing(t *testing.T) {
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, tt.input)
+		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -14,6 +14,13 @@ import (
 // Version stores current Goby version
 const Version = "0.0.9"
 
+// These are the enums for marking parser's mode, which decides whether it should pop unused values.
+const (
+	NormalMode int = iota
+	REPLMode
+	TestMode
+)
+
 type isIndexTable struct {
 	Data map[string]int
 }
@@ -63,6 +70,8 @@ type VM struct {
 	channelObjectMap *objectMap
 
 	sync.Mutex
+
+	mode int
 }
 
 // New initializes a vm to initialize state and returns it.

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -147,7 +147,9 @@ func initTestVM() *VM {
 		panic(err)
 	}
 
-	return New(fn, []string{})
+	v := New(fn, []string{})
+	v.mode = TestMode
+	return v
 }
 
 func (v *VM) testEval(t *testing.T, input, filepath string) Object {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -11,6 +11,12 @@ import (
 	"testing"
 )
 
+type errorTestCase struct {
+	input     string
+	expected  string
+	errorLine int
+}
+
 func TestVM_REPLExec(t *testing.T) {
 	tests := []struct {
 		inputs   []string

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/goby-lang/goby/compiler/bytecode"
 	"github.com/goby-lang/goby/compiler/lexer"
 	"github.com/goby-lang/goby/compiler/parser"
+	"os"
+	"runtime"
 	"testing"
 )
 
@@ -133,10 +135,16 @@ foo
 }
 
 func initTestVM() *VM {
-	return New("./", []string{})
+	fn, err := os.Getwd()
+
+	if err != nil {
+		panic(err)
+	}
+
+	return New(fn, []string{})
 }
 
-func (v *VM) testEval(t *testing.T, input string) Object {
+func (v *VM) testEval(t *testing.T, input, filepath string) Object {
 	iss, err := compiler.CompileToInstructions(input, parser.TestMode)
 
 	if err != nil {
@@ -144,7 +152,7 @@ func (v *VM) testEval(t *testing.T, input string) Object {
 		t.Fatal(err.Error())
 	}
 
-	v.ExecInstructions(iss, "./")
+	v.ExecInstructions(iss, filepath)
 
 	return v.mainThread.stack.top().Target
 }
@@ -274,4 +282,9 @@ func isError(obj Object) bool {
 		return ok
 	}
 	return false
+}
+
+func getFilename() string {
+	_, filename, _, _ := runtime.Caller(1)
+	return filename
 }


### PR DESCRIPTION
Currently the error message is like
```
ArgumentError: Expect at most 1 args for method 'set'. got: 2.
```

It should be:
```
ArgumentError: Expect at most 1 args for method 'set'. got: 2. At samples/sample-1.gb:16
```

And if we're executing files, it should exit with status 1