### PR TITLE
Forbidden duplicated method parameters

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -23,6 +23,8 @@ const (
 	MethodDefinitionError
 	// InvalidAssignmentError means user assigns value to wrong type of expressions
 	InvalidAssignmentError
+	// SyntaxError means there's a grammatical in the source code
+	SyntaxError
 )
 
 // Error represents parser's parsing error

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -114,6 +114,10 @@ func (p *Parser) parseParameters() []ast.Expression {
 		p.nextToken()
 		p.nextToken()
 		param := p.parseExpression(NORMAL)
+
+		if contains(params, param) {
+			p.error = &Error{Message: fmt.Sprintf("Duplicate argument name: \"%s\". Line: %d", param.TokenLiteral(), p.curToken.Line), errType: SyntaxError}
+		}
 		params = append(params, param)
 	}
 
@@ -235,4 +239,23 @@ func (p *Parser) parseWhileStatement() *ast.WhileStatement {
 	ws.Body = p.parseBlockStatement()
 
 	return ws
+}
+
+func contains(arr []ast.Expression, elm ast.Expression) bool {
+	for _, e := range arr {
+		if getLiteral(elm) == getLiteral(e) {
+			return true
+		}
+	}
+	return false
+}
+
+func getLiteral(exp ast.Expression) string {
+	assignExp, ok := exp.(*ast.AssignExpression)
+
+	if ok {
+		return assignExp.Variables[0].TokenLiteral()
+	}
+
+	return exp.TokenLiteral()
 }

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -118,8 +118,8 @@ func (p *Parser) parseParameters() []ast.Expression {
 		p.nextToken()
 		param := p.parseExpression(NORMAL)
 
-		if contains(params, param) {
-			p.error = &Error{Message: fmt.Sprintf("Duplicate argument name: \"%s\". Line: %d", getLiteral(param), p.curToken.Line), errType: SyntaxError}
+		if containsArg(params, param) {
+			p.error = &Error{Message: fmt.Sprintf("Duplicate argument name: \"%s\". Line: %d", getArgName(param), p.curToken.Line), errType: SyntaxError}
 		}
 		params = append(params, param)
 	}
@@ -244,16 +244,16 @@ func (p *Parser) parseWhileStatement() *ast.WhileStatement {
 	return ws
 }
 
-func contains(arr []ast.Expression, elm ast.Expression) bool {
-	for _, e := range arr {
-		if getLiteral(elm) == getLiteral(e) {
+func containsArg(params []ast.Expression, param ast.Expression) bool {
+	for _, p := range params {
+		if getArgName(param) == getArgName(p) {
 			return true
 		}
 	}
 	return false
 }
 
-func getLiteral(exp ast.Expression) string {
+func getArgName(exp ast.Expression) string {
 	assignExp, ok := exp.(*ast.AssignExpression)
 
 	if ok {

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -119,7 +119,7 @@ func (p *Parser) parseParameters() []ast.Expression {
 		param := p.parseExpression(NORMAL)
 
 		if contains(params, param) {
-			p.error = &Error{Message: fmt.Sprintf("Duplicate argument name: \"%s\". Line: %d", param.TokenLiteral(), p.curToken.Line), errType: SyntaxError}
+			p.error = &Error{Message: fmt.Sprintf("Duplicate argument name: \"%s\". Line: %d", getLiteral(param), p.curToken.Line), errType: SyntaxError}
 		}
 		params = append(params, param)
 	}

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -118,7 +118,7 @@ func (p *Parser) parseParameters() []ast.Expression {
 		p.nextToken()
 		param := p.parseExpression(NORMAL)
 
-		if containsArg(params, param) {
+		if paramDuplicated(params, param) {
 			p.error = &Error{Message: fmt.Sprintf("Duplicate argument name: \"%s\". Line: %d", getArgName(param), p.curToken.Line), errType: SyntaxError}
 		}
 		params = append(params, param)
@@ -244,7 +244,7 @@ func (p *Parser) parseWhileStatement() *ast.WhileStatement {
 	return ws
 }
 
-func containsArg(params []ast.Expression, param ast.Expression) bool {
+func paramDuplicated(params []ast.Expression, param ast.Expression) bool {
 	for _, p := range params {
 		if getArgName(param) == getArgName(p) {
 			return true

--- a/compiler/parser/statement_parsing_test.go
+++ b/compiler/parser/statement_parsing_test.go
@@ -197,6 +197,22 @@ func TestDefStatement(t *testing.T) {
 	testIntegerLiteral(t, secondExpressionStmt.Expression, 123)
 }
 
+func TestDefStatementFailWithTheSameParams(t *testing.T) {
+	input := `
+	def add(x, y, x)
+	  x + y
+	end
+	`
+
+	l := lexer.New(input)
+	p := New(l)
+	_, err := p.ParseProgram()
+
+	if err == nil {
+		t.Fatalf("expect not to allow parameters with the same name")
+	}
+}
+
 func TestDefStatementWithYield(t *testing.T) {
 	input := `
 	def foo

--- a/compiler/parser/statement_parsing_test.go
+++ b/compiler/parser/statement_parsing_test.go
@@ -227,8 +227,6 @@ func TestDefStatementFailWithDuplicateArgumentName(t *testing.T) {
 			a + b
 		end
 		`, "Duplicate argument name: \"b\". Line: 1"},
-
-
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
I just noticed goby allows to define methods with the same argument name, which is prohibited in ruby. An example below

```
def someMethod(a, a)
  return a
end
```

So I just disabled it! Thanks! 😄 