### PR TITLE
POST request functionality to Net::HTTP class and tests for .get() and .post() methods

### DIFF
--- a/vm/http.go
+++ b/vm/http.go
@@ -3,8 +3,8 @@ package vm
 import (
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 var (

--- a/vm/http_test.go
+++ b/vm/http_test.go
@@ -97,6 +97,11 @@ func TestHTTPObjectFail(t *testing.T) {
 
 		Net::HTTP.post("http://127.0.0.1:3000/error", "text/plain", "Let me down")
 		`, "InternalError: 404 Not Found", 4},
+		{`
+		require "net/http"
+
+		Net::HTTP.post("http://127.0.0.1:3001", "text/plain", "Let me down")
+		`, "InternalError: Post http://127.0.0.1:3001: dial tcp 127.0.0.1:3001: getsockopt: connection refused", 4},
 	}
 
 	//block until server is ready

--- a/vm/http_test.go
+++ b/vm/http_test.go
@@ -1,0 +1,66 @@
+package vm
+
+import (
+	"testing"
+	//"net/http/httptest"
+	//"net/http"
+	"net/http"
+	"io/ioutil"
+)
+
+func TestHTTPObject(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		//test get request
+		{`
+		require "net/http"
+
+		Net::HTTP.get("http://127.0.0.1:3000")
+		`, "GET Hello World"},
+		{`
+		require "net/http"
+
+		Net::HTTP.post("http://127.0.0.1:3000", "text/plain", "Hi Again")
+		`, "POST Hi Again"},
+	}
+
+	c := make(chan bool, 1)
+
+	//server to test off of
+	go func() {
+		m := http.NewServeMux()
+
+		m.HandleFunc("/", func (w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+
+			if r.Method == http.MethodPost {
+				b, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					panic(err)
+				}
+				w.Write([]byte(r.Method + " " + string(b)))
+			} else {
+				w.Write([]byte(r.Method + " Hello World"))
+			}
+
+		})
+
+		c <- true
+
+		http.ListenAndServe(":3000", m)
+	}()
+
+	//block until server is ready
+	<- c
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+

--- a/vm/http_test.go
+++ b/vm/http_test.go
@@ -9,33 +9,46 @@ import (
 	"net/http"
 )
 
+//chan parameter for blocking until server is prepared
+func startTestServer(c chan bool) {
+	m := http.NewServeMux()
+
+	m.HandleFunc("/index", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		if r.Method == http.MethodPost {
+			b, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				panic(err)
+			}
+			fmt.Fprintf(w, "POST %s", b)
+		} else {
+			fmt.Fprint(w, "GET Hello World")
+		}
+
+	})
+
+	m.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		fmt.Fprint(w, "oops")
+	})
+
+	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println(r.URL.Path)
+	})
+
+	c <- true
+
+	http.ListenAndServe(":3000", m)
+}
+
 func TestHTTPObject(t *testing.T) {
 
+	//blocking channel
 	c := make(chan bool, 1)
 
 	//server to test off of
-	go func() {
-		m := http.NewServeMux()
-
-		m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-
-			if r.Method == http.MethodPost {
-				b, err := ioutil.ReadAll(r.Body)
-				if err != nil {
-					panic(err)
-				}
-				fmt.Fprintf(w, "POST %s", b)
-			} else {
-				fmt.Fprint(w, "GET Hello World")
-			}
-
-		})
-
-		c <- true
-
-		http.ListenAndServe(":3000", m)
-	}()
+	go startTestServer(c)
 
 	tests := []struct {
 		input    string
@@ -45,12 +58,12 @@ func TestHTTPObject(t *testing.T) {
 		{`
 		require "net/http"
 
-		Net::HTTP.get("http://127.0.0.1:3000")
+		Net::HTTP.get("http://127.0.0.1:3000/index")
 		`, "GET Hello World"},
 		{`
 		require "net/http"
 
-		Net::HTTP.post("http://127.0.0.1:3000", "text/plain", "Hi Again")
+		Net::HTTP.post("http://127.0.0.1:3000/index", "text/plain", "Hi Again")
 		`, "POST Hi Again"},
 	}
 
@@ -62,6 +75,38 @@ func TestHTTPObject(t *testing.T) {
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestHTTPObjectFail(t *testing.T) {
+	//blocking channel
+	c := make(chan bool, 1)
+
+	//server to test off of
+	go startTestServer(c)
+
+	testsFail := []errorTestCase{
+		{`
+		require "net/http"
+
+		Net::HTTP.get("http://127.0.0.1:3000/error")
+		`, "InternalError: 404 Not Found", 4},
+		{`
+		require "net/http"
+
+		Net::HTTP.post("http://127.0.0.1:3000/error", "text/plain", "Let me down")
+		`, "InternalError: 404 Not Found", 4},
+	}
+
+	//block until server is ready
+	<-c
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, 1)
 		v.checkSP(t, i, 1)
 	}
 }


### PR DESCRIPTION
http.go
	HTTP.post() - uses native go http.Post() method to post data via http
http_test.go tests for http class
	HTTP.get()
	HTTP.post()