### PR TITLE
[WIP] HTTP client upgrades

### DIFF
--- a/vm/error.go
+++ b/vm/error.go
@@ -19,6 +19,11 @@ const (
 	UnsupportedMethodError = "UnsupportedMethodError"
 	// ConstantAlreadyInitializedError means user re-declares twice
 	ConstantAlreadyInitializedError = "ConstantAlreadyInitializedError"
+	//HTTPError is for general errors returned from http functions
+	HTTPError = "HTTP Error"
+	//HTTPResponseError is for non 200 responses in general contexts
+	//ex Net::HTTP.post()
+	HTTPResponseError = "HTTP Response Error"
 )
 
 func (vm *VM) initErrorObject(errorType, format string, args ...interface{}) *Error {

--- a/vm/http.go
+++ b/vm/http.go
@@ -71,12 +71,12 @@ func builtinHTTPClassMethods() []*BuiltInMethodObject {
 					}
 
 					resp, err := http.Get(uri.String())
-
 					if err != nil {
-						return t.vm.initErrorObject(InternalError, err.Error())
+						return t.vm.initErrorObject(HTTPError, err.Error())
 					}
+
 					if resp.StatusCode != http.StatusOK {
-						return t.vm.initErrorObject(InternalError, resp.Status)
+						return t.vm.initErrorObject(HTTPResponseError, resp.Status)
 					}
 
 					content, err := ioutil.ReadAll(resp.Body)
@@ -98,22 +98,18 @@ func builtinHTTPClassMethods() []*BuiltInMethodObject {
 						return t.vm.initErrorObject(ArgumentError, "Expect 3 arguments. got=%v", strconv.Itoa(len(args)))
 					}
 
-					uri, err := url.Parse(args[0].(*StringObject).value)
-					if err != nil {
-						return t.vm.initErrorObject(ArgumentError, err.Error())
-					}
+					host := args[0].(*StringObject).value
 
 					contentType := args[1].(*StringObject).value
 
 					body := args[2].(*StringObject).value
 
-					resp, err := http.Post(uri.String(), contentType, strings.NewReader(body))
-
+					resp, err := http.Post(host, contentType, strings.NewReader(body))
 					if err != nil {
-						return t.vm.initErrorObject(InternalError, err.Error())
+						return t.vm.initErrorObject(HTTPError, err.Error())
 					}
 					if resp.StatusCode != http.StatusOK {
-						return t.vm.initErrorObject(InternalError, resp.Status)
+						return t.vm.initErrorObject(HTTPResponseError, resp.Status)
 					}
 
 					content, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
	HTTPError is for errors returned from http calls
	HTTPResponseError is only returned in get() and post() on non 200 responses. The general Net::HTTP.NewRequest() method will not use this