### PR TITLE
Support splat argument

### DIFF
--- a/compiler/ast/statements.go
+++ b/compiler/ast/statements.go
@@ -99,6 +99,7 @@ type DefStatement struct {
 	Name           *Identifier
 	Receiver       Expression
 	Parameters     []Expression
+	SplatParameter *Identifier
 	BlockStatement *BlockStatement
 }
 

--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -10,6 +10,7 @@ import (
 const (
 	NormalArg int = iota
 	OptionedArg
+	SplatArg
 )
 
 func (g *Generator) compileStatements(stmts []ast.Statement, scope *scope, table *localTable) {
@@ -175,6 +176,11 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 		}
 
 		newIS.argTypes = append(newIS.argTypes, argType)
+	}
+
+	if stmt.SplatParameter != nil {
+		scope.localTable.setLCL(stmt.SplatParameter.Value, scope.localTable.depth)
+		newIS.argTypes = append(newIS.argTypes, SplatArg)
 	}
 
 	if len(stmt.BlockStatement.Statements) == 0 {

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -90,6 +90,13 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 		} else {
 			params = p.parseParameters()
 
+			if p.peekTokenIs(token.Asterisk) {
+				p.nextToken()
+				if p.expectPeek(token.Ident) {
+					stmt.SplatParameter = p.parseIdentifier().(*ast.Identifier)
+				}
+			}
+
 			if !p.expectPeek(token.RParen) {
 				return nil
 			}
@@ -115,7 +122,13 @@ func (p *Parser) parseParameters() []ast.Expression {
 
 	for p.peekTokenIs(token.Comma) {
 		p.nextToken()
+
+		if p.peekTokenIs(token.Asterisk) {
+			break
+		}
+
 		p.nextToken()
+
 		param := p.parseExpression(NORMAL)
 
 		if paramDuplicated(params, param) {

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -122,6 +122,24 @@ func TestArgumentError(t *testing.T) {
 		{`"1234567890".include? "123", Class, String`,
 			"ArgumentError: Expect 1 argument. got=3",
 			1},
+		{`def foo(a, *b)
+		end
+
+		foo
+		`, "ArgumentError: Expect at least 1 args for method 'foo'. got: 0",
+			4},
+		{`def foo(a, b, *c)
+		end
+
+		foo(10)
+		`, "ArgumentError: Expect at least 2 args for method 'foo'. got: 1",
+			4},
+		{`def foo(a, b = 10, *c)
+		end
+
+		foo
+		`, "ArgumentError: Expect at least 1 args for method 'foo'. got: 0",
+			4},
 	}
 
 	for i, tt := range tests {

--- a/vm/method.go
+++ b/vm/method.go
@@ -33,6 +33,18 @@ func (m *MethodObject) toJSON() string {
 	return m.toString()
 }
 
+func (m *MethodObject) argTypes() []int {
+	return m.instructionSet.argTypes
+}
+
+func (m *MethodObject) lastArgType() int{
+	if len(m.argTypes()) > 0 {
+		return m.argTypes()[len(m.argTypes())-1]
+	}
+
+	return -1
+}
+
 // BuiltInMethodObject represents methods defined in go.
 type BuiltInMethodObject struct {
 	*baseObj

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -136,6 +136,36 @@ func TestDefStatement(t *testing.T) {
 
 		a.foo
 		`, 10},
+		{`
+		def foo(a, *b)
+		  b.each do |i|
+		    a = a + i
+		  end
+		  a
+		end
+
+		foo(10, 15, 20)
+		`, 45},
+		{`
+		def foo(a, b, *c)
+		  c.each do |i|
+		    a = a + i
+		  end
+		  a + b
+		end
+
+		foo(10, 15, 20, 25)
+		`, 70},
+		{`
+		def foo(a, b = 15, *c)
+		  c.each do |i|
+		    a = a + i
+		  end
+		  a + b
+		end
+
+		foo(10, 20, 25)
+		`, 55},
 	}
 
 	for i, tt := range tests {

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -166,6 +166,17 @@ func TestDefStatement(t *testing.T) {
 
 		foo(10, 20, 25)
 		`, 55},
+		{`
+		def foo(*a)
+		  r = 0
+		  a.each do |i|
+		    r += i
+		  end
+		  r
+		end
+
+		foo(10, 20, 30)
+		`, 60},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Support splat argument like

```ruby
def foo(a, *b)
  puts(a)
  puts(b)
end

foo(1, 2, 3, 4)
#=> 1
[2, 3, 4]

```

This closes #374 