### PR TITLE
Refactor method parameter parsing

### DIFF
--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -160,11 +160,9 @@ func (ae *AssignExpression) String() string {
 		variables = append(variables, v.String())
 	}
 
-	out.WriteString("(")
 	out.WriteString(strings.Join(variables, ", "))
 	out.WriteString(" = ")
 	out.WriteString(ae.Value.String())
-	out.WriteString(")")
 
 	return out.String()
 }

--- a/compiler/ast/statements.go
+++ b/compiler/ast/statements.go
@@ -99,7 +99,6 @@ type DefStatement struct {
 	Name           *Identifier
 	Receiver       Expression
 	Parameters     []Expression
-	SplatParameter *Identifier
 	BlockStatement *BlockStatement
 }
 

--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -173,14 +173,16 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 			argType = OptionedArg
 			exp.Optioned = 1
 			g.compileAssignExpression(newIS, exp, scope, scope.localTable)
+		case *ast.PrefixExpression:
+			if exp.Operator != "*" {
+				continue
+			}
+			argType = SplatArg
+			ident := exp.Right.(*ast.Identifier)
+			scope.localTable.setLCL(ident.Value, scope.localTable.depth)
 		}
 
 		newIS.argTypes = append(newIS.argTypes, argType)
-	}
-
-	if stmt.SplatParameter != nil {
-		scope.localTable.setLCL(stmt.SplatParameter.Value, scope.localTable.depth)
-		newIS.argTypes = append(newIS.argTypes, SplatArg)
 	}
 
 	if len(stmt.BlockStatement.Statements) == 0 {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -121,6 +121,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.False, p.parseBooleanLiteral)
 	p.registerPrefix(token.Null, p.parseNilExpression)
 	p.registerPrefix(token.Minus, p.parsePrefixExpression)
+	p.registerPrefix(token.Asterisk, p.parsePrefixExpression)
 	p.registerPrefix(token.Bang, p.parsePrefixExpression)
 	p.registerPrefix(token.LParen, p.parseGroupedExpression)
 	p.registerPrefix(token.If, p.parseIfExpression)

--- a/compiler/parser/statement_parsing_test.go
+++ b/compiler/parser/statement_parsing_test.go
@@ -197,7 +197,7 @@ func TestDefStatement(t *testing.T) {
 	testIntegerLiteral(t, secondExpressionStmt.Expression, 123)
 }
 
-func TestDefStatementFailWithDuplicateArgumentName(t *testing.T) {
+func TestDefStatementArgumentDefinitionError(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected string
@@ -208,17 +208,12 @@ func TestDefStatementFailWithDuplicateArgumentName(t *testing.T) {
 		end
 		`, "Duplicate argument name: \"x\". Line: 1"},
 		{`
-		def add(a, b = 1, b)
+		def add(a, b, b = [1, 2])
 			a + b
 		end
 		`, "Duplicate argument name: \"b\". Line: 1"},
 		{`
-		def add(a, b = [1, 2], b)
-			a + b
-		end
-		`, "Duplicate argument name: \"b\". Line: 1"},
-		{`
-		def add(a, b = [1, 2], b = [3, 4], c)
+		def add(a, b = [1, 2], b = [3, 4])
 			a + b
 		end
 		`, "Duplicate argument name: \"b\". Line: 1"},
@@ -227,6 +222,31 @@ func TestDefStatementFailWithDuplicateArgumentName(t *testing.T) {
 			a + b
 		end
 		`, "Duplicate argument name: \"b\". Line: 1"},
+		{`
+		def add(a = 1, b)
+			a + b
+		end
+		`, "Normal argument \"b\" should be defined before optioned argument. Line: 1"},
+		{`
+		def add(a = 1, b, c)
+			a + b
+		end
+		`, "Normal argument \"b\" should be defined before optioned argument. Line: 1"},
+		{`
+		def add(*a, b)
+			a + b
+		end
+		`, "Normal argument \"b\" should be defined before splat argument. Line: 1"},
+		{`
+		def add(*a, b = 1, c)
+			a + b
+		end
+		`, "Optioned argument \"b = 1\" should be defined before splat argument. Line: 1"},
+		{`
+		def add(*a, *b, c)
+			a + b
+		end
+		`, "Can't define splat argument more than once. Line: 1"},
 	}
 
 	for i, tt := range tests {

--- a/vm/method.go
+++ b/vm/method.go
@@ -37,7 +37,7 @@ func (m *MethodObject) argTypes() []int {
 	return m.instructionSet.argTypes
 }
 
-func (m *MethodObject) lastArgType() int{
+func (m *MethodObject) lastArgType() int {
 	if len(m.argTypes()) > 0 {
 		return m.argTypes()[len(m.argTypes())-1]
 	}

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -68,33 +68,12 @@ func TestDefStatement(t *testing.T) {
 		foo(20)
 		`, 30},
 		{`
-		def foo(x = 100, y)
-		  x + y
-		end
-
-		foo(20)
-		`, 120},
-		{`
 		def foo(x, y=10)
 		  x + y
 		end
 
 		foo(100)
 		`, 110},
-		{`
-		def foo(x=10, y, z)
-		  x + y + z
-		end
-
-		foo(10, 20)
-		`, 40},
-		{`
-		def foo(x=10, y=11, z)
-		  x + y + z
-		end
-
-		foo(10, 20)
-		`, 41},
 		{`
 		def foo(x=10, y=11, z=12)
 		  x + y + z


### PR DESCRIPTION
- Consider splat argument as a type of prefix expression
- Restrict parameters define order: normal arg > optioned arg > splat arg
- Forbidden splat arg be defined twice