### PR TITLE
Support splatting array into multiple arguments

### DIFF
--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -182,6 +182,9 @@ func (g *Generator) compilePrefixExpression(is *InstructionSet, exp *ast.PrefixE
 	case "!":
 		g.compileExpression(is, exp.Right, scope, table)
 		is.define(Send, exp.Line(), exp.Operator, 0)
+	case "*":
+		g.compileExpression(is, exp.Right, scope, table)
+		is.define(SplatArray, exp.Line())
 	case "-":
 		is.define(PutObject, exp.Line(), 0)
 		g.compileExpression(is, exp.Right, scope, table)

--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -28,6 +28,7 @@ const (
 	PutNull             = "putnil"
 	NewArray            = "newarray"
 	ExpandArray         = "expand_array"
+	SplatArray          = "splat_array"
 	NewHash             = "newhash"
 	NewRange            = "newrange"
 	BranchUnless        = "branchunless"

--- a/vm/array.go
+++ b/vm/array.go
@@ -25,6 +25,7 @@ func (vm *VM) initArrayClass() *RClass {
 type ArrayObject struct {
 	*baseObj
 	Elements []Object
+	splat    bool
 }
 
 func (a *ArrayObject) Value() interface{} {

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -140,6 +140,15 @@ func TestArgumentError(t *testing.T) {
 		foo
 		`, "ArgumentError: Expect at least 1 args for method 'foo'. got: 0",
 			4},
+		{`def foo(a, b, c)
+		  a + b + c
+		end
+
+		arr = [1, 2, 3, 5]
+		foo(*arr)
+		`,
+			"ArgumentError: Expect at most 3 args for method 'foo'. got: 4",
+			6},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
For example:

```ruby
def foo(a, b, c)
  a + b + c
end

a = [6, 5]
puts(foo(4, *a)) #=> 15
```

And can be mixed with splat arguments

```ruby
def foo(a, b, c)
  a + b + c
end

def bar(*arr)
  foo(*arr)
end

puts(bar(2, 3, 5)) #=> 10
```

And if the splatted object is not an array, it just return that object like:

```ruby
def foo(a, b)
  a + b
end

puts(foo(*4, *6)) #=> 10
```