### PR TITLE
it is extreme panic to run 'goby xxxx'

### DIFF
--- a/goby.go
+++ b/goby.go
@@ -40,7 +40,7 @@ func main() {
 
 	fp := flag.Arg(0)
 
-	if fp == "" {
+	if fp == "" || !strings.Contains(fp, ".") {
 		flag.Usage()
 		os.Exit(0)
 	}


### PR DESCRIPTION
sorry, my English is poor 。

When I run “goby xxxx” Without extension。

follows panic.
==========================================
panic: runtime error: index out of range

goroutine 1 [running]:
main.extractFileInfo(0x7fff5fbffc77, 0x4, 0x1, 0x5, 0x0, 0x0, 0x0, 0x30)
	/Users/zcl/go/src/github.com/goby-lang/goby/goby.go:92 +0x123
main.main()
	/Users/zcl/go/src/github.com/goby-lang/goby/goby.go:51 +0x22e
==========================================
so. I made a simple change.