### PR TITLE
Change File class to builtin class

### DIFF
--- a/vm/class.go
+++ b/vm/class.go
@@ -22,6 +22,7 @@ const (
 	methodClass   = "method"
 	pluginClass   = "Plugin"
 	goObjectClass = "GoObject"
+	fileClass     = "File"
 )
 
 // initializeClass is a common function for vm, which initializes and returns

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -490,15 +490,16 @@ func TestRequireRelative(t *testing.T) {
 	v.checkSP(t, 0, 1)
 }
 
-func TestRequireSuccess(t *testing.T) {
+func TestRequireStandardLibSuccess(t *testing.T) {
 	input := `
-	require "file"
+	require "uri"
 
-	File.extname("foo.rb")
+	u = URI.parse("http://example.com")
+	u.scheme
 	`
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, ".rb")
+	checkExpected(t, 0, evaluated, "http")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }

--- a/vm/file.go
+++ b/vm/file.go
@@ -14,13 +14,21 @@ var fileModeTable = map[string]int{
 	"w+": syscall.O_RDWR,
 }
 
-func initFileClass(vm *VM) {
-	fc := vm.initializeClass("File", false)
+func (vm *VM) initFileClass() *RClass {
+	fc := vm.initializeClass(fileClass, false)
 	fc.setBuiltInMethods(builtinFileClassMethods(), true)
 	fc.setBuiltInMethods(builtinFileInstanceMethods(), false)
-	vm.objectClass.setClassConstant(fc)
 
-	vm.execGobyLib("file.gb")
+	vm.libFiles = append(vm.libFiles, "file.gb")
+
+	return fc
+}
+
+func (vm *VM) initFileObject(f *os.File) *FileObject {
+	return &FileObject{
+		baseObj: &baseObj{class: vm.topLevelClass(fileClass)},
+		File:    f,
+	}
 }
 
 // FileObject is a special type that contains file pointer so we can keep track on target file.
@@ -207,7 +215,7 @@ func builtinFileClassMethods() []*BuiltInMethodObject {
 					}
 
 					// TODO: Refactor this class retrieval mess
-					fileObj := &FileObject{File: f, baseObj: &baseObj{class: t.vm.topLevelClass("File")}}
+					fileObj := &FileObject{File: f, baseObj: &baseObj{class: t.vm.topLevelClass(fileClass)}}
 
 					return fileObj
 				}

--- a/vm/file_test.go
+++ b/vm/file_test.go
@@ -11,32 +11,22 @@ func TestFileObject(t *testing.T) {
 		expected interface{}
 	}{
 		{`
-		require "file"
-
 		f = File.new("../test_fixtures/file_test/size.gb")
 		f.name
 		`, "../test_fixtures/file_test/size.gb"},
 		{`
-		require "file"
-
 		f = File.new("../test_fixtures/file_test/size.gb")
 		f.size
 		`, 22},
 		{`
-		require "file"
-
 		f = File.new("../test_fixtures/file_test/size.gb")
 		f.close
 		`, nil},
 		{`
-		require "file"
-
 		f = File.new("../test_fixtures/file_test/size.gb")
 		f.read
 		`, "this file's size is\n22"},
 		{`
-		require "file"
-
 		file = ""
 		File.open("../test_fixtures/file_test/size.gb", "r", 0755) do |f|
 	 	  file = f.read
@@ -60,8 +50,7 @@ func TestFileBasenameMethod(t *testing.T) {
 		expected string
 	}{
 		{`
-		require "file"
-		File.basename("/home/goby/plugin/test.gb")
+				File.basename("/home/goby/plugin/test.gb")
 		`, "test.gb"},
 	}
 
@@ -80,8 +69,6 @@ func TestFileDeleteMethod(t *testing.T) {
 		expected interface{}
 	}{
 		{`
-		require "file"
-
 		File.open("/tmp/out1.txt", "w", 0755)
 		File.open("/tmp/out2.txt", "w", 0755)
 		File.open("/tmp/out3.txt", "w", 0755)
@@ -89,8 +76,6 @@ func TestFileDeleteMethod(t *testing.T) {
 		File.delete("/tmp/out1.txt", "/tmp/out2.txt", "/tmp/out3.txt")
 		`, 3},
 		{`
-		require "file"
-
 		File.open("/tmp/out.txt", "w", 0755)
 		File.delete("/tmp/out.txt")
 		File.exist?("/tmp/out.txt")
@@ -112,11 +97,9 @@ func TestFileExtnameMethod(t *testing.T) {
 		expected string
 	}{
 		{`
-		require "file"
 		File.extname("loop.gb")
 		`, ".gb"},
 		{`
-		require "file"
 		File.extname("text.txt")
 		`, ".txt"},
 	}
@@ -136,15 +119,12 @@ func TestFileJoinMethod(t *testing.T) {
 		expected string
 	}{
 		{`
-		require "file"
 		File.join("test1", "test2", "test3")
 		`, "test1/test2/test3"},
 		{`
-		require "file"
 		File.join("goby", "plugin")
 		`, "goby/plugin"},
 		{`
-		require "file"
 		File.join("plugin")
 		`, "plugin"},
 	}
@@ -164,8 +144,6 @@ func TestFileWriteMethod(t *testing.T) {
 		expected interface{}
 	}{
 		{`
-		require "file"
-
 		l = 0
 		File.open("/tmp/out.txt", "w", 0755) do |f|
 		  l = f.write("12345")
@@ -174,8 +152,6 @@ func TestFileWriteMethod(t *testing.T) {
 		l
 		`, 5},
 		{`
-		require "file"
-
 		File.open("/tmp/out.txt", "w", 0755) do |f|
 		  f.write("Goby is awesome!!!")
 		end
@@ -183,14 +159,10 @@ func TestFileWriteMethod(t *testing.T) {
 		File.new("/tmp/out.txt").read
 		`, "Goby is awesome!!!"},
 		{`
-		require "file"
-
 		File.open("/tmp/out.txt", "w", 0755)
 		File.new("/tmp/out.txt").size
 		`, 0},
 		{`
-		require "file"
-
 		File.open("/tmp/out.txt", "w", 0755)
 		File.exist?("/tmp/out.txt")
 		`, true},
@@ -207,8 +179,6 @@ func TestFileWriteMethod(t *testing.T) {
 
 func TestFileSizeMethod(t *testing.T) {
 	input := `
-	require "file"
-
 	File.size("../test_fixtures/file_test/size.gb")
 	`
 
@@ -225,7 +195,6 @@ func TestFileSplitMethod(t *testing.T) {
 		expected []interface{}
 	}{
 		{`
-		require "file"
 		File.split("/home/goby/plugin/test.gb")
 		`, []interface{}{"/home/goby/plugin/", "test.gb"}},
 	}


### PR DESCRIPTION
For two reasons:

- File class is builtin class in Ruby
- We need to use File class during VM's initialization, so it has to be a builtin class