### PR TITLE
Add Array#unshift

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -735,6 +735,22 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 				}
 			},
 		},
+		{
+			// Inserts the specified element in the first position of the array.
+			//
+			// ```ruby
+			// a = [1, 2]
+			// a.unshift(0) # => [0, 1, 2]
+			// a       # => [0, 1, 2]
+			// ```
+			Name: "unshift",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					arr := receiver.(*ArrayObject)
+					return arr.unshift(args)
+				}
+			},
+		},
 	}
 }
 
@@ -861,3 +877,10 @@ func (a *ArrayObject) copy() Object {
 
 	return newArr
 }
+
+// unshift inserts an element in the first position of the array
+func (a *ArrayObject) unshift(objs []Object) *ArrayObject {
+	a.Elements = append(objs, a.Elements...)
+	return a
+}
+

--- a/vm/array.go
+++ b/vm/array.go
@@ -741,7 +741,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```ruby
 			// a = [1, 2]
 			// a.unshift(0) # => [0, 1, 2]
-			// a       # => [0, 1, 2]
+			// a            # => [0, 1, 2]
 			// ```
 			Name: "unshift",
 			Fn: func(receiver Object) builtinMethodBody {

--- a/vm/array.go
+++ b/vm/array.go
@@ -883,4 +883,3 @@ func (a *ArrayObject) unshift(objs []Object) *ArrayObject {
 	a.Elements = append(objs, a.Elements...)
 	return a
 }
-

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -1117,4 +1117,3 @@ func TestArrayUnshiftMethod(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
-

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -1062,3 +1062,59 @@ func TestArrayShiftMethodFail(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+
+func TestArrayUnshiftMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			`
+			a = [1, 2, 3]
+			a.unshift(0)
+			a[0]
+			`, 0},
+		{
+			`
+			a = [1, 2, 3]
+			a.unshift(0)
+			a.length
+			`, 4},
+		{
+			`
+			a = []
+			a.unshift(nil)
+			a[0]
+			`, nil},
+		{
+			`
+			a = []
+			a.unshift("foo")
+			a.unshift(1, 2)
+			a[0, 3]
+			`, 1},
+		{
+			`
+			a = []
+			a.unshift("foo")
+			a.unshift(1, 2)
+			a[1]
+			`, 2},
+		{
+			`
+			a = []
+			a.unshift("foo")
+			a.unshift(1, 2)
+			a[1]
+			`, "foo"},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -1091,7 +1091,7 @@ func TestArrayUnshiftMethod(t *testing.T) {
 			a = []
 			a.unshift("foo")
 			a.unshift(1, 2)
-			a[0, 3]
+			a[0]
 			`, 1},
 		{
 			`
@@ -1105,7 +1105,7 @@ func TestArrayUnshiftMethod(t *testing.T) {
 			a = []
 			a.unshift("foo")
 			a.unshift(1, 2)
-			a[1]
+			a[2]
 			`, "foo"},
 	}
 


### PR DESCRIPTION
Add functionality for `Array#unshift`, which inserts one or more elements in the first position of the array.

This is a provisional PR. I've manually tested it, but I have a couple of issues:

1. the last three `TestArrayUnshiftMethod` samples could be neatly merged if I could use sliced array access, which currently crashes (see #403)
2. setting up a testing environment is harder than expected (see #404), so I'm not able to run the test suite.