### PR TITLE
[ci skip] Correct an error in Array#at() method documentation

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -137,7 +137,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			// Retrieves an object in an array using the index argument.
-			// It raises an error if index out of range.
+			// The index is 0-based; nil is returned when trying to access the index out of bounds.
 			//
 			// ```ruby
 			// a = [1, 2, 3]


### PR DESCRIPTION
The method documentation differs from the implementation (and the Ruby reference) - no error is raised in case of out-of-bound access, instead, nil is returned.