### PR TITLE
Make travis work on forked repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - sudo apt-get install apache2-utils
 
 before_script:
+  - ./prepare_travis_for_fork.sh
   - psql -c 'create database goby_test;' -U postgres
 
 script:

--- a/prepare_travis_for_fork.sh
+++ b/prepare_travis_for_fork.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+# On forked repositories, the code will be cloned under `$GOPATH/src/github.com/<fork_owner>/<fork_name>`,
+# which is not compatible with the Goby defined imports.
+# The Travis `go_import_path` seems not to solve the problem, as it will end up creating
+# `$GOPATH/src/github.com/goby-lang/goby/<go_import_path>`.
+# In order to solve this problem, we simply move the data in the project where in the intended location,
+# which is `$GOBY_ROOT` (`$GOPATH/src/github.com/goby-lang/goby`).
+
+if [[ ${TRAVIS_REPO_SLUG} != "goby-lang/goby" ]]; then
+  mkdir -p "$(dirname ${GOBY_ROOT})"
+  mv $HOME/gopath/src/github.com/${TRAVIS_REPO_SLUG} ${GOBY_ROOT}
+  cd ${GOBY_ROOT}
+fi


### PR DESCRIPTION
Goby's Travis setup won't work on forked repositories, as the cloned location is different from what the `import` statements expect.

Fixing the problem can't be accomplished by renaming the repository, since the goby project parent name (eg. `saveriomiroddi`) is the owner's/organization's name, and can't be changed.

The Travis `go_import_path` doesn't work as intended, so the logic is simply to move the directory to make it compatible with the `import`s.