### PR TITLE
Add the packaging metadata to build the goby snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: goby
+version: master
+summary: A new language helps you develop microservices
+description: |
+  Goby is an object-oriented interpreter language deeply inspired by Ruby as
+  well as its core implementation by 100% pure Go. Moreover, it has standard
+  libraries to provide several features such as the Plugin system.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode
+
+apps:
+  goby:
+    environment:
+      GOBY_ROOT: $SNAP
+    command: goby
+
+parts:
+  goby:
+    source: .
+    plugin: go
+    go-importpath: github.com/goby-lang/goby
+    install:
+      cp -R lib/ $SNAPCRAFT_PART_INSTALL
+    after: [go]
+  go:
+    source-tag: go1.9


### PR DESCRIPTION
This package will let you publish the latest goby in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.