### PR TITLE
Exclude incorrectly parsed files from codeclimate checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,8 +3,14 @@ engines:
     enabled: true
   golint:
     enabled: true
+    exclude_paths:
+      - "vm/instruction.go"
+      - "vm/vm.go"
   gofmt:
     enabled: true
+    exclude_paths:
+      - "vm/instruction.go"
+      - "vm/vm.go"
 
 exclude_paths:
   - "Godeps"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: goby
+name: goby-lang
 version: master
 summary: A new language helps you develop microservices
 description: |

--- a/vm/array.go
+++ b/vm/array.go
@@ -282,6 +282,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					if blockFrame != nil {
+						if len(arr.Elements) == 0 {
+							t.callFrameStack.pop()
+						}
+
 						for _, obj := range arr.Elements {
 							result := t.builtinMethodYield(blockFrame, obj)
 							if result.Target.(*BooleanObject).value {
@@ -410,6 +414,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 
 					arr := receiver.(*ArrayObject)
 
+					// If it's an empty array, pop the block's call frame
+					if len(arr.Elements) == 0 {
+						t.callFrameStack.pop()
+					}
+
 					for _, obj := range arr.Elements {
 						t.builtinMethodYield(blockFrame, obj)
 					}
@@ -430,6 +439,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					arr := receiver.(*ArrayObject)
+
+					// If it's an empty array, pop the block's call frame
+					if len(arr.Elements) == 0 {
+						t.callFrameStack.pop()
+					}
 
 					for i := range arr.Elements {
 						t.builtinMethodYield(blockFrame, t.vm.initIntegerObject(i))
@@ -639,6 +653,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
 					}
 
+					// If it's an empty array, pop the block's call frame
+					if len(arr.Elements) == 0 {
+						t.callFrameStack.pop()
+					}
+
 					for i, obj := range arr.Elements {
 						result := t.builtinMethodYield(blockFrame, obj)
 						elements[i] = result.Target
@@ -708,6 +727,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					arr := receiver.(*ArrayObject)
 					if blockFrame == nil {
 						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+					}
+
+					// If it's an empty array, pop the block's call frame
+					if len(arr.Elements) == 0 {
+						t.callFrameStack.pop()
 					}
 
 					var prev Object
@@ -791,6 +815,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 
 					if blockFrame == nil {
 						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+					}
+
+					// If it's an empty array, pop the block's call frame
+					if len(arr.Elements) == 0 {
+						t.callFrameStack.pop()
 					}
 
 					for _, obj := range arr.Elements {

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -393,6 +393,11 @@ func TestArrayCountMethod(t *testing.T) {
 			i.size > 1
 		end
 		`, 3},
+		{`
+		[].count do |i|
+			i.size > 1
+		end
+		`, 0},
 	}
 
 	for i, tt := range tests {
@@ -519,6 +524,13 @@ func TestArrayEachMethod(t *testing.T) {
 		end
 		sum
 		`, 15},
+		{`
+		sum = 0
+		[].each do |i|
+		  sum += i
+		end
+		sum
+		`, 0},
 	}
 
 	for i, tt := range tests {
@@ -561,6 +573,13 @@ func TestArrayEachIndexMethod(t *testing.T) {
 		end
 		sum
 		`, 10},
+		{`
+		sum = 0
+		[].each_index do |i|
+			sum += i
+		end
+		sum
+		`, 0},
 	}
 
 	for i, tt := range tests {
@@ -923,6 +942,10 @@ func TestArrayMapMethod(t *testing.T) {
 			i + "1"
 		end
 		`, []interface{}{"11", "sss1", "qwe1"}},
+		{`
+		[].map do |i|
+		end
+		`, []interface{}{}},
 	}
 
 	for i, tt := range tests {
@@ -1036,6 +1059,11 @@ func TestArrayReduceMethod(t *testing.T) {
 			prev + s
 		end
 		`, "Yes, this is a test!"},
+		{`
+		[].reduce("foo") do |i|
+			true
+		end
+		`, "foo"},
 	}
 
 	for i, tt := range tests {
@@ -1133,6 +1161,11 @@ func TestArraySelectMethod(t *testing.T) {
 			i == "test"
 		end
 		`, []interface{}{"test", "test"}},
+		{`
+		[].select do |i|
+			true
+		end
+		`, []interface{}{}},
 	}
 
 	for i, tt := range tests {

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -190,6 +190,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					h := receiver.(*HashObject)
+
+					if len(h.Pairs) == 0 {
+						t.callFrameStack.pop()
+					}
+
 					keys := h.sortedKeys()
 					var arrOfKeys []Object
 
@@ -230,6 +235,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					h := receiver.(*HashObject)
+
+					if len(h.Pairs) == 0 {
+						t.callFrameStack.pop()
+					}
+
 					keys := h.sortedKeys()
 					var arrOfValues []Object
 
@@ -464,6 +474,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					h := receiver.(*HashObject)
+
+					if len(h.Pairs) == 0 {
+						t.callFrameStack.pop()
+					}
+
 					for k, v := range h.Pairs {
 						result := t.builtinMethodYield(blockFrame, v)
 						h.Pairs[k] = result.Target
@@ -668,6 +683,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					h := receiver.(*HashObject)
+
+					if len(h.Pairs) == 0 {
+						t.callFrameStack.pop()
+					}
+
 					resultHash := make(map[string]Object)
 					for k, v := range h.Pairs {
 						result := t.builtinMethodYield(blockFrame, v)

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -248,6 +248,13 @@ func TestHashEachKeyMethod(t *testing.T) {
 			end
 			arr
 		`, []interface{}{"a", "b", "c"}},
+		{`
+			arr = []
+			{}.each_key do |key|
+			  arr.push(key)
+			end
+			arr
+		`, []interface{}{}},
 	}
 
 	for i, tt := range tests {
@@ -297,6 +304,11 @@ func TestHashEachValueMethod(t *testing.T) {
 			  # Empty Block
 			end
 		`, []interface{}{true, 123}},
+		{`
+			{}.each_value do |v|
+			  # Empty Block
+			end
+		`, []interface{}{}},
 	}
 
 	for i, tt := range hashTests {
@@ -332,6 +344,13 @@ func TestHashEachValueMethod(t *testing.T) {
 			end
 			string
 			`, "Hello World Goby Lang "},
+		{`
+			string = ""
+			{}.each_value do |v|
+			  string = string + v + " "
+			end
+			string
+			`, ""},
 	}
 
 	for i, tt := range normalTests {
@@ -706,6 +725,13 @@ func TestHashMapValuesMethod(t *testing.T) {
 		end
 		result["c"]
 		`, 9},
+		{`
+		h = {}
+		result = h.map_values do |v|
+		  v * 3
+		end
+		result["c"]
+		`, nil},
 	}
 
 	for i, tt := range tests {
@@ -1138,6 +1164,13 @@ func TestHashTransformValuesMethod(t *testing.T) {
 		end
 		result["c"]
 		`, 9},
+		{`
+		h = {}
+		result = h.transform_values do |v|
+		  v * 3
+		end
+		result["c"]
+		`, nil},
 	}
 
 	for i, tt := range tests {

--- a/vm/issue_vm.go
+++ b/vm/issue_vm.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 )
 
-
 // InitIssueReportVM initializes a vm in test mode for issue reporting
 func InitIssueReportVM(dir string, args []string) (*VM, error) {
 	v, err := New(dir, args)


### PR DESCRIPTION
Due to CC not currently supporting Go 1.9 syntax, some files are not parsed correctly, and cause CC to fail.