### PR TITLE
Implement Array#*

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -75,11 +75,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 
 					copiesNumber, ok := args[0].(*IntegerObject)
 
-					if ok {
-						return arr.concatenateCopies(t, copiesNumber)
-					} else {
+					if ! ok {
 						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
 					}
+
+					return arr.concatenateCopies(t, copiesNumber)
 				}
 			},
 		},

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -161,6 +161,54 @@ func TestArrayIndex(t *testing.T) {
 	}
 }
 
+func TestArrayStarOperator(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []interface{}
+	}{
+		{`
+			a = [1, 2, 3]
+			a * 2
+		`, []interface{}{1, 2, 3, 1, 2, 3}},
+		// Make sure the result is an entirely new array.
+		{`
+			a = [1, 2, 3]
+			(a * 2)[0] = -1
+			a
+		`, []interface{}{1, 2, 3}},
+		{`
+			a = [1, 2, 3]
+			a * 0
+		`, []interface{}{}},
+		{`
+			a = []
+			a * 2
+		`, []interface{}{}},
+	}
+
+	for i, tt := range tests {
+		vm := initTestVM()
+		evaluated := vm.testEval(t, tt.input, getFilename())
+		testArrayObject(t, i, evaluated, tt.expected)
+		vm.checkCFP(t, i, 0)
+		vm.checkSP(t, i, 1)
+	}
+}
+
+func TestArrayStarOperatorFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`[1, 2] * nil`, "TypeError: Expect argument to be Integer. got: Null", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestArrayPlusOperator(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
The implementation required a refactoring of the `Array#join` method, in order to avoid code duplication.