### PR TITLE
Merge `[]` and `at()` methods code

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -51,7 +51,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					arr := receiver.(*ArrayObject)
-					return arr.index(t, args, blockFrame)
+					return arr.index(t, args)
 				}
 			},
 		},
@@ -215,7 +215,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
 					arr := receiver.(*ArrayObject)
-					return arr.index(t, args, blockFrame)
+					return arr.index(t, args)
 				}
 			},
 		},
@@ -945,7 +945,7 @@ func (a *ArrayObject) toJSON() string {
 }
 
 // Retrieves an object in an array using Integer index; common to `[]` and `at()`.
-func (a *ArrayObject) index(t *thread, args []Object, blockFrame *callFrame) Object {
+func (a *ArrayObject) index(t *thread, args []Object) Object {
 	if len(args) != 1 {
 		return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 arguments. got=%d", len(args))
 	}

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -310,8 +310,8 @@ func TestArrayAtMethod(t *testing.T) {
 
 func TestArrayAtMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`[1, 2, 3].at`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`[1, 2, 3].at(2, 3)`, "ArgumentError: Expect 1 argument. got=2", 1},
+		{`[1, 2, 3].at`, "ArgumentError: Expect 1 arguments. got=0", 1},
+		{`[1, 2, 3].at(2, 3)`, "ArgumentError: Expect 1 arguments. got=2", 1},
 		{`[1, 2, 3].at(true)`, "TypeError: Expect argument to be Integer. got: Boolean", 1},
 		{`[1, 2, 3].at(1..3)`, "TypeError: Expect argument to be Integer. got: Range", 1},
 	}


### PR DESCRIPTION
The implementation is a direct copy of the previous `[]` code.