### PR TITLE
Add GoMap class

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -75,7 +75,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 
 					copiesNumber, ok := args[0].(*IntegerObject)
 
-					if ! ok {
+					if !ok {
 						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
 					}
 

--- a/vm/classes/classes.go
+++ b/vm/classes/classes.go
@@ -15,4 +15,5 @@ const (
 	PluginClass   = "Plugin"
 	GoObjectClass = "GoObject"
 	FileClass     = "File"
+	GoMapClass    = "GoMap"
 )

--- a/vm/go_map.go
+++ b/vm/go_map.go
@@ -72,6 +72,32 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 				}
 			},
 		},
+		{
+			Name: "get",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					if len(args) != 1 {
+						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
+					}
+
+					key, ok := args[0].(*StringObject)
+
+					if !ok {
+						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+					}
+
+					m := receiver.(*GoMap).data
+
+					result, ok := m[key.value]
+
+					if !ok {
+						return NULL
+					}
+
+					return result.(Object)
+				}
+			},
+		},
 	}
 }
 

--- a/vm/go_map.go
+++ b/vm/go_map.go
@@ -55,16 +55,16 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 			Name: "to_hash",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+					if len(args) != 0 {
+						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
 
 					m := receiver.(*GoMap)
 
 					pairs := map[string]Object{}
 
-					for k, v := range m.data {
-						pairs[k] = t.vm.initObjectFromGoType(v)
+					for k, obj := range m.data {
+						pairs[k] = obj.(Object)
 
 					}
 
@@ -95,6 +95,28 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					return result.(Object)
+				}
+			},
+		},
+		{
+			Name: "set",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					if len(args) != 2 {
+						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 argument. got: %d", len(args))
+					}
+
+					key, ok := args[0].(*StringObject)
+
+					if !ok {
+						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+					}
+
+					m := receiver.(*GoMap).data
+
+					m[key.value] = args[1]
+
+					return args[1]
 				}
 			},
 		},

--- a/vm/go_map.go
+++ b/vm/go_map.go
@@ -1,0 +1,109 @@
+package vm
+
+import (
+	"fmt"
+
+	"github.com/goby-lang/goby/vm/classes"
+	"github.com/goby-lang/goby/vm/errors"
+)
+
+// GoMap ...
+type GoMap struct {
+	*baseObj
+	data map[string]interface{}
+}
+
+// Class methods --------------------------------------------------------
+func builtinGoMapClassMethods() []*BuiltinMethodObject {
+	return []*BuiltinMethodObject{
+		{
+			// Initialize a new GoMap instance.
+			// It can be called without any arguments, which will create an empty map.
+			// Or you can pass a hash as argument, so the map will have same pairs.
+			//
+			// @return [GoMap]
+			Name: "new",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					m := make(map[string]interface{})
+
+					if len(args) == 0 {
+						return t.vm.initGoMap(m)
+					}
+
+					hash, ok := args[0].(*HashObject)
+
+					if !ok {
+						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.HashClass, args[0].Class().Name)
+					}
+
+					for k, v := range hash.Pairs {
+						m[k] = v
+					}
+
+					return t.vm.initGoMap(m)
+				}
+			},
+		},
+	}
+}
+
+// Instance methods -----------------------------------------------------
+func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
+	return []*BuiltinMethodObject{
+		{
+			Name: "to_hash",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					if blockFrame == nil {
+						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+					}
+
+					m := receiver.(*GoMap)
+
+					pairs := map[string]Object{}
+
+					for k, v := range m.data {
+						pairs[k] = t.vm.initObjectFromGoType(v)
+
+					}
+
+					return t.vm.initHashObject(pairs)
+				}
+			},
+		},
+	}
+}
+
+// Internal functions ===================================================
+
+// Functions for initialization -----------------------------------------
+
+func (vm *VM) initGoMap(d map[string]interface{}) *GoMap {
+	return &GoMap{data: d, baseObj: &baseObj{class: vm.topLevelClass(classes.GoMapClass)}}
+}
+
+func (vm *VM) initGoMapClass() *RClass {
+	sc := vm.initializeClass(classes.GoMapClass, false)
+	sc.setBuiltinMethods(builtinGoMapClassMethods(), true)
+	sc.setBuiltinMethods(builtinGoMapInstanceMethods(), false)
+	vm.objectClass.setClassConstant(sc)
+	return sc
+}
+
+// Polymorphic helper functions -----------------------------------------
+
+// Value returns the object
+func (m *GoMap) Value() interface{} {
+	return m.data
+}
+
+// toString returns the object's name as the string format
+func (m *GoMap) toString() string {
+	return fmt.Sprintf("<GoMap: %p>", m)
+}
+
+// toJSON just delegates to toString
+func (m *GoMap) toJSON() string {
+	return m.toString()
+}

--- a/vm/go_map_test.go
+++ b/vm/go_map_test.go
@@ -69,3 +69,51 @@ func TestGoMapGetMethod(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+
+func TestGoMapSetMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`
+		m = GoMap.new
+		m.set("foo", "bar")
+		m.get("foo")
+		`, "bar"},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestGoMapToHashMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`
+		h = { foo: "bar" }
+		m = GoMap.new(h)
+		h2 = m.to_hash
+		h2[:foo]
+		`, "bar"},
+		{`
+		m = GoMap.new
+		h = m.to_hash
+		h[:foo]
+		`, nil},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/go_map_test.go
+++ b/vm/go_map_test.go
@@ -1,0 +1,46 @@
+package vm
+
+import (
+	"testing"
+)
+
+func TestGoMapInitWithoutArg(t *testing.T) {
+	input := `
+	GoMap.new
+	`
+
+	v := initTestVM()
+	evaluated := v.testEval(t, input, getFilename())
+
+	_, ok := evaluated.(*GoMap)
+
+	if !ok {
+		t.Errorf("Expect object to be an instance of GoMap. got: %s", evaluated.toString())
+	}
+}
+
+func TestGoMapInitWithHash(t *testing.T) {
+	input := `
+	h = { foo: "bar" }
+	GoMap.new(h)
+	`
+
+	v := initTestVM()
+	evaluated := v.testEval(t, input, getFilename())
+
+	m, ok := evaluated.(*GoMap)
+
+	if !ok {
+		t.Fatalf("Expect object to be an instance of GoMap. got: %s", evaluated.toString())
+	}
+
+	bar, ok := m.data["foo"]
+
+	if !ok {
+		t.Fatal("Expect object's data to contains \"foo\" key")
+	}
+
+	b := bar.(*StringObject)
+
+	testStringObject(t, 0, b, "bar")
+}

--- a/vm/go_map_test.go
+++ b/vm/go_map_test.go
@@ -44,3 +44,28 @@ func TestGoMapInitWithHash(t *testing.T) {
 
 	testStringObject(t, 0, b, "bar")
 }
+
+func TestGoMapGetMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`
+		h = { foo: "bar" }
+		m = GoMap.new(h)
+		m.get("foo")
+		`, "bar"},
+		{`
+		m = GoMap.new
+		m.get("foo")
+		`, nil},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/go_object.go
+++ b/vm/go_object.go
@@ -15,12 +15,12 @@ type GoObject struct {
 }
 
 // Class methods --------------------------------------------------------
-func builtinGoClassMethods() []*BuiltinMethodObject {
+func builtinGoObjectClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{}
 }
 
 // Instance methods -----------------------------------------------------
-func builtinGoInstanceMethods() []*BuiltinMethodObject {
+func builtinGoObjectInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "go_func",
@@ -59,8 +59,8 @@ func (vm *VM) initGoObject(d interface{}) *GoObject {
 
 func (vm *VM) initGoClass() *RClass {
 	sc := vm.initializeClass(classes.GoObjectClass, false)
-	sc.setBuiltinMethods(builtinGoClassMethods(), true)
-	sc.setBuiltinMethods(builtinGoInstanceMethods(), false)
+	sc.setBuiltinMethods(builtinGoObjectClassMethods(), true)
+	sc.setBuiltinMethods(builtinGoObjectInstanceMethods(), false)
 	vm.objectClass.setClassConstant(sc)
 	return sc
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -201,6 +201,7 @@ func (vm *VM) initConstants() {
 		vm.initChannelClass(),
 		vm.initGoClass(),
 		vm.initFileClass(),
+		vm.initGoMapClass(),
 	}
 
 	// Init error classes


### PR DESCRIPTION
Add GoMap to store `map[string]interface{}`.
Because instead of returning values, some Go function mutates a map.
This is the reason we need a way to create Go map from Goby.