### PR TITLE
Hash#clear: clear the invoked hash

### DIFF
--- a/vm/hash.go
+++ b/vm/hash.go
@@ -158,7 +158,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
 
-					return t.vm.initHashObject(make(map[string]Object))
+					h := receiver.(*HashObject)
+
+					h.Pairs = make(map[string]Object)
+
+					return h
 				}
 			},
 		},

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -188,22 +188,30 @@ func TestHashComparisonOperation(t *testing.T) {
 }
 
 func TestHashClearMethod(t *testing.T) {
-	input := `
-	{ foo: 123, bar: "test", baz: true }.clear
-	`
+	tests := []struct {
+		input    string
+		expected map[string]interface{}
+	}{
+		// object modification
+		{`
+			hash = { foo: 123, bar: "test" }
+			hash.clear
+			hash
+		`, map[string]interface{}{}},
 
-	v := initTestVM()
-	evaluated := v.testEval(t, input, getFilename())
-
-	h, ok := evaluated.(*HashObject)
-	if !ok {
-		t.Fatalf("Expect evaluated value to be a hash. got: %T", evaluated)
-	} else if h.length() != 0 {
-		t.Fatalf("Expect length of pairs of hash to be 0. got: %v", h.length())
+		// return value
+		{`
+			{ foo: 123, bar: "test" }.clear
+		`, map[string]interface{}{}},
 	}
 
-	v.checkCFP(t, 0, 0)
-	v.checkSP(t, 0, 1)
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		testHashObject(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
 }
 
 func TestHashClearMethodFail(t *testing.T) {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -276,6 +276,35 @@ func testArrayObject(t *testing.T, index int, obj Object, expected []interface{}
 	return true
 }
 
+// Tests a Hash Object, with a few limitations:
+//
+// - the tested hash must be shallow (no nested objects as values);
+// - the test hash must have strings as keys;
+// - the error message won't mention the key - only the value.
+//
+// The second limitation is currently the only Hash format in Goby, anyway.
+//
+func testHashObject(t *testing.T, index int, objectResult Object, expected map[string]interface{}) bool {
+	result, ok := objectResult.(*HashObject)
+
+	if !ok {
+		t.Errorf("At test case %d: result is not Hash. got=%T", index, objectResult)
+		return false
+	}
+
+	if len(result.Pairs) != len(expected) {
+		t.Errorf("Unexpected result size. Expected %d, got=%d", len(expected), len(result.Pairs))
+	}
+
+	for expectedKey, expectedValue := range expected {
+		resultValue := result.Pairs[expectedKey]
+
+		checkExpected(t, i, resultValue, expectedValue)
+	}
+
+	return true
+}
+
 func checkExpected(t *testing.T, i int, evaluated Object, expected interface{}) {
 	if isError(evaluated) {
 		t.Errorf("At test case %d: %s", i, evaluated.toString())


### PR DESCRIPTION
Conform the behavior to the same Ruby API, as the previous behavior (returning an empty hash without performing any other operation) doesn't have any usefulness.

This PR also adds a new testing API, `testHashObject()`.