### PR TITLE
Implement the `:dig` method for `Hash` and `Array`

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -1101,28 +1101,28 @@ func (a *ArrayObject) dig(t *thread, keys []Object) Object {
 
 	if !ok {
 		return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, currentKey.Class().Name)
-	} else {
-		normalizedIndex := a.normalizeIndex(intCurrentKey)
-
-		if normalizedIndex == -1 {
-			return NULL
-		} else {
-		  nextKeys := keys[1:]
-			currentValue := a.Elements[normalizedIndex]
-
-			if len(nextKeys) == 0 {
-				return currentValue
-			} else {
-				diggableCurrentValue, ok := currentValue.(Diggable)
-
-				if !ok {
-					return t.vm.initErrorObject(errors.TypeError, "Expect target to be Diggable, got %s", currentValue.Class().Name)
-				} else {
-					return diggableCurrentValue.dig(t, nextKeys)
-				}
-			}
-		}
 	}
+
+	normalizedIndex := a.normalizeIndex(intCurrentKey)
+
+	if normalizedIndex == -1 {
+		return NULL
+	}
+
+  nextKeys := keys[1:]
+	currentValue := a.Elements[normalizedIndex]
+
+	if len(nextKeys) == 0 {
+		return currentValue
+	}
+
+	diggableCurrentValue, ok := currentValue.(Diggable)
+
+	if !ok {
+		return t.vm.initErrorObject(errors.TypeError, "Expect target to be Diggable, got %s", currentValue.Class().Name)
+	}
+
+	return diggableCurrentValue.dig(t, nextKeys)
 }
 
 // Retrieves an object in an array using Integer index; common to `[]` and `at()`.
@@ -1142,9 +1142,9 @@ func (a *ArrayObject) index(t *thread, args []Object) Object {
 
 	if normalizedIndex == -1 {
 		return NULL
-	} else {
-		return a.Elements[normalizedIndex]
 	}
+
+	return a.Elements[normalizedIndex]
 }
 
 // flatten returns a array of Objects that is one-dimensional flattening of Elements
@@ -1181,7 +1181,9 @@ func (a *ArrayObject) normalizeIndex(objectIndex *IntegerObject) int {
 
 	if index >= aLength {
 		return -1
-	} else if index < 0 && -index > aLength {
+	}
+
+	if index < 0 && -index > aLength {
 		return -1
 	}
 
@@ -1189,9 +1191,9 @@ func (a *ArrayObject) normalizeIndex(objectIndex *IntegerObject) int {
 
 	if index < 0 {
 		return aLength + index
-	} else {
-		return index
 	}
+
+	return index
 }
 
 // pop removes the last element in the array and returns it

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -83,6 +83,49 @@ func TestArrayComparisonOperation(t *testing.T) {
 	}
 }
 
+func TestArrayDigMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`
+			[1 , 2].dig(-2)
+		`, 1},
+		{`
+			[{a: 3} , 2].dig(0, :a)
+		`, 3},
+		{`
+			[[], 2].dig(0, 1)
+		`, nil},
+		{`
+			[[], 2].dig(0, 1, 2)
+		`, nil},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestArrayDigMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`[1, 2].dig`, "ArgumentError: Expected 1+ arguments, got 0", 1},
+		{`[1, 2].dig(0, 1)`, "TypeError: Expect target to be Diggable, got Integer", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestArrayIndex(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/vm/diggable.go
+++ b/vm/diggable.go
@@ -1,0 +1,6 @@
+package vm
+
+// Diggable represents a class that support the #dig method.
+type Diggable interface {
+  dig(t *thread, keys []Object) Object
+}

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -163,6 +163,32 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			},
 		},
 		{
+			// Extracts the nested value specified by the sequence of idx objects by calling `dig` at
+			// each step, returning nil if any intermediate step is nil.
+			//
+			// ```Ruby
+			// { a: 1 , b: 2 }.dig(:a)         # => 1
+			// { a: {}, b: 2 }.dig(:a, :b)     # => nil
+			// { a: {}, b: 2 }.dig(:a, :b, :c) # => nil
+			// { a: 1, b: 2 }.dig(:a, :b)      # => TypeError: Expect target to be Diggable
+			// ```
+			//
+			// @return [Object]
+			Name: "dig",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					if len(args) == 0 {
+						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1+ arguments, got 0")
+					}
+
+					hash := receiver.(*HashObject)
+					value := hash.dig(t, args)
+
+					return value
+				}
+			},
+		},
+		{
 			// Loop through keys of the hash with given block frame. It also returns array of
 			// keys in alphabetical order.
 			//
@@ -816,6 +842,35 @@ func (h *HashObject) copy() Object {
 	}
 
 	return newHash
+}
+
+// recursive indexed access - see ArrayObject#dig documentation.
+func (h *HashObject) dig(t *thread, keys []Object) Object {
+	currentKey := keys[0]
+	stringCurrentKey, ok := currentKey.(*StringObject)
+
+	if !ok {
+		return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, currentKey.Class().Name)
+	} else {
+		nextKeys := keys[1:]
+		currentValue, ok := h.Pairs[stringCurrentKey.value]
+
+		if !ok {
+			return NULL
+		} else {
+			if len(nextKeys) == 0 {
+				return currentValue
+			} else {
+				diggableCurrentValue, ok := currentValue.(Diggable)
+
+				if !ok {
+					return t.vm.initErrorObject(errors.TypeError, "Expect target to be Diggable, got %s", currentValue.Class().Name)
+				} else {
+					return diggableCurrentValue.dig(t, nextKeys)
+				}
+			}
+		}
+	}
 }
 
 // Other helper functions ----------------------------------------------

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -851,26 +851,26 @@ func (h *HashObject) dig(t *thread, keys []Object) Object {
 
 	if !ok {
 		return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, currentKey.Class().Name)
-	} else {
-		nextKeys := keys[1:]
-		currentValue, ok := h.Pairs[stringCurrentKey.value]
-
-		if !ok {
-			return NULL
-		} else {
-			if len(nextKeys) == 0 {
-				return currentValue
-			} else {
-				diggableCurrentValue, ok := currentValue.(Diggable)
-
-				if !ok {
-					return t.vm.initErrorObject(errors.TypeError, "Expect target to be Diggable, got %s", currentValue.Class().Name)
-				} else {
-					return diggableCurrentValue.dig(t, nextKeys)
-				}
-			}
-		}
 	}
+
+	nextKeys := keys[1:]
+	currentValue, ok := h.Pairs[stringCurrentKey.value]
+
+	if !ok {
+		return NULL
+	}
+
+	if len(nextKeys) == 0 {
+		return currentValue
+	}
+
+	diggableCurrentValue, ok := currentValue.(Diggable)
+
+	if !ok {
+		return t.vm.initErrorObject(errors.TypeError, "Expect target to be Diggable, got %s", currentValue.Class().Name)
+	}
+
+	return diggableCurrentValue.dig(t, nextKeys)
 }
 
 // Other helper functions ----------------------------------------------

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -221,6 +221,46 @@ func TestHashClearMethodFail(t *testing.T) {
 	}
 }
 
+func TestHashDigMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`
+			{ a: 1, b: 2 }.dig(:a)
+		`, 1},
+		{`
+			{ a: {}, b: 2 }.dig(:a, :b)
+		`, nil},
+		{`
+			{ a: {}, b: 2 }.dig(:a, :b, :c)
+		`, nil},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestHashDigMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`{ a: [], b: 2 }.dig`, "ArgumentError: Expected 1+ arguments, got 0", 1},
+		{`{ a: 1, b: 2 }.dig(:a, :b)`, "TypeError: Expect target to be Diggable, got Integer", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestHashEachKeyMethod(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
Implemented the `:dig` method for `Hash` and `Array`, via `Diggable` Go interface.

The PR contains also a small refactoring in the `Array` class, adding the internal `normalizedIndex()` method.