### PR TITLE
Add `.DS_Store` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ goby
 
 *.gbbc
 coverage.txt
+.DS_Store


### PR DESCRIPTION
`.DS_Store` files should be ignored, as it's MacOS-specific metadata, irrelevant to the project itself.