### PR TITLE
Float class (backend)

### DIFF
--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -120,6 +120,15 @@ func (vm *VM) initBoolClass() *RClass {
 // Polymorphic helper functions -----------------------------------------
 
 // Value returns the object
+func toBooleanObject(value bool) *BooleanObject {
+	if value {
+		return TRUE
+	}
+
+	return FALSE
+}
+
+// Value returns the object
 func (b *BooleanObject) Value() interface{} {
 	return b.value
 }

--- a/vm/classes/classes.go
+++ b/vm/classes/classes.go
@@ -4,6 +4,7 @@ const (
 	ObjectClass   = "Object"
 	ClassClass    = "Class"
 	IntegerClass  = "Integer"
+	FloatClass    = "Float"
 	StringClass   = "String"
 	ArrayClass    = "Array"
 	HashClass     = "Hash"

--- a/vm/float.go
+++ b/vm/float.go
@@ -49,18 +49,11 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "+",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					objectRightValue, ok := args[0].(Numeric)
+					operation := func(leftValue float64, rightValue float64) float64 {
+						return leftValue + rightValue
+					}
 
-          if ! ok {
-            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
-          }
-
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
-
-					result := leftValue + rightValue
-
-					return t.vm.initFloatObject(result)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation)
 				}
 			},
 		},
@@ -74,18 +67,11 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "%",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-          objectRightValue, ok := args[0].(Numeric)
+					operation := func(leftValue float64, rightValue float64) float64 {
+						return math.Mod(leftValue, rightValue)
+					}
 
-          if ! ok {
-            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
-          }
-
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
-
-					result := math.Mod(leftValue, rightValue)
-
-					return t.vm.initFloatObject(result)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation)
 				}
 			},
 		},
@@ -99,18 +85,11 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "-",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-          objectRightValue, ok := args[0].(Numeric)
+					operation := func(leftValue float64, rightValue float64) float64 {
+						return leftValue - rightValue
+					}
 
-          if ! ok {
-            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
-          }
-
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
-
-					result := leftValue - rightValue
-
-					return t.vm.initFloatObject(result)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation)
 				}
 			},
 		},
@@ -124,18 +103,11 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "*",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-          objectRightValue, ok := args[0].(Numeric)
+					operation := func(leftValue float64, rightValue float64) float64 {
+						return leftValue * rightValue
+					}
 
-          if ! ok {
-            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
-          }
-
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
-
-					result := leftValue * rightValue
-
-					return t.vm.initFloatObject(result)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation)
 				}
 			},
 		},
@@ -149,18 +121,11 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "**",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-          objectRightValue, ok := args[0].(Numeric)
+					operation := func(leftValue float64, rightValue float64) float64 {
+						return math.Pow(leftValue, rightValue)
+					}
 
-          if ! ok {
-            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
-          }
-
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
-
-					result := math.Pow(leftValue, rightValue)
-
-					return t.vm.initFloatObject(result)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation)
 				}
 			},
 		},
@@ -174,18 +139,11 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "/",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-          objectRightValue, ok := args[0].(Numeric)
+					operation := func(leftValue float64, rightValue float64) float64 {
+						return leftValue / rightValue
+					}
 
-          if ! ok {
-            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
-          }
-
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
-
-					result := leftValue / rightValue
-
-					return t.vm.initFloatObject(result)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation)
 				}
 			},
 		},
@@ -200,18 +158,11 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: ">",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-          objectRightValue, ok := args[0].(Numeric)
+					operation := func(leftValue float64, rightValue float64) bool {
+						return leftValue > rightValue
+					}
 
-          if ! ok {
-            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
-          }
-
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
-
-					result := leftValue > rightValue
-
-					return toBooleanObject(result)
+					return receiver.(*FloatObject).numericComparison(t, args[0], operation)
 				}
 			},
 		},
@@ -226,18 +177,11 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: ">=",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-          objectRightValue, ok := args[0].(Numeric)
+					operation := func(leftValue float64, rightValue float64) bool {
+						return leftValue >= rightValue
+					}
 
-          if ! ok {
-            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
-          }
-
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
-
-					result := leftValue >= rightValue
-
-					return toBooleanObject(result)
+					return receiver.(*FloatObject).numericComparison(t, args[0], operation)
 				}
 			},
 		},
@@ -252,18 +196,11 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "<",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-          objectRightValue, ok := args[0].(Numeric)
+					operation := func(leftValue float64, rightValue float64) bool {
+						return leftValue < rightValue
+					}
 
-          if ! ok {
-            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
-          }
-
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
-
-					result := leftValue < rightValue
-
-					return toBooleanObject(result)
+					return receiver.(*FloatObject).numericComparison(t, args[0], operation)
 				}
 			},
 		},
@@ -278,18 +215,11 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "<=",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-          objectRightValue, ok := args[0].(Numeric)
+					operation := func(leftValue float64, rightValue float64) bool {
+						return leftValue <= rightValue
+					}
 
-          if ! ok {
-            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
-          }
-
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
-
-					result := leftValue <= rightValue
-
-					return toBooleanObject(result)
+					return receiver.(*FloatObject).numericComparison(t, args[0], operation)
 				}
 			},
 		},
@@ -305,14 +235,14 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "<=>",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-          objectRightValue, ok := args[0].(Numeric)
+					rightNumeric, ok := args[0].(Numeric)
 
-          if ! ok {
-            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
-          }
+					if ! ok {
+						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+					}
 
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
+					leftValue := receiver.(*FloatObject).value
+					rightValue := rightNumeric.floatValue()
 
 					if leftValue < rightValue {
 						return t.vm.initIntegerObject(-1)
@@ -339,16 +269,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-          objectRightValue, ok := args[0].(Numeric)
-
-          if ! ok {
-            return FALSE
-          }
-
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
-
-					result := leftValue == rightValue
+					result := receiver.(*FloatObject).equalityTest(args[0])
 
 					return toBooleanObject(result)
 				}
@@ -368,16 +289,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "!=",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-          objectRightValue, ok := args[0].(Numeric)
-
-          if ! ok {
-            return TRUE
-          }
-
-          leftValue := receiver.(*FloatObject).value
-          rightValue := objectRightValue.floatValue()
-
-					result := leftValue != rightValue
+					result := ! receiver.(*FloatObject).equalityTest(args[0])
 
 					return toBooleanObject(result)
 				}
@@ -440,6 +352,53 @@ func (f *FloatObject) Value() interface{} {
 // Numeric interface
 func (f *FloatObject) floatValue() float64 {
 	return f.value
+}
+
+// Apply the passed arithmetic operation, while performing type conversion.
+func (f *FloatObject) arithmeticOperation(t *thread, rightObject Object, operation func(leftValue float64, rightValue float64) float64) Object {
+	rightNumeric, ok := rightObject.(Numeric)
+
+	if ! ok {
+		return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", rightObject.Class().Name)
+	}
+
+	leftValue := f.value
+	rightValue := rightNumeric.floatValue()
+
+	result := operation(leftValue, rightValue)
+
+	return t.vm.initFloatObject(result)
+}
+
+// Apply an equality test, returning true if the objects are considered equal,
+// and false otherwise.
+func (f *FloatObject) equalityTest(rightObject Object) bool {
+	rightNumeric, ok := rightObject.(Numeric)
+
+	if ! ok {
+		return false
+	}
+
+	leftValue := f.value
+	rightValue := rightNumeric.floatValue()
+
+	return leftValue == rightValue
+}
+
+// Apply the passed numeric comparison, while performing type conversion.
+func (f *FloatObject) numericComparison(t *thread, rightObject Object, operation func(leftValue float64, rightValue float64) bool) Object {
+	rightNumeric, ok := rightObject.(Numeric)
+
+	if ! ok {
+		return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", rightObject.Class().Name)
+	}
+
+	leftValue := f.value
+	rightValue := rightNumeric.floatValue()
+
+	result := operation(leftValue, rightValue)
+
+	return toBooleanObject(result)
 }
 
 // toString returns the object's value as the string format, in non

--- a/vm/float.go
+++ b/vm/float.go
@@ -451,6 +451,11 @@ func (f *FloatObject) Value() interface{} {
 	return f.value
 }
 
+// Numeric interface
+func (f *FloatObject) floatValue() float64 {
+	return f.value
+}
+
 // toString returns the object's value as the string format, in non
 // exponential format (straight number, without exponent `E<exp>`).
 func (f *FloatObject) toString() string {

--- a/vm/float.go
+++ b/vm/float.go
@@ -12,8 +12,8 @@ import (
 // representation.
 //
 // ```ruby
-// '1.1'.to_f + '1.1'.to_f # => 2.2
-// '2.1'.to_f * '2.1'.to_f # => 4.41
+// 1.1 + 1.1 # => 2.2
+// 2.1 * 2.1 # => 4.41
 // ```
 //
 // - `Float.new` is not supported.
@@ -40,153 +40,157 @@ func builtinFloatClassMethods() []*BuiltinMethodObject {
 func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
-			// Returns the sum of self and another Float.
+			// Returns the sum of self and a Numeric.
 			//
 			// ```Ruby
-			// 1 + 2 # => 3
+			// 1.1 + 2 # => 3.1
 			// ```
 			// @return [Float]
 			Name: "+",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					objectRightValue, ok := args[0].(Numeric)
 
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
+          if ! ok {
+            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+          }
 
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
-						return err
-					}
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
 
-					rightValue := right.value
-					return t.vm.initFloatObject(leftValue + rightValue)
+					result := leftValue + rightValue
+
+					return t.vm.initFloatObject(result)
 				}
 			},
 		},
 		{
-			// Divides left hand operand by right hand operand and returns remainder.
+			// Returns the modulo between self and a Numeric.
 			//
 			// ```Ruby
-			// 5 % 2 # => 1
+			// 5.5 % 2 # => 1.5
 			// ```
 			// @return [Float]
 			Name: "%",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+          objectRightValue, ok := args[0].(Numeric)
 
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
+          if ! ok {
+            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+          }
 
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
-						return err
-					}
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
 
-					rightValue := right.value
 					result := math.Mod(leftValue, rightValue)
+
 					return t.vm.initFloatObject(result)
 				}
 			},
 		},
 		{
-			// Returns the subtraction of another Float from self.
+			// Returns the subtraction of a Numeric from self.
 			//
 			// ```Ruby
-			// 1 - 1 # => 0
+			// 1.5 - 1 # => 0.5
 			// ```
 			// @return [Float]
 			Name: "-",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+          objectRightValue, ok := args[0].(Numeric)
 
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
+          if ! ok {
+            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+          }
 
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
-						return err
-					}
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
 
-					rightValue := right.value
-					return t.vm.initFloatObject(leftValue - rightValue)
-				}
-			},
-		},
-		{
-			// Returns self multiplying another Float.
-			//
-			// ```Ruby
-			// 2 * 10 # => 20
-			// ```
-			// @return [Float]
-			Name: "*",
-			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					result := leftValue - rightValue
 
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
-
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
-						return err
-					}
-
-					rightValue := right.value
-					return t.vm.initFloatObject(leftValue * rightValue)
-				}
-			},
-		},
-		{
-			// Returns self squaring another Float.
-			//
-			// ```Ruby
-			// 2 ** 8 # => 256
-			// ```
-			// @return [Float]
-			Name: "**",
-			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
-
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
-						return err
-					}
-
-					rightValue := right.value
-					result := math.Pow(leftValue, rightValue)
 					return t.vm.initFloatObject(result)
 				}
 			},
 		},
 		{
-			// Returns self divided by another Float.
+			// Returns self multiplying a Numeric.
 			//
 			// ```Ruby
-			// 6 / 3 # => 2
+			// 2.5 * 10 # => 25.0
+			// ```
+			// @return [Float]
+			Name: "*",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+          objectRightValue, ok := args[0].(Numeric)
+
+          if ! ok {
+            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+          }
+
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
+
+					result := leftValue * rightValue
+
+					return t.vm.initFloatObject(result)
+				}
+			},
+		},
+		{
+			// Returns self squaring a Numeric.
+			//
+			// ```Ruby
+			// 4.0 ** 2.5 # => 32.0
+			// ```
+			// @return [Float]
+			Name: "**",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+          objectRightValue, ok := args[0].(Numeric)
+
+          if ! ok {
+            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+          }
+
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
+
+					result := math.Pow(leftValue, rightValue)
+
+					return t.vm.initFloatObject(result)
+				}
+			},
+		},
+		{
+			// Returns self divided by a Numeric.
+			//
+			// ```Ruby
+			// 7.5 / 3 # => 2.5
 			// ```
 			// @return [Float]
 			Name: "/",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+          objectRightValue, ok := args[0].(Numeric)
 
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
+          if ! ok {
+            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+          }
 
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
-						return err
-					}
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
 
-					rightValue := right.value
-					return t.vm.initFloatObject(leftValue / rightValue)
+					result := leftValue / rightValue
+
+					return t.vm.initFloatObject(result)
 				}
 			},
 		},
 		{
-			// Returns if self is larger than another Float.
+			// Returns if self is larger than a Numeric.
 			//
 			// ```Ruby
 			// 10 > -1 # => true
@@ -196,27 +200,23 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: ">",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+          objectRightValue, ok := args[0].(Numeric)
 
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
+          if ! ok {
+            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+          }
 
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
-						return err
-					}
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
 
-					rightValue := right.value
+					result := leftValue > rightValue
 
-					if leftValue > rightValue {
-						return TRUE
-					}
-
-					return FALSE
+					return toBooleanObject(result)
 				}
 			},
 		},
 		{
-			// Returns if self is larger than or equals to another Float.
+			// Returns if self is larger than or equals to a Numeric.
 			//
 			// ```Ruby
 			// 2 >= 1 # => true
@@ -226,27 +226,23 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: ">=",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+          objectRightValue, ok := args[0].(Numeric)
 
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
+          if ! ok {
+            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+          }
 
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
-						return err
-					}
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
 
-					rightValue := right.value
+					result := leftValue >= rightValue
 
-					if leftValue >= rightValue {
-						return TRUE
-					}
-
-					return FALSE
+					return toBooleanObject(result)
 				}
 			},
 		},
 		{
-			// Returns if self is smaller than another Float.
+			// Returns if self is smaller than a Numeric.
 			//
 			// ```Ruby
 			// 1 < 3 # => true
@@ -256,27 +252,23 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "<",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+          objectRightValue, ok := args[0].(Numeric)
 
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
+          if ! ok {
+            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+          }
 
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
-						return err
-					}
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
 
-					rightValue := right.value
+					result := leftValue < rightValue
 
-					if leftValue < rightValue {
-						return TRUE
-					}
-
-					return FALSE
+					return toBooleanObject(result)
 				}
 			},
 		},
 		{
-			// Returns if self is smaller than or equals to another Float.
+			// Returns if self is smaller than or equals to a Numeric.
 			//
 			// ```Ruby
 			// 1 <= 3 # => true
@@ -286,47 +278,41 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "<=",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+          objectRightValue, ok := args[0].(Numeric)
 
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
+          if ! ok {
+            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+          }
 
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
-						return err
-					}
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
 
-					rightValue := right.value
+					result := leftValue <= rightValue
 
-					if leftValue <= rightValue {
-						return TRUE
-					}
-
-					return FALSE
+					return toBooleanObject(result)
 				}
 			},
 		},
 		{
-			// Returns 1 if self is larger than the incoming Float, -1 if smaller. Otherwise 0.
+			// Returns 1 if self is larger than a Numeric, -1 if smaller. Otherwise 0.
 			//
 			// ```Ruby
-			// 1 <=> 3 # => -1
-			// 1 <=> 1 # => 0
-			// 3 <=> 1 # => 1
+			// 1.5 <=> 3 # => -1
+			// 1.0 <=> 1 # => 0
+			// 3.5 <=> 1 # => 1
 			// ```
 			// @return [Float]
 			Name: "<=>",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+          objectRightValue, ok := args[0].(Numeric)
 
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
+          if ! ok {
+            return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+          }
 
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
-						return err
-					}
-
-					rightValue := right.value
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
 
 					if leftValue < rightValue {
 						return t.vm.initIntegerObject(-1)
@@ -340,60 +326,60 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			},
 		},
 		{
-			// Returns if self is equal to another Float.
+			// Returns if self is equal to an Object.
+			// If the Object is a Numeric, a comparison is performed, otherwise, the
+			// result is always false.
 			//
 			// ```Ruby
-			// 1 == 3 # => false
-			// 1 == 1 # => true
+			// 1.0 == 3     # => false
+			// 1.0 == 1     # => true
+			// 1.0 == '1.0' # => false
 			// ```
 			// @return [Boolean]
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+          objectRightValue, ok := args[0].(Numeric)
 
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
+          if ! ok {
+            return FALSE
+          }
 
-					if !ok {
-						return FALSE
-					}
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
 
-					rightValue := right.value
+					result := leftValue == rightValue
 
-					if leftValue == rightValue {
-						return TRUE
-					}
-
-					return FALSE
+					return toBooleanObject(result)
 				}
 			},
 		},
 		{
-			// Returns if self is not equal to another Float.
+			// Returns if self is not equal to an Object.
+			// If the Object is a Numeric, a comparison is performed, otherwise, the
+			// result is always true.
 			//
 			// ```Ruby
-			// 1 != 3 # => true
-			// 1 != 1 # => false
+			// 1.0 != 3     # => true
+			// 1.0 != 1     # => false
+			// 1.0 != '1.0' # => true
 			// ```
 			// @return [Boolean]
 			Name: "!=",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+          objectRightValue, ok := args[0].(Numeric)
 
-					leftValue := receiver.(*FloatObject).value
-					right, ok := args[0].(*FloatObject)
+          if ! ok {
+            return TRUE
+          }
 
-					if !ok {
-						return TRUE
-					}
+          leftValue := receiver.(*FloatObject).value
+          rightValue := objectRightValue.floatValue()
 
-					rightValue := right.value
+					result := leftValue != rightValue
 
-					if leftValue != rightValue {
-						return TRUE
-					}
-
-					return FALSE
+					return toBooleanObject(result)
 				}
 			},
 		},
@@ -401,7 +387,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// Returns the `Integer` representation of self.
 			//
 			// ```Ruby
-			// '100.1'.to_f.to_i # => 100
+			// 100.1.to_i # => 100
 			// ```
 			// @return [Integer]
 			Name: "to_i",

--- a/vm/float.go
+++ b/vm/float.go
@@ -1,0 +1,468 @@
+package vm
+
+import (
+	"math"
+	"strconv"
+
+	"github.com/goby-lang/goby/vm/classes"
+	"github.com/goby-lang/goby/vm/errors"
+)
+
+// FloatObject represents an inexact real number using the native architecture's double-precision floating point
+// representation.
+//
+// ```ruby
+// '1.1'.to_f + '1.1'.to_f # => 2.2
+// '2.1'.to_f * '2.1'.to_f # => 4.41
+// ```
+//
+// - `Float.new` is not supported.
+type FloatObject struct {
+	*baseObj
+	value float64
+}
+
+// Class methods --------------------------------------------------------
+func builtinFloatClassMethods() []*BuiltinMethodObject {
+	return []*BuiltinMethodObject{
+		{
+			Name: "new",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					return t.unsupportedMethodError("#new", receiver)
+				}
+			},
+		},
+	}
+}
+
+// Instance methods -----------------------------------------------------
+func builtinFloatInstanceMethods() []*BuiltinMethodObject {
+	return []*BuiltinMethodObject{
+		{
+			// Returns the sum of self and another Float.
+			//
+			// ```Ruby
+			// 1 + 2 # => 3
+			// ```
+			// @return [Float]
+			Name: "+",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
+						return err
+					}
+
+					rightValue := right.value
+					return t.vm.initFloatObject(leftValue + rightValue)
+				}
+			},
+		},
+		{
+			// Divides left hand operand by right hand operand and returns remainder.
+			//
+			// ```Ruby
+			// 5 % 2 # => 1
+			// ```
+			// @return [Float]
+			Name: "%",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
+						return err
+					}
+
+					rightValue := right.value
+					result := math.Mod(leftValue, rightValue)
+					return t.vm.initFloatObject(result)
+				}
+			},
+		},
+		{
+			// Returns the subtraction of another Float from self.
+			//
+			// ```Ruby
+			// 1 - 1 # => 0
+			// ```
+			// @return [Float]
+			Name: "-",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
+						return err
+					}
+
+					rightValue := right.value
+					return t.vm.initFloatObject(leftValue - rightValue)
+				}
+			},
+		},
+		{
+			// Returns self multiplying another Float.
+			//
+			// ```Ruby
+			// 2 * 10 # => 20
+			// ```
+			// @return [Float]
+			Name: "*",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
+						return err
+					}
+
+					rightValue := right.value
+					return t.vm.initFloatObject(leftValue * rightValue)
+				}
+			},
+		},
+		{
+			// Returns self squaring another Float.
+			//
+			// ```Ruby
+			// 2 ** 8 # => 256
+			// ```
+			// @return [Float]
+			Name: "**",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
+						return err
+					}
+
+					rightValue := right.value
+					result := math.Pow(leftValue, rightValue)
+					return t.vm.initFloatObject(result)
+				}
+			},
+		},
+		{
+			// Returns self divided by another Float.
+			//
+			// ```Ruby
+			// 6 / 3 # => 2
+			// ```
+			// @return [Float]
+			Name: "/",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
+						return err
+					}
+
+					rightValue := right.value
+					return t.vm.initFloatObject(leftValue / rightValue)
+				}
+			},
+		},
+		{
+			// Returns if self is larger than another Float.
+			//
+			// ```Ruby
+			// 10 > -1 # => true
+			// 3 > 3 # => false
+			// ```
+			// @return [Boolean]
+			Name: ">",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
+						return err
+					}
+
+					rightValue := right.value
+
+					if leftValue > rightValue {
+						return TRUE
+					}
+
+					return FALSE
+				}
+			},
+		},
+		{
+			// Returns if self is larger than or equals to another Float.
+			//
+			// ```Ruby
+			// 2 >= 1 # => true
+			// 1 >= 1 # => true
+			// ```
+			// @return [Boolean]
+			Name: ">=",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
+						return err
+					}
+
+					rightValue := right.value
+
+					if leftValue >= rightValue {
+						return TRUE
+					}
+
+					return FALSE
+				}
+			},
+		},
+		{
+			// Returns if self is smaller than another Float.
+			//
+			// ```Ruby
+			// 1 < 3 # => true
+			// 1 < 1 # => false
+			// ```
+			// @return [Boolean]
+			Name: "<",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
+						return err
+					}
+
+					rightValue := right.value
+
+					if leftValue < rightValue {
+						return TRUE
+					}
+
+					return FALSE
+				}
+			},
+		},
+		{
+			// Returns if self is smaller than or equals to another Float.
+			//
+			// ```Ruby
+			// 1 <= 3 # => true
+			// 1 <= 1 # => true
+			// ```
+			// @return [Boolean]
+			Name: "<=",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
+						return err
+					}
+
+					rightValue := right.value
+
+					if leftValue <= rightValue {
+						return TRUE
+					}
+
+					return FALSE
+				}
+			},
+		},
+		{
+			// Returns 1 if self is larger than the incoming Float, -1 if smaller. Otherwise 0.
+			//
+			// ```Ruby
+			// 1 <=> 3 # => -1
+			// 1 <=> 1 # => 0
+			// 3 <=> 1 # => 1
+			// ```
+			// @return [Float]
+			Name: "<=>",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.FloatClass, args[0].Class().Name)
+						return err
+					}
+
+					rightValue := right.value
+
+					if leftValue < rightValue {
+						return t.vm.initIntegerObject(-1)
+					}
+					if leftValue > rightValue {
+						return t.vm.initIntegerObject(1)
+					}
+
+					return t.vm.initIntegerObject(0)
+				}
+			},
+		},
+		{
+			// Returns if self is equal to another Float.
+			//
+			// ```Ruby
+			// 1 == 3 # => false
+			// 1 == 1 # => true
+			// ```
+			// @return [Boolean]
+			Name: "==",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						return FALSE
+					}
+
+					rightValue := right.value
+
+					if leftValue == rightValue {
+						return TRUE
+					}
+
+					return FALSE
+				}
+			},
+		},
+		{
+			// Returns if self is not equal to another Float.
+			//
+			// ```Ruby
+			// 1 != 3 # => true
+			// 1 != 1 # => false
+			// ```
+			// @return [Boolean]
+			Name: "!=",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+
+					leftValue := receiver.(*FloatObject).value
+					right, ok := args[0].(*FloatObject)
+
+					if !ok {
+						return TRUE
+					}
+
+					rightValue := right.value
+
+					if leftValue != rightValue {
+						return TRUE
+					}
+
+					return FALSE
+				}
+			},
+		},
+		{
+			// Returns the `Integer` representation of self.
+			//
+			// ```Ruby
+			// '100.1'.to_f.to_i # => 100
+			// ```
+			// @return [Integer]
+			Name: "to_i",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					r := receiver.(*FloatObject)
+					newInt := t.vm.initIntegerObject(int(r.value))
+					newInt.flag = i
+					return newInt
+				}
+			},
+		},
+		{
+			Name: "ptr",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					r := receiver.(*FloatObject)
+					return t.vm.initGoObject(&r.value)
+				}
+			},
+		},
+	}
+}
+
+// Internal functions ===================================================
+
+// Functions for initialization -----------------------------------------
+
+func (vm *VM) initFloatObject(value float64) *FloatObject {
+	return &FloatObject{
+		baseObj: &baseObj{class: vm.topLevelClass(classes.FloatClass)},
+		value:   value,
+	}
+}
+
+func (vm *VM) initFloatClass() *RClass {
+	ic := vm.initializeClass(classes.FloatClass, false)
+	ic.setBuiltinMethods(builtinFloatInstanceMethods(), false)
+	ic.setBuiltinMethods(builtinFloatClassMethods(), true)
+	return ic
+}
+
+// Polymorphic helper functions -----------------------------------------
+
+// Value returns the object
+func (f *FloatObject) Value() interface{} {
+	return f.value
+}
+
+// toString returns the object's value as the string format, in non
+// exponential format (straight number, without exponent `E<exp>`).
+func (f *FloatObject) toString() string {
+	return strconv.FormatFloat(f.value, 'f', -1, 64)
+}
+
+// toJSON just delegates to toString
+func (f *FloatObject) toJSON() string {
+	return f.toString()
+}
+
+// equal checks if the Float values between receiver and argument are equal
+func (f *FloatObject) equal(e *FloatObject) bool {
+	return f.value == e.value
+}

--- a/vm/float_test.go
+++ b/vm/float_test.go
@@ -1,0 +1,144 @@
+package vm
+
+import (
+	"testing"
+)
+
+func TestFloatClassSuperclass(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`Float.class.name`, "Class"},
+		{`Float.superclass.name`, "Object"},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestFloatArithmeticOperation(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`'1.5'.to_f + '2'.to_f`, 3.5},
+		{`'22.5'.to_f - '10'.to_f`, 12.5},
+		{`'5.5'.to_f * '20'.to_f`, 110.0},
+		{`'4.5'.to_f % '2'.to_f`, 0.5},
+		{`'10.5'.to_f % '3.5'.to_f`, 0.0},
+		{`'25.5'.to_f / '5'.to_f`, 5.1},
+		{`'5.5'.to_f ** '2'.to_f`, 30.25},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestFloatArithmeticOperationFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`'1'.to_f + "p"`, "TypeError: Expect argument to be Float. got: String", 1},
+		{`'1'.to_f - "m"`, "TypeError: Expect argument to be Float. got: String", 1},
+		{`'1'.to_f ** "p"`, "TypeError: Expect argument to be Float. got: String", 1},
+		{`'1'.to_f / "t"`, "TypeError: Expect argument to be Float. got: String", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestFloatComparison(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`'25.5'.to_f > '5'.to_f`, true},
+		{`'4.5'.to_f > '6'.to_f`, false},
+		{`'-5.5'.to_f < '-4'.to_f`, true},
+		{`'100.5'.to_f < '81'.to_f`, false},
+		{`'25.5'.to_f > '5'.to_f`, true},
+		{`'4.5'.to_f > '6'.to_f`, false},
+		{`'4.5'.to_f >= '4'.to_f`, true},
+		{`'2.5'.to_f >= '5'.to_f`, false},
+		{`'-5.5'.to_f < '-4'.to_f`, true},
+		{`'100.5'.to_f < '81'.to_f`, false},
+		{`'10.5'.to_f <= '10.5'.to_f`, true},
+		{`'10.5'.to_f <= '0'.to_f`, false},
+		{`'10.5'.to_f <=> '0'.to_f`, 1},
+		{`'1.5'.to_f <=> '2'.to_f`, -1},
+		{`'4.5'.to_f <=> '4.5'.to_f`, 0},
+		{`'123.5'.to_f == '123.5'.to_f`, true},
+		{`'123.5'.to_f == '124'.to_f`, false},
+		{`'123.5'.to_f == "'123'.to_f"`, false},
+		{`'123.5'.to_f == (1..3)`, false},
+		{`'123.5'.to_f == { a: '1'.to_f, b: '2'.to_f }`, false},
+		{`'123.5'.to_f == ['1'.to_f, "String", true, 2..5]`, false},
+		{`'123.5'.to_f == Float`, false},
+		{`'123.5'.to_f != '123.5'.to_f`, false},
+		{`'123.5'.to_f != '124'.to_f`, true},
+		{`'123.5'.to_f != "'123'.to_f"`, true},
+		{`'123.5'.to_f != (1..3)`, true},
+		{`'123.5'.to_f != { a: '1'.to_f, b: '2'.to_f }`, true},
+		{`'123.5'.to_f != ['1'.to_f, "String", true, 2..5]`, true},
+		{`'123.5'.to_f != Float`, true},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestFloatComparisonFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`'1'.to_f > "m"`, "TypeError: Expect argument to be Float. got: String", 1},
+		{`'1'.to_f >= "m"`, "TypeError: Expect argument to be Float. got: String", 1},
+		{`'1'.to_f < "m"`, "TypeError: Expect argument to be Float. got: String", 1},
+		{`'1'.to_f <= "m"`, "TypeError: Expect argument to be Float. got: String", 1},
+		{`'1'.to_f <=> "m"`, "TypeError: Expect argument to be Float. got: String", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestFloatConversions(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`'100.3'.to_f.to_i`, 100},
+		{`'100.3'.to_f.to_s`, "100.3"},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/float_test.go
+++ b/vm/float_test.go
@@ -47,10 +47,10 @@ func TestFloatArithmeticOperation(t *testing.T) {
 
 func TestFloatArithmeticOperationFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`'1'.to_f + "p"`, "TypeError: Expect argument to be Float. got: String", 1},
-		{`'1'.to_f - "m"`, "TypeError: Expect argument to be Float. got: String", 1},
-		{`'1'.to_f ** "p"`, "TypeError: Expect argument to be Float. got: String", 1},
-		{`'1'.to_f / "t"`, "TypeError: Expect argument to be Float. got: String", 1},
+		{`'1'.to_f + "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`'1'.to_f - "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`'1'.to_f ** "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`'1'.to_f / "t"`, "TypeError: Expect argument to be Numeric. got: String", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -91,7 +91,7 @@ func TestFloatComparison(t *testing.T) {
 		{`'123.5'.to_f == Float`, false},
 		{`'123.5'.to_f != '123.5'.to_f`, false},
 		{`'123.5'.to_f != '124'.to_f`, true},
-		{`'123.5'.to_f != "'123'.to_f"`, true},
+		{`'123.5'.to_f != '123'.to_f`, true},
 		{`'123.5'.to_f != (1..3)`, true},
 		{`'123.5'.to_f != { a: '1'.to_f, b: '2'.to_f }`, true},
 		{`'123.5'.to_f != ['1'.to_f, "String", true, 2..5]`, true},
@@ -109,11 +109,11 @@ func TestFloatComparison(t *testing.T) {
 
 func TestFloatComparisonFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`'1'.to_f > "m"`, "TypeError: Expect argument to be Float. got: String", 1},
-		{`'1'.to_f >= "m"`, "TypeError: Expect argument to be Float. got: String", 1},
-		{`'1'.to_f < "m"`, "TypeError: Expect argument to be Float. got: String", 1},
-		{`'1'.to_f <= "m"`, "TypeError: Expect argument to be Float. got: String", 1},
-		{`'1'.to_f <=> "m"`, "TypeError: Expect argument to be Float. got: String", 1},
+		{`'1'.to_f > "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`'1'.to_f >= "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`'1'.to_f < "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`'1'.to_f <= "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`'1'.to_f <=> "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/float_test.go
+++ b/vm/float_test.go
@@ -22,18 +22,39 @@ func TestFloatClassSuperclass(t *testing.T) {
 	}
 }
 
-func TestFloatArithmeticOperation(t *testing.T) {
+func TestFloatArithmeticOperationWithFloat(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected interface{}
 	}{
-		{`'1.5'.to_f + '2'.to_f`, 3.5},
-		{`'22.5'.to_f - '10'.to_f`, 12.5},
-		{`'5.5'.to_f * '20'.to_f`, 110.0},
-		{`'4.5'.to_f % '2'.to_f`, 0.5},
-		{`'10.5'.to_f % '3.5'.to_f`, 0.0},
-		{`'25.5'.to_f / '5'.to_f`, 5.1},
-		{`'5.5'.to_f ** '2'.to_f`, 30.25},
+    {`'13.5'.to_f  +  '3.2'.to_f`,  16.7},
+    {`'13.5'.to_f  -  '3.2'.to_f`,  10.3},
+    {`'13.5'.to_f  *  '3.2'.to_f`,  43.2},
+    {`'13.5'.to_f  %  '3.75'.to_f`, 2.25},
+    {`'13.5'.to_f  /  '3.75'.to_f`, 3.6},
+    {`'16.0'.to_f  ** '3.5'.to_f`,  16384.0},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestFloatArithmeticOperationWithInteger(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+    {`'13.5'.to_f  +  3`, 16.5},
+    {`'13.5'.to_f  -  3`, 10.5},
+    {`'13.5'.to_f  *  3`, 40.5},
+    {`'13.5'.to_f  %  3`, 1.5},
+    {`'13.5'.to_f  /  3`, 4.5},
+    {`'13.5'.to_f  ** 3`, 2460.375},
 	}
 
 	for i, tt := range tests {
@@ -62,40 +83,57 @@ func TestFloatArithmeticOperationFail(t *testing.T) {
 	}
 }
 
-func TestFloatComparison(t *testing.T) {
+func TestFloatComparisonWithFloat(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected interface{}
 	}{
-		{`'25.5'.to_f > '5'.to_f`, true},
-		{`'4.5'.to_f > '6'.to_f`, false},
-		{`'-5.5'.to_f < '-4'.to_f`, true},
-		{`'100.5'.to_f < '81'.to_f`, false},
-		{`'25.5'.to_f > '5'.to_f`, true},
-		{`'4.5'.to_f > '6'.to_f`, false},
-		{`'4.5'.to_f >= '4'.to_f`, true},
-		{`'2.5'.to_f >= '5'.to_f`, false},
-		{`'-5.5'.to_f < '-4'.to_f`, true},
-		{`'100.5'.to_f < '81'.to_f`, false},
-		{`'10.5'.to_f <= '10.5'.to_f`, true},
-		{`'10.5'.to_f <= '0'.to_f`, false},
-		{`'10.5'.to_f <=> '0'.to_f`, 1},
-		{`'1.5'.to_f <=> '2'.to_f`, -1},
-		{`'4.5'.to_f <=> '4.5'.to_f`, 0},
-		{`'123.5'.to_f == '123.5'.to_f`, true},
-		{`'123.5'.to_f == '124'.to_f`, false},
-		{`'123.5'.to_f == "'123'.to_f"`, false},
-		{`'123.5'.to_f == (1..3)`, false},
-		{`'123.5'.to_f == { a: '1'.to_f, b: '2'.to_f }`, false},
-		{`'123.5'.to_f == ['1'.to_f, "String", true, 2..5]`, false},
-		{`'123.5'.to_f == Float`, false},
-		{`'123.5'.to_f != '123.5'.to_f`, false},
-		{`'123.5'.to_f != '124'.to_f`, true},
-		{`'123.5'.to_f != '123'.to_f`, true},
-		{`'123.5'.to_f != (1..3)`, true},
-		{`'123.5'.to_f != { a: '1'.to_f, b: '2'.to_f }`, true},
-		{`'123.5'.to_f != ['1'.to_f, "String", true, 2..5]`, true},
-		{`'123.5'.to_f != Float`, true},
+    {`'1.5'.to_f >   '2.5'.to_f`,  false},
+    {`'2.5'.to_f >   '1.5'.to_f`,  true},
+    {`'3.5'.to_f >   '3.5'.to_f`,  false},
+    {`'1.5'.to_f <   '2.5'.to_f`,  true},
+    {`'2.5'.to_f <   '1.5'.to_f`,  false},
+    {`'3.5'.to_f <   '3.5'.to_f`,  false},
+    {`'1.5'.to_f >=  '2.5'.to_f`,  false},
+    {`'2.5'.to_f >=  '1.5'.to_f`,  true},
+    {`'3.5'.to_f >=  '3.5'.to_f`,  true},
+    {`'1.5'.to_f <=  '2.5'.to_f`,  true},
+    {`'2.5'.to_f <=  '1.5'.to_f`,  false},
+    {`'3.5'.to_f <=  '3.5'.to_f`,  true},
+    {`'1.5'.to_f <=> '2.5'.to_f`,  -1},
+    {`'2.5'.to_f <=> '1.5'.to_f`,  1},
+    {`'3.5'.to_f <=> '3.5'.to_f`,  0},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestFloatComparisonWithInteger(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+    {`'1'.to_f >   2`,  false},
+    {`'2'.to_f >   1`,  true},
+    {`'3'.to_f >   3`,  false},
+    {`'1'.to_f <   2`,  true},
+    {`'2'.to_f <   1`,  false},
+    {`'3'.to_f <   3`,  false},
+    {`'1'.to_f >=  2`,  false},
+    {`'2'.to_f >=  1`,  true},
+    {`'3'.to_f >=  3`,  true},
+    {`'1'.to_f <=  2`,  true},
+    {`'2'.to_f <=  1`,  false},
+    {`'3'.to_f <=  3`,  true},
+    {`'1'.to_f <=> 2`,  -1},
+    {`'2'.to_f <=> 1`,  1},
+    {`'3'.to_f <=> 3`,  0},
 	}
 
 	for i, tt := range tests {
@@ -121,6 +159,38 @@ func TestFloatComparisonFail(t *testing.T) {
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestFloatEquality(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`'123.5'.to_f  ==  '123.5'.to_f`, true},
+		{`'123'.to_f    ==  123`,          true},
+		{`'123.5'.to_f  ==  '124'.to_f`,   false},
+		{`'123.5'.to_f  ==  "123.5"`,      false},
+		{`'123.5'.to_f  ==  (1..3)`,       false},
+		{`'123.5'.to_f  ==  { a: 1 }`,     false},
+		{`'123.5'.to_f  ==  [1]`,          false},
+		{`'123.5'.to_f  ==  Float`,        false},
+		{`'123.5'.to_f  !=  '123.5'.to_f`, false},
+		{`'123.5'.to_f  !=  123`,          true},
+		{`'123.5'.to_f  !=  '124'.to_f`,   true},
+		{`'123.5'.to_f  !=  "123.5"`,      true},
+		{`'123.5'.to_f  !=  (1..3)`,       true},
+		{`'123.5'.to_f  !=  { a: 1 }`,     true},
+		{`'123.5'.to_f  !=  [1]`,          true},
+		{`'123.5'.to_f  !=  Float`,        true},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -740,6 +740,11 @@ func (i *IntegerObject) Value() interface{} {
 	return i.value
 }
 
+// Numeric interface
+func (i *IntegerObject) floatValue() float64 {
+	return float64(i.value)
+}
+
 // toString returns the object's name as the string format
 func (i *IntegerObject) toString() string {
 	return strconv.Itoa(i.value)

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -61,26 +61,23 @@ func builtinIntegerClassMethods() []*BuiltinMethodObject {
 func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
-			// Returns the sum of self and another Integer.
+			// Returns the sum of self and another Numeric.
 			//
 			// ```Ruby
 			// 1 + 2 # => 3
 			// ```
-			// @return [Integer]
+			// @return [Numeric]
 			Name: "+",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						return err
+					intOperation := func(leftValue int, rightValue int) int {
+						return leftValue + rightValue
+					}
+					floatOperation := func(leftValue float64, rightValue float64) float64 {
+						return leftValue + rightValue
 					}
 
-					rightValue := right.value
-					return t.vm.initIntegerObject(leftValue + rightValue)
+					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation)
 				}
 			},
 		},
@@ -90,123 +87,107 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```Ruby
 			// 5 % 2 # => 1
 			// ```
-			// @return [Integer]
+			// @return [Numeric]
 			Name: "%",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						return err
+					intOperation := func(leftValue int, rightValue int) int {
+						return leftValue % rightValue
+					}
+					floatOperation := func(leftValue float64, rightValue float64) float64 {
+						return math.Mod(leftValue, rightValue)
 					}
 
-					rightValue := right.value
-					return t.vm.initIntegerObject(leftValue % rightValue)
+					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation)
 				}
 			},
 		},
 		{
-			// Returns the subtraction of another Integer from self.
+			// Returns the subtraction of another Numeric from self.
 			//
 			// ```Ruby
 			// 1 - 1 # => 0
 			// ```
-			// @return [Integer]
+			// @return [Numeric]
 			Name: "-",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						return err
+					intOperation := func(leftValue int, rightValue int) int {
+						return leftValue - rightValue
+					}
+					floatOperation := func(leftValue float64, rightValue float64) float64 {
+						return leftValue - rightValue
 					}
 
-					rightValue := right.value
-					return t.vm.initIntegerObject(leftValue - rightValue)
+					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation)
 				}
 			},
 		},
 		{
-			// Returns self multiplying another Integer.
+			// Returns self multiplying another Numeric.
 			//
 			// ```Ruby
 			// 2 * 10 # => 20
 			// ```
-			// @return [Integer]
+			// @return [Numeric]
 			Name: "*",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						return err
+					intOperation := func(leftValue int, rightValue int) int {
+						return leftValue * rightValue
+					}
+					floatOperation := func(leftValue float64, rightValue float64) float64 {
+						return leftValue * rightValue
 					}
 
-					rightValue := right.value
-					return t.vm.initIntegerObject(leftValue * rightValue)
+					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation)
 				}
 			},
 		},
 		{
-			// Returns self squaring another Integer.
+			// Returns self squaring another Numeric.
 			//
 			// ```Ruby
 			// 2 ** 8 # => 256
 			// ```
-			// @return [Integer]
+			// @return [Numeric]
 			Name: "**",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						return err
+					intOperation := func(leftValue int, rightValue int) int {
+						return int(math.Pow(float64(leftValue), float64(rightValue)))
+					}
+					floatOperation := func(leftValue float64, rightValue float64) float64 {
+						return math.Pow(leftValue, rightValue)
 					}
 
-					rightValue := right.value
-					result := math.Pow(float64(leftValue), float64(rightValue))
-					return t.vm.initIntegerObject(int(result))
+					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation)
 				}
 			},
 		},
 		{
-			// Returns self divided by another Integer.
+			// Returns self divided by another Numeric.
 			//
 			// ```Ruby
 			// 6 / 3 # => 2
 			// ```
-			// @return [Integer]
+			// @return [Numeric]
 			Name: "/",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						return err
+					intOperation := func(leftValue int, rightValue int) int {
+						return leftValue / rightValue
+					}
+					floatOperation := func(leftValue float64, rightValue float64) float64 {
+						return leftValue / rightValue
 					}
 
-					rightValue := right.value
-					return t.vm.initIntegerObject(leftValue / rightValue)
+					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation)
 				}
 			},
 		},
 		{
-			// Returns if self is larger than another Integer.
+			// Returns if self is larger than another Numeric.
 			//
 			// ```Ruby
 			// 10 > -1 # => true
@@ -216,27 +197,19 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			Name: ">",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						return err
+					intComparison := func(leftValue int, rightValue int) bool {
+						return leftValue > rightValue
+					}
+					floatComparison := func(leftValue float64, rightValue float64) bool {
+						return leftValue > rightValue
 					}
 
-					rightValue := right.value
-
-					if leftValue > rightValue {
-						return TRUE
-					}
-
-					return FALSE
+					return receiver.(*IntegerObject).numericComparison(t, args[0], intComparison, floatComparison)
 				}
 			},
 		},
 		{
-			// Returns if self is larger than or equals to another Integer.
+			// Returns if self is larger than or equals to another Numeric.
 			//
 			// ```Ruby
 			// 2 >= 1 # => true
@@ -246,27 +219,19 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			Name: ">=",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						return err
+					intComparison := func(leftValue int, rightValue int) bool {
+						return leftValue >= rightValue
+					}
+					floatComparison := func(leftValue float64, rightValue float64) bool {
+						return leftValue >= rightValue
 					}
 
-					rightValue := right.value
-
-					if leftValue >= rightValue {
-						return TRUE
-					}
-
-					return FALSE
+					return receiver.(*IntegerObject).numericComparison(t, args[0], intComparison, floatComparison)
 				}
 			},
 		},
 		{
-			// Returns if self is smaller than another Integer.
+			// Returns if self is smaller than another Numeric.
 			//
 			// ```Ruby
 			// 1 < 3 # => true
@@ -276,27 +241,19 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			Name: "<",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						return err
+					intComparison := func(leftValue int, rightValue int) bool {
+						return leftValue < rightValue
+					}
+					floatComparison := func(leftValue float64, rightValue float64) bool {
+						return leftValue < rightValue
 					}
 
-					rightValue := right.value
-
-					if leftValue < rightValue {
-						return TRUE
-					}
-
-					return FALSE
+					return receiver.(*IntegerObject).numericComparison(t, args[0], intComparison, floatComparison)
 				}
 			},
 		},
 		{
-			// Returns if self is smaller than or equals to another Integer.
+			// Returns if self is smaller than or equals to another Numeric.
 			//
 			// ```Ruby
 			// 1 <= 3 # => true
@@ -306,27 +263,19 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			Name: "<=",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						return err
+					intComparison := func(leftValue int, rightValue int) bool {
+						return leftValue <= rightValue
+					}
+					floatComparison := func(leftValue float64, rightValue float64) bool {
+						return leftValue <= rightValue
 					}
 
-					rightValue := right.value
-
-					if leftValue <= rightValue {
-						return TRUE
-					}
-
-					return FALSE
+					return receiver.(*IntegerObject).numericComparison(t, args[0], intComparison, floatComparison)
 				}
 			},
 		},
 		{
-			// Returns 1 if self is larger than the incoming Integer, -1 if smaller. Otherwise 0.
+			// Returns 1 if self is larger than the incoming Numeric, -1 if smaller. Otherwise 0.
 			//
 			// ```Ruby
 			// 1 <=> 3 # => -1
@@ -337,83 +286,76 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			Name: "<=>",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					rightObject := args[0]
 
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
+					switch rightObject.(type) {
+					case *IntegerObject:
+						leftValue := receiver.(*IntegerObject).value
+						rightValue := rightObject.(*IntegerObject).value
 
-					if !ok {
-						err := t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						return err
+						if leftValue < rightValue {
+							return t.vm.initIntegerObject(-1)
+						}
+						if leftValue > rightValue {
+							return t.vm.initIntegerObject(1)
+						}
+
+						return t.vm.initIntegerObject(0)
+					case *FloatObject:
+						leftValue := float64(receiver.(*IntegerObject).value)
+						rightValue := rightObject.(*FloatObject).value
+
+						if leftValue < rightValue {
+							return t.vm.initIntegerObject(-1)
+						}
+						if leftValue > rightValue {
+							return t.vm.initIntegerObject(1)
+						}
+
+						return t.vm.initIntegerObject(0)
+					default:
+						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", rightObject.Class().Name)
 					}
-
-					rightValue := right.value
-
-					if leftValue < rightValue {
-						return t.vm.initIntegerObject(-1)
-					}
-					if leftValue > rightValue {
-						return t.vm.initIntegerObject(1)
-					}
-
-					return t.vm.initIntegerObject(0)
 				}
 			},
 		},
 		{
-			// Returns if self is equal to another Integer.
+			// Returns if self is equal to an Object.
+			// If the Object is a Numeric, a comparison is performed, otherwise, the
+			// result is always false.
 			//
 			// ```Ruby
-			// 1 == 3 # => false
-			// 1 == 1 # => true
+			// 1 == 3   # => false
+			// 1 == 1   # => true
+			// 1 == '1' # => false
 			// ```
 			// @return [Boolean]
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					result := receiver.(*IntegerObject).equalityTest(args[0])
 
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						return FALSE
-					}
-
-					rightValue := right.value
-
-					if leftValue == rightValue {
-						return TRUE
-					}
-
-					return FALSE
+					return toBooleanObject(result)
 				}
 			},
 		},
 		{
-			// Returns if self is not equal to another Integer.
+			// Returns if self is not equal to an Object.
+			// If the Object is a Numeric, a comparison is performed, otherwise, the
+			// result is always true.
 			//
 			// ```Ruby
-			// 1 != 3 # => true
-			// 1 != 1 # => false
+			// 1 != 3   # => true
+			// 1 != 1   # => false
+			// 1 != '1' # => true
 			// ```
 			// @return [Boolean]
 			Name: "!=",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					result := !receiver.(*IntegerObject).equalityTest(args[0])
 
-					leftValue := receiver.(*IntegerObject).value
-					right, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						return TRUE
-					}
-
-					rightValue := right.value
-
-					if leftValue != rightValue {
-						return TRUE
-					}
-
-					return FALSE
+					return toBooleanObject(result)
 				}
 			},
 		},
@@ -743,6 +685,82 @@ func (i *IntegerObject) Value() interface{} {
 // Numeric interface
 func (i *IntegerObject) floatValue() float64 {
 	return float64(i.value)
+}
+
+// Apply the passed arithmetic operation, while performing type conversion.
+func (i *IntegerObject) arithmeticOperation(
+	t *thread,
+	rightObject Object,
+	intOperation func(leftValue int, rightValue int) int,
+	floatOperation func(leftValue float64, rightValue float64) float64,
+) Object {
+	switch rightObject.(type) {
+	case *IntegerObject:
+		leftValue := i.value
+		rightValue := rightObject.(*IntegerObject).value
+
+		result := intOperation(leftValue, rightValue)
+
+		return t.vm.initIntegerObject(result)
+	case *FloatObject:
+		leftValue := float64(i.value)
+		rightValue := rightObject.(*FloatObject).value
+
+		result := floatOperation(leftValue, rightValue)
+
+		return t.vm.initFloatObject(result)
+	default:
+		return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", rightObject.Class().Name)
+	}
+}
+
+// Apply an equality test, returning true if the objects are considered equal,
+// and false otherwise.
+// See comment on numericComparison().
+func (i *IntegerObject) equalityTest(rightObject Object) bool {
+	switch rightObject.(type) {
+	case *IntegerObject:
+		leftValue := i.value
+		rightValue := rightObject.(*IntegerObject).value
+
+		return leftValue == rightValue
+	case *FloatObject:
+		leftValue := i.floatValue()
+		rightValue := rightObject.(*FloatObject).value
+
+		return leftValue == rightValue
+	default:
+		return false
+	}
+}
+
+// Apply the passed numeric comparison, while performing type conversion.
+// 64-bit floats cover all the 32-bit integers, but since int is defined
+// as *at least* 32 bit, we use two separate functions for safety.
+func (i *IntegerObject) numericComparison(
+	t *thread,
+	rightObject Object,
+	intComparison func(leftValue int, rightValue int) bool,
+	floatComparison func(leftValue float64, rightValue float64) bool,
+) Object {
+	switch rightObject.(type) {
+	case *IntegerObject:
+		leftValue := i.value
+		rightValue := rightObject.(*IntegerObject).value
+
+		result := intComparison(leftValue, rightValue)
+
+		return toBooleanObject(result)
+	case *FloatObject:
+		leftValue := i.floatValue()
+		rightValue := rightObject.(*FloatObject).value
+
+		result := floatComparison(leftValue, rightValue)
+
+		return toBooleanObject(result)
+	default:
+		return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", rightObject.Class().Name)
+	}
 }
 
 // toString returns the object's name as the string format

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -440,6 +440,22 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 				}
 			},
 		},
+		// Returns the `Float` conversion of self.
+		//
+		// ```Ruby
+		// 100.to_f # => '100.0'.to_f
+		// ```
+		// @return [Float]
+		{
+			Name: "to_f",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					r := receiver.(*IntegerObject)
+					newFloat := t.vm.initFloatObject(float64(r.value))
+					return newFloat
+				}
+			},
+		},
 		{
 			// Returns self.
 			//

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -61,10 +61,10 @@ func TestIntegerArithmeticOperation(t *testing.T) {
 
 func TestIntegerArithmeticOperationFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`1 + "p"`, "TypeError: Expect argument to be Integer. got: String", 1},
-		{`1 - "m"`, "TypeError: Expect argument to be Integer. got: String", 1},
-		{`1 ** "p"`, "TypeError: Expect argument to be Integer. got: String", 1},
-		{`1 / "t"`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`1 + "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1 - "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1 ** "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1 / "t"`, "TypeError: Expect argument to be Numeric. got: String", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -123,11 +123,11 @@ func TestIntegerComparison(t *testing.T) {
 
 func TestIntegerComparisonFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`1 > "m"`, "TypeError: Expect argument to be Integer. got: String", 1},
-		{`1 >= "m"`, "TypeError: Expect argument to be Integer. got: String", 1},
-		{`1 < "m"`, "TypeError: Expect argument to be Integer. got: String", 1},
-		{`1 <= "m"`, "TypeError: Expect argument to be Integer. got: String", 1},
-		{`1 <=> "m"`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`1 > "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1 >= "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1 < "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1 <= "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1 <=> "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -66,6 +66,28 @@ func TestIntegerArithmeticOperationWithFloat(t *testing.T) {
 	}
 }
 
+func TestIntegerArithmeticOperationsPriority(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+    {`1 / 1 + 1`,         2},
+    {`0 / (1 + 1000)`,    0},
+    {`5 ** (3 * 2) + 21`, 15646},
+    {`(3 - 1) ** 4 / 2`,  8},
+    {`(25 / 5 + 5) * 3`,  30},
+    {`(25 / 5 + 5) * 2`,  20},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestIntegerArithmeticOperationFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`1 + "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -22,32 +22,39 @@ func TestIntegerClassSuperclass(t *testing.T) {
 	}
 }
 
-func TestIntegerArithmeticOperation(t *testing.T) {
+func TestIntegerArithmeticOperationWithInteger(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected interface{}
 	}{
-		{`1 + 2`, 3},
-		{`10 + 0`, 10},
-		{`22 - 10`, 12},
-		{`2 - 10`, -8},
-		{`5 * 20`, 100},
-		{`4 % 2`, 0},
-		{`10 % 3`, 1},
-		{`6 % 4`, 2},
-		{`25 / 5`, 5},
-		{`25 > 5`, true},
-		{`4 > 6`, false},
-		{`-5 < -4`, true},
-		{`100 < 81`, false},
-		{`5 ** 4`, 625},
-		{`25 / 5`, 5},
-		{`1 / 1 + 1`, 2},
-		{`0 / (1 + 1000)`, 0},
-		{`5 ** (3 * 2) + 21`, 15646},
-		{`(3 - 1) ** 4 / 2`, 8},
-		{`(25 / 5 + 5) * 3`, 30},
-		{`(25 / 5 + 5) * 2`, 20},
+		{`13  +  3`,  16},
+		{`13  -  3`,  10},
+		{`13  *  3`,  39},
+		{`13  %  3`,  1},
+		{`13  /  3`,  4},
+		{`13  ** 3`,  2197},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestIntegerArithmeticOperationWithFloat(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`13  +  '3.5'.to_f`,  16.5},
+		{`13  -  '3.5'.to_f`,  9.5},
+		{`13  *  '3.5'.to_f`,  45.5},
+		{`13  %  '3.5'.to_f`,  2.5},
+		{`13  /  '6.5'.to_f`,  2.0},
+		{`4   ** '3.5'.to_f`,  128.0},
 	}
 
 	for i, tt := range tests {
@@ -76,40 +83,57 @@ func TestIntegerArithmeticOperationFail(t *testing.T) {
 	}
 }
 
-func TestIntegerComparison(t *testing.T) {
+func TestIntegerComparisonWithInteger(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected interface{}
 	}{
-		{`25 > 5`, true},
-		{`4 > 6`, false},
-		{`-5 < -4`, true},
-		{`100 < 81`, false},
-		{`25 > 5`, true},
-		{`4 > 6`, false},
-		{`4 >= 4`, true},
-		{`2 >= 5`, false},
-		{`-5 < -4`, true},
-		{`100 < 81`, false},
-		{`10 <= 10`, true},
-		{`10 <= 0`, false},
-		{`10 <=> 0`, 1},
-		{`1 <=> 2`, -1},
-		{`4 <=> 4`, 0},
-		{`123 == 123`, true},
-		{`123 == 124`, false},
-		{`123 == "123"`, false},
-		{`123 == (1..3)`, false},
-		{`123 == { a: 1, b: 2 }`, false},
-		{`123 == [1, "String", true, 2..5]`, false},
-		{`123 == Integer`, false},
-		{`123 != 123`, false},
-		{`123 != 124`, true},
-		{`123 != "123"`, true},
-		{`123 != (1..3)`, true},
-		{`123 != { a: 1, b: 2 }`, true},
-		{`123 != [1, "String", true, 2..5]`, true},
-		{`123 != Integer`, true},
+		{`1 >   2`,  false},
+		{`2 >   1`,  true},
+		{`3 >   3`,  false},
+		{`1 <   2`,  true},
+		{`2 <   1`,  false},
+		{`3 <   3`,  false},
+		{`1 >=  2`,  false},
+		{`2 >=  1`,  true},
+		{`3 >=  3`,  true},
+		{`1 <=  2`,  true},
+		{`2 <=  1`,  false},
+		{`3 <=  3`,  true},
+		{`1 <=> 2`,  -1},
+		{`2 <=> 1`,  1},
+		{`3 <=> 3`,  0},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestIntegerComparisonWithFloat(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`1 >   '2'.to_f`,  false},
+		{`2 >   '1'.to_f`,  true},
+		{`3 >   '3'.to_f`,  false},
+		{`1 <   '2'.to_f`,  true},
+		{`2 <   '1'.to_f`,  false},
+		{`3 <   '3'.to_f`,  false},
+		{`1 >=  '2'.to_f`,  false},
+		{`2 >=  '1'.to_f`,  true},
+		{`3 >=  '3'.to_f`,  true},
+		{`1 <=  '2'.to_f`,  true},
+		{`2 <=  '1'.to_f`,  false},
+		{`3 <=  '3'.to_f`,  true},
+		{`1 <=> '2'.to_f`,  -1},
+		{`2 <=> '1'.to_f`,  1},
+		{`3 <=> '3'.to_f`,  0},
 	}
 
 	for i, tt := range tests {
@@ -135,6 +159,38 @@ func TestIntegerComparisonFail(t *testing.T) {
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
 		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestIntegerEquality(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`4  ==  4`,            true},
+		{`4  ==  '4'.to_f`,     true},
+		{`4  ==  '5'.to_f`,     false},
+		{`4  ==  '4'`,          false},
+		{`4  ==  (1..3)`,       false},
+		{`4  ==  { a: 1 }`,     false},
+		{`4  ==  [1]`,          false},
+		{`4  ==  Float`,        false},
+		{`4  !=  4`,            false},
+		{`4  !=  '4'.to_f`,     false},
+		{`4  !=  '5'.to_f`,     true},
+		{`4  !=  '4'`,          true},
+		{`4  !=  (1..3)`,       true},
+		{`4  !=  { a: 1 }`,     true},
+		{`4  !=  [1]`,          true},
+		{`4  !=  Float`,        true},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -145,6 +145,7 @@ func TestIntegerConversion(t *testing.T) {
 		expected interface{}
 	}{
 		{`100.to_i`, 100},
+		{`100.to_f`, 100.0},
 		{`100.to_s`, "100"},
 	}
 

--- a/vm/numeric.go
+++ b/vm/numeric.go
@@ -1,0 +1,8 @@
+package vm
+
+// Numeric currently represents a class that support some numeric conversions.
+// At this stage, it's not meant to be a Goby class in a strict sense, but only
+// a convenient interface.
+type Numeric interface {
+  floatValue() float64
+}

--- a/vm/string.go
+++ b/vm/string.go
@@ -1380,6 +1380,42 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			},
 		},
 		{
+			// Returns the result of converting self to Float.
+			// Unexpected characters will cause a 0.0 value, except trailing whitespace,
+			// which is ignored.
+			//
+			// ```ruby
+			// "123.5".to_f     # => 123.5
+			// ".5".to_f      	# => 0.5
+			// "  3.5".to_f     # => 3.5
+			// "3.5e2".to_f     # => 350
+			// "3.5ef".to_f     # => 0
+			// ```
+			//
+			// @return [Float]
+			Name: "to_f",
+			Fn: func(receiver Object) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+					str := receiver.(*StringObject).value
+
+					for i, char := range str {
+						if ! unicode.IsSpace(char) {
+							str = str[i:]
+							break
+						}
+					}
+
+					parsedStr, err := strconv.ParseFloat(str, 64)
+
+					if err != nil {
+						return t.vm.initFloatObject(0)
+					}
+
+					return t.vm.initFloatObject(parsedStr)
+				}
+			},
+		},
+		{
 			// Returns the result of converting self to Integer
 			//
 			// ```ruby

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -63,6 +63,11 @@ func TestStringConversion(t *testing.T) {
 		{`" \t123".to_i`, 123},
 		{`"123string123".to_i`, 123},
 		{`"string123".to_i`, 0},
+		{`"123.5".to_f`, 123.5},
+		{`".5".to_f`, 0.5},
+		{`"  123.5".to_f`, 123.5},
+		{`"3.5e2".to_f`, 350.0},
+		{`"3.5ef".to_f`, 0.0},
 		{`
 		  arr = "Goby".to_a
 		  arr[0]

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -191,6 +191,7 @@ func (vm *VM) initConstants() {
 	// Init builtin classes
 	builtinClasses := []*RClass{
 		vm.initIntegerClass(),
+		vm.initFloatClass(),
 		vm.initStringClass(),
 		vm.initBoolClass(),
 		vm.initNullClass(),

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -209,6 +209,24 @@ func testIntegerObject(t *testing.T, i int, obj Object, expected int) bool {
 	}
 }
 
+func testFloatObject(t *testing.T, i int, obj Object, expected float64) bool {
+	switch result := obj.(type) {
+	case *FloatObject:
+		if result.value != expected {
+			t.Errorf("At test case %d: object has wrong value. expect=%d, got=%d", i, expected, result.value)
+			return false
+		}
+
+		return true
+	case *Error:
+		t.Errorf("At test case %d: %s", i, result.Message)
+		return false
+	default:
+		t.Errorf("At test case %d: object is not Float. got=%T (%+v).", i, obj, obj)
+		return false
+	}
+}
+
 func testNullObject(t *testing.T, i int, obj Object) bool {
 	switch result := obj.(type) {
 	case *NullObject:
@@ -343,6 +361,8 @@ func checkExpected(t *testing.T, i int, evaluated Object, expected interface{}) 
 	switch expected := expected.(type) {
 	case int:
 		testIntegerObject(t, i, evaluated, expected)
+	case float64:
+		testFloatObject(t, i, evaluated, expected)
 	case string:
 		testStringObject(t, i, evaluated, expected)
 	case bool:


### PR DESCRIPTION
Backend implementation of the Float class, without the frontend (parsing). At this stage, Floats are instantiated via `String#to_f`.

Two related additions are made to the codebase:

- the `Numeric` interface, common to `Float` and `Integer`; currently it's only a lightweight, convenient, interface, not a full/visible Goby class
- the static method `toBooleanObject()`, which replaces the boilerplate for converting Go boolean values to a Goby boolean Object

This PR closes the backend side of #379.