### PR TITLE
Ignore trailing whitespace in `String#to_i`, instead of immediately exiting

### DIFF
--- a/vm/string.go
+++ b/vm/string.go
@@ -1383,8 +1383,9 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// Returns the result of converting self to Integer
 			//
 			// ```ruby
-			// "123".to_i # => 123
-			// "3d print".to_i # => 3
+			// "123".to_i       # => 123
+			// "3d print".to_i  # => 3
+			// "  321".to_i     # => 321
 			// "some text".to_i # => 0
 			// ```
 			//
@@ -1404,7 +1405,9 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					for _, char := range str {
 						if unicode.IsDigit(char) {
 							digits += string(char)
-						} else {
+						} else if unicode.IsSpace(char) && len(digits) == 0 {
+							// do nothing; allow trailing spaces
+					  } else {
 							break
 						}
 					}

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -60,6 +60,7 @@ func TestStringConversion(t *testing.T) {
 		{`'\'Maxwell\''.to_s`, "'Maxwell'"},
 		{`"123".to_i`, 123},
 		{`"string".to_i`, 0},
+		{`" \t123".to_i`, 123},
 		{`"123string123".to_i`, 123},
 		{`"string123".to_i`, 0},
 		{`


### PR DESCRIPTION
Example:

    `  123`.to_i #=> 123, instead of 0

This is the longer and more readable implementation. By reversing the condition, it's possible to save one branch.