### PR TITLE
Keyword argument support part 2

### DIFF
--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -106,8 +106,12 @@ func (g *Generator) compileCallExpression(is *InstructionSet, exp *ast.CallExpre
 				argSet.setArg(i, key.Value, OptionalKeywordArg)
 			}
 		case *ast.PrefixExpression:
-			ident := arg.Right.(*ast.Identifier)
-			argSet.setArg(i, ident.Value, SplatArg)
+			if arg.Operator == "*" {
+				ident, ok := arg.Right.(*ast.Identifier)
+				if ok {
+					argSet.setArg(i, ident.Value, SplatArg)
+				}
+			}
 		}
 
 		g.compileExpression(is, arg, scope, table)

--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -38,6 +38,8 @@ func (g *Generator) compileExpression(is *InstructionSet, exp ast.Expression, sc
 		is.define(NewHash, sourceLine, len(exp.Data)*2)
 	case *ast.SelfExpression:
 		is.define(PutSelf, sourceLine)
+	case *ast.PairExpression:
+		g.compileExpression(is, exp.Value, scope, table)
 	case *ast.PrefixExpression:
 		g.compilePrefixExpression(is, exp, scope, table)
 	case *ast.InfixExpression:

--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -51,6 +51,7 @@ type Instruction struct {
 	line       int
 	anchor     *anchor
 	sourceLine int
+	ArgSet     *ArgSet
 }
 
 // AnchorLine returns instruction anchor's line number if it has an anchor
@@ -142,7 +143,7 @@ func (is *InstructionSet) Type() string {
 	return is.isType
 }
 
-func (is *InstructionSet) define(action string, sourceLine int, params ...interface{}) {
+func (is *InstructionSet) define(action string, sourceLine int, params ...interface{}) *Instruction {
 	ps := []string{}
 	i := &Instruction{Action: action, Params: ps, line: is.count, sourceLine: sourceLine}
 	for _, param := range params {
@@ -162,6 +163,7 @@ func (is *InstructionSet) define(action string, sourceLine int, params ...interf
 
 	is.Instructions = append(is.Instructions, i)
 	is.count++
+	return i
 }
 
 func (is *InstructionSet) compile() string {

--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -78,6 +78,14 @@ func (i *Instruction) compile() string {
 		return fmt.Sprintf("%d %s %d\n", i.line, i.Action, i.anchor.line)
 	}
 	if len(i.Params) > 0 {
+		lastParam := i.Params[len(i.Params)-1]
+
+		// If the send action doesn't have a block (block info), we'll have a trailing space after join.
+		// So we need to remove that empty string element
+		if i.Action == Send && len(lastParam) == 0 {
+			return fmt.Sprintf("%d %s %s\n", i.line, i.Action, strings.Join(i.Params[:len(i.Params)-1], " "))
+		}
+
 		return fmt.Sprintf("%d %s %s\n", i.line, i.Action, strings.Join(i.Params, " "))
 	}
 

--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -112,6 +112,16 @@ func (as *ArgSet) Names() []string {
 	return as.names
 }
 
+func (as *ArgSet) FindIndex(name string) int {
+	for i, n := range as.names {
+		if n == name {
+			return i
+		}
+	}
+
+	return -1
+}
+
 // ArgTypes returns enums that represents each argument's type
 func (is *InstructionSet) ArgTypes() *ArgSet {
 	return is.argTypes

--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -122,6 +122,11 @@ func (as *ArgSet) FindIndex(name string) int {
 	return -1
 }
 
+func (as *ArgSet) setArg(index int, name string, argType int) {
+	as.names[index] = name
+	as.types[index] = argType
+}
+
 // ArgTypes returns enums that represents each argument's type
 func (is *InstructionSet) ArgTypes() *ArgSet {
 	return is.argTypes

--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -187,12 +187,11 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 			newIS.argTypes.names[i] = ident.Value
 			newIS.argTypes.types[i] = SplatArg
 		case *ast.PairExpression:
-
 			key := exp.Key.(*ast.Identifier)
+			index, depth := scope.localTable.setLCL(key.Value, scope.localTable.depth)
 
 			if exp.Value != nil {
 				g.compileExpression(newIS, exp.Value, scope, scope.localTable)
-				index, depth := scope.localTable.setLCL(key.Value, scope.localTable.depth)
 				newIS.define(SetLocal, exp.Line(), depth, index, 1)
 
 				newIS.argTypes.names[i] = key.Value

--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -166,8 +166,7 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 		case *ast.Identifier:
 			scope.localTable.setLCL(exp.Value, scope.localTable.depth)
 
-			newIS.argTypes.names[i] = exp.Value
-			newIS.argTypes.types[i] = NormalArg
+			newIS.argTypes.setArg(i, exp.Value, NormalArg)
 		case *ast.AssignExpression:
 			exp.Optioned = 1
 
@@ -175,8 +174,7 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 			varName := v.(*ast.Identifier)
 			g.compileAssignExpression(newIS, exp, scope, scope.localTable)
 
-			newIS.argTypes.names[i] = varName.Value
-			newIS.argTypes.types[i] = OptionedArg
+			newIS.argTypes.setArg(i, varName.Value, OptionedArg)
 		case *ast.PrefixExpression:
 			if exp.Operator != "*" {
 				continue
@@ -184,8 +182,7 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 			ident := exp.Right.(*ast.Identifier)
 			scope.localTable.setLCL(ident.Value, scope.localTable.depth)
 
-			newIS.argTypes.names[i] = ident.Value
-			newIS.argTypes.types[i] = SplatArg
+			newIS.argTypes.setArg(i, ident.Value, SplatArg)
 		case *ast.PairExpression:
 			key := exp.Key.(*ast.Identifier)
 			index, depth := scope.localTable.setLCL(key.Value, scope.localTable.depth)
@@ -193,12 +190,9 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 			if exp.Value != nil {
 				g.compileExpression(newIS, exp.Value, scope, scope.localTable)
 				newIS.define(SetLocal, exp.Line(), depth, index, 1)
-
-				newIS.argTypes.names[i] = key.Value
-				newIS.argTypes.types[i] = OptionalKeywordArg
+				newIS.argTypes.setArg(i, key.Value, OptionalKeywordArg)
 			} else {
-				newIS.argTypes.names[i] = key.Value
-				newIS.argTypes.types[i] = RequiredKeywordArg
+				newIS.argTypes.setArg(i, key.Value, RequiredKeywordArg)
 			}
 		}
 	}

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -317,5 +317,10 @@ func getArgName(exp ast.Expression) string {
 		return assignExp.Variables[0].TokenLiteral()
 	}
 
+	switch exp := exp.(type) {
+	case *ast.PairExpression:
+		return exp.Key.(*ast.Identifier).Value
+	}
+
 	return exp.TokenLiteral()
 }

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -31,7 +31,7 @@ type instructionSet struct {
 	name         string
 	instructions []*instruction
 	filename     filename
-	argTypes     *bytecode.ArgSet
+	paramTypes   *bytecode.ArgSet
 }
 
 func (is *instructionSet) define(line int, a *action, params ...interface{}) *instruction {

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -431,9 +431,14 @@ var builtinActions = map[operationType]*action{
 		name: bytecode.Send,
 		operation: func(t *thread, cf *callFrame, args ...interface{}) {
 			var method Object
+			var keywords []string
 
 			methodName := args[0].(string)
 			argCount := args[1].(int)
+
+			if len(args) > 3 {
+				keywords = strings.Split(args[3].(string), ":")
+			}
 
 			if arr, ok := t.stack.top().Target.(*ArrayObject); ok && arr.splat {
 				// Pop array
@@ -462,9 +467,9 @@ var builtinActions = map[operationType]*action{
 
 			switch m := method.(type) {
 			case *MethodObject:
-				t.evalMethodObject(receiver, m, receiverPr, argCount, blockFrame)
+				t.evalMethodObject(receiver, m, receiverPr, argCount, keywords, blockFrame)
 			case *BuiltinMethodObject:
-				t.evalBuiltinMethod(receiver, m, receiverPr, argCount, blockFrame)
+				t.evalBuiltinMethod(receiver, m, receiverPr, argCount, keywords, blockFrame)
 			case *Error:
 				t.returnError(errors.InternalError, m.toString())
 			}

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -24,6 +24,7 @@ type instruction struct {
 	Params     []interface{}
 	Line       int
 	sourceLine int
+	argSet     *bytecode.ArgSet
 }
 
 type instructionSet struct {
@@ -431,14 +432,10 @@ var builtinActions = map[operationType]*action{
 		name: bytecode.Send,
 		operation: func(t *thread, cf *callFrame, args ...interface{}) {
 			var method Object
-			var keywords []string
 
 			methodName := args[0].(string)
 			argCount := args[1].(int)
-
-			if len(args) > 3 {
-				keywords = strings.Split(args[3].(string), ":")
-			}
+			argSet := args[3].(*bytecode.ArgSet)
 
 			if arr, ok := t.stack.top().Target.(*ArrayObject); ok && arr.splat {
 				// Pop array
@@ -467,9 +464,9 @@ var builtinActions = map[operationType]*action{
 
 			switch m := method.(type) {
 			case *MethodObject:
-				t.evalMethodObject(receiver, m, receiverPr, argCount, keywords, blockFrame)
+				t.evalMethodObject(receiver, m, receiverPr, argCount, argSet, blockFrame)
 			case *BuiltinMethodObject:
-				t.evalBuiltinMethod(receiver, m, receiverPr, argCount, keywords, blockFrame)
+				t.evalBuiltinMethod(receiver, m, receiverPr, argCount, argSet, blockFrame)
 			case *Error:
 				t.returnError(errors.InternalError, m.toString())
 			}

--- a/vm/instruction_translator.go
+++ b/vm/instruction_translator.go
@@ -100,6 +100,11 @@ func (it *instructionTranslator) transferInstruction(is *instructionSet, i *byte
 		}
 
 		params = append(params, line)
+	case bytecode.Send:
+		for _, param := range i.Params {
+			params = append(params, it.parseParam(param))
+		}
+		params = append(params, i.ArgSet)
 	default:
 		for _, param := range i.Params {
 			params = append(params, it.parseParam(param))

--- a/vm/instruction_translator.go
+++ b/vm/instruction_translator.go
@@ -73,7 +73,7 @@ func (it *instructionTranslator) transferInstructionSet(iss []*instructionSet, s
 		it.transferInstruction(is, i)
 	}
 
-	is.argTypes = set.ArgTypes()
+	is.paramTypes = set.ArgTypes()
 
 	iss = append(iss, is)
 }

--- a/vm/method.go
+++ b/vm/method.go
@@ -42,12 +42,12 @@ func (m *MethodObject) Value() interface{} {
 	return m.toString()
 }
 
-func (m *MethodObject) argTypes() []int {
-	return m.instructionSet.argTypes.Types()
+func (m *MethodObject) paramTypes() []int {
+	return m.instructionSet.paramTypes.Types()
 }
 
 func (m *MethodObject) isSplatArgIncluded() bool {
-	for _, argType := range m.argTypes() {
+	for _, argType := range m.paramTypes() {
 		if argType == bytecode.SplatArg {
 			return true
 		}
@@ -57,7 +57,7 @@ func (m *MethodObject) isSplatArgIncluded() bool {
 }
 
 func (m *MethodObject) isKeywordArgIncluded() bool {
-	for _, argType := range m.argTypes() {
+	for _, argType := range m.paramTypes() {
 		if argType == bytecode.OptionalKeywordArg || argType == bytecode.RequiredKeywordArg {
 			return true
 		}

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -274,10 +274,29 @@ func TestDefStatementWithKeywordArgument(t *testing.T) {
 
 		foo(b: 20, a: 10, 40, 100)
 		`, 50},
-		// We should forbidden this
-		// ```ruby
-		// foo(b: 20, 40, a: 10, 100)
-		// ```
+		//{`
+		//def foo(bar, foo = 100, a:, b:)
+		//  a - b + foo - bar
+		//end
+		//
+		//foo(b: 20, a: 10, 40)
+		//`, 50},
+
+		// Add splat arguments
+		{`
+		def foo(bar, foo, a:, b:, *args)
+		  a - b + foo - bar + *args[1]
+		end
+
+		foo(b: 20, a: 10, 40, 100, "foo", 50)
+		`, 100},
+		{`
+		def foo(bar, foo, a:, b:, *args)
+		  a - b + foo - bar + *args[1]
+		end
+
+		foo(b: 20, a: 10, 40, 100, "foo", 50)
+		`, 100},
 	}
 
 	for i, tt := range tests {

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -115,6 +115,23 @@ func TestDefStatement(t *testing.T) {
 
 		a.foo
 		`, 10},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestDefStatementWithSplatArgument(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+
 		{`
 		def foo(a, *b)
 		  b.each do |i|
@@ -156,20 +173,111 @@ func TestDefStatement(t *testing.T) {
 
 		foo(10, 20, 30)
 		`, 60},
-		//{`
-		//def foo(a:20)
-		//  a
-		//end
-		//
-		//foo(a:10)
-		//`, 10},
-		//{`
-		//def foo(a:20)
-		//  a
-		//end
-		//
-		//foo
-		//`, 20},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestDefStatementWithKeywordArgument(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`
+		def foo(a:)
+		  a
+		end
+
+		foo(a:10)
+		`, 10},
+		{`
+		def foo(a: 20)
+		  a
+		end
+
+		foo
+		`, 20},
+		{`
+		def foo(a: 20)
+		  a
+		end
+
+		foo(a: 10)
+		`, 10},
+		{`
+		def foo(a:, b:)
+		  a - b
+		end
+
+		foo(a:10, b: 20)
+		`, -10},
+		{`
+		def foo(a: 10, b:)
+		  a - b
+		end
+
+		foo(b: 20)
+		`, -10},
+		{`
+		def foo(a:, b: 20)
+		  a - b
+		end
+
+		foo(a: 10)
+		`, -10},
+		{`
+		def foo(a:, b:)
+		  a - b
+		end
+
+		foo(b:10, a: 20)
+		`, 10},
+		{`
+		def foo(foo, a:, b:)
+		  a - b + foo
+		end
+
+		foo(100, a:10, b: 20)
+		`, 90},
+		{`
+		def foo(foo, a: 10, b:)
+		  a - b + foo
+		end
+
+		foo(100, b: 20)
+		`, 90},
+		// Two normal arguments plus two keyword arguments
+		{`
+		def foo(bar, foo, a:, b:)
+		  a - b + foo - bar
+		end
+
+		foo(40, 100, a:10, b: 20)
+		`, 50},
+		{`
+		def foo(bar, foo, a:, b:)
+		  a - b + foo - bar
+		end
+
+		foo(40, 100, b: 20, a: 10)
+		`, 50},
+		{`
+		def foo(bar, foo, a:, b:)
+		  a - b + foo - bar
+		end
+
+		foo(b: 20, a: 10, 40, 100)
+		`, 50},
+		// We should forbidden this
+		// ```ruby
+		// foo(b: 20, 40, a: 10, 100)
+		// ```
 	}
 
 	for i, tt := range tests {

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -274,13 +274,13 @@ func TestDefStatementWithKeywordArgument(t *testing.T) {
 
 		foo(b: 20, a: 10, 40, 100)
 		`, 50},
-		//{`
-		//def foo(bar, foo = 100, a:, b:)
-		//  a - b + foo - bar
-		//end
-		//
-		//foo(b: 20, a: 10, 40)
-		//`, 50},
+		{`
+		def foo(bar, foo = 100, a:, b:)
+		  a - b + foo - bar
+		end
+
+		foo(b: 20, a: 10, 40)
+		`, 50},
 
 		// Add splat arguments
 		{`

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -88,12 +88,11 @@ func (t *thread) retrieveBlock(cf *callFrame, args []interface{}) (blockFrame *c
 	var blockName string
 	var hasBlock bool
 
-	if len(args) > 2 {
+	blockFlag := args[2].(string)
+
+	if len(blockFlag) != 0 {
 		hasBlock = true
-		blockFlag := args[2].(string)
 		blockName = strings.Split(blockFlag, ":")[1]
-	} else {
-		hasBlock = false
 	}
 
 	if hasBlock {


### PR DESCRIPTION
This PR finishes the keyword argument's compilation.

And the most important change is the way we passing parameters/arguments information between compiler and VM. We use a new data structure called `ArgSet`. It records parameters/arguments name and their type (argument type) in order.

This is a little like a cheating, because this couples the compiler and the VM very heavily. Also, we can't properly do integration tests on compiler, because it's hard to print out this data structure.

But all these things will be fixed in the future PRs, at least we have keyword argument support now 😄 