### PR TITLE
Fix integer parsing panic

### DIFF
--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -185,8 +185,9 @@ func (p *Parser) parseIntegerLiteral() ast.Expression {
 
 	value, err := strconv.ParseInt(lit.TokenLiteral(), 0, 64)
 	if err != nil {
-		msg := fmt.Sprintf("could not parse %q as integer", lit.TokenLiteral())
-		panic(msg)
+		msg := fmt.Sprintf("could not parse %q as integer. Line: %d", lit.TokenLiteral(), p.curToken.Line)
+		p.error = &Error{Message: msg, errType: SyntaxError}
+		return nil
 	}
 
 	lit.Value = int(value)

--- a/compiler/parser/expression_parsing_test.go
+++ b/compiler/parser/expression_parsing_test.go
@@ -314,6 +314,22 @@ func TestIntegerLiteralExpression(t *testing.T) {
 	testIntegerLiteral(t, literal, 5)
 }
 
+func TestIntegerLiteralExpressionFail(t *testing.T) {
+	input := `9223372036854775808;`
+
+	l := lexer.New(input)
+	p := New(l)
+	_, err := p.ParseProgram()
+
+	if err == nil {
+		t.Fatal("Expected Integer literal parsing error")
+	} else if p.error.Message != "could not parse \"9223372036854775808\" as integer. Line: 0" {
+		t.Fatalf("Unexpected parsing error: %s", p.error.Message)
+	}
+
+	// "could not parse 9223372036854775808 as integer. Line: 1"
+}
+
 func TestStringLiteralExpression(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
Return an error instead of panic, when an Integer parsing error occurs.

Such error can happen under regular (non-programmtic error) circumstances, when the user inputs a too big integer.

Fixes #448.