### PR TITLE
Refactor parse block to give tokens telling where to stop

### DIFF
--- a/compiler/parser/flow_control_parsing.go
+++ b/compiler/parser/flow_control_parsing.go
@@ -33,7 +33,7 @@ func (p *Parser) parseCaseExpression() ast.Expression {
 	ie.Conditionals = p.parseCaseConditionals()
 
 	if p.curTokenIs(token.Else) {
-		ie.Alternative = p.parseBlockStatement()
+		ie.Alternative = p.parseBlockStatement(token.End)
 		ie.Alternative.KeepLastValue()
 	}
 
@@ -60,7 +60,7 @@ func (p *Parser) parseCaseConditional(base ast.Expression) *ast.ConditionalExpre
 	p.nextToken()
 
 	ce.Condition = p.parseCaseCondition(base)
-	ce.Consequence = p.parseBlockStatement()
+	ce.Consequence = p.parseBlockStatement(token.When, token.Else, token.End)
 	ce.Consequence.KeepLastValue()
 
 	return ce
@@ -93,7 +93,7 @@ func (p *Parser) parseIfExpression() ast.Expression {
 
 	// curToken is now ELSE or RBRACE
 	if p.curTokenIs(token.Else) {
-		ie.Alternative = p.parseBlockStatement()
+		ie.Alternative = p.parseBlockStatement(token.End)
 		ie.Alternative.KeepLastValue()
 	}
 
@@ -116,8 +116,7 @@ func (p *Parser) parseConditionalExpression() *ast.ConditionalExpression {
 	ce := &ast.ConditionalExpression{BaseNode: &ast.BaseNode{Token: p.curToken}}
 	p.nextToken()
 	ce.Condition = p.parseExpression(NORMAL)
-
-	ce.Consequence = p.parseBlockStatement()
+	ce.Consequence = p.parseBlockStatement(token.ElsIf, token.Else, token.End)
 	ce.Consequence.KeepLastValue()
 
 	return ce

--- a/compiler/parser/method_call_parsing.go
+++ b/compiler/parser/method_call_parsing.go
@@ -141,6 +141,6 @@ func (p *Parser) parseBlockArgument(exp *ast.CallExpression) {
 		exp.BlockArguments = params
 	}
 
-	exp.Block = p.parseBlockStatement()
+	exp.Block = p.parseBlockStatement(token.End)
 	exp.Block.KeepLastValue()
 }

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -286,11 +286,11 @@ func (p *Parser) parseBlockStatement(endTokens ...token.Type) *ast.BlockStatemen
 		p.nextToken()
 	}
 
-OuterLoop:
+ParseBlockLoop:
 	for {
 		for _, t := range endTokens {
 			if p.curTokenIs(t) {
-				break OuterLoop
+				break ParseBlockLoop
 			}
 		}
 

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -98,7 +98,7 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 	}
 
 	stmt.Parameters = params
-	stmt.BlockStatement = p.parseBlockStatement()
+	stmt.BlockStatement = p.parseBlockStatement(token.End)
 	stmt.BlockStatement.KeepLastValue()
 
 	return stmt
@@ -227,7 +227,7 @@ func (p *Parser) parseClassStatement() *ast.ClassStatement {
 		}
 	}
 
-	stmt.Body = p.parseBlockStatement()
+	stmt.Body = p.parseBlockStatement(token.End)
 
 	return stmt
 }
@@ -240,7 +240,7 @@ func (p *Parser) parseModuleStatement() *ast.ModuleStatement {
 	}
 
 	stmt.Name = &ast.Constant{BaseNode: &ast.BaseNode{Token: p.curToken}, Value: p.curToken.Literal}
-	stmt.Body = p.parseBlockStatement()
+	stmt.Body = p.parseBlockStatement(token.End)
 
 	return stmt
 }
@@ -274,7 +274,7 @@ func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 	return stmt
 }
 
-func (p *Parser) parseBlockStatement() *ast.BlockStatement {
+func (p *Parser) parseBlockStatement(endTokens ...token.Type) *ast.BlockStatement {
 
 	// curToken is '{'
 	bs := &ast.BlockStatement{BaseNode: &ast.BaseNode{Token: p.curToken}}
@@ -286,7 +286,13 @@ func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 		p.nextToken()
 	}
 
-	for !p.curTokenIs(token.End) && !p.curTokenIs(token.Else) && !p.curTokenIs(token.ElsIf) && !p.curTokenIs(token.When) {
+OuterLoop:
+	for {
+		for _, t := range endTokens {
+			if p.curTokenIs(t) {
+				break OuterLoop
+			}
+		}
 
 		if p.curTokenIs(token.EOF) {
 			p.error = &Error{Message: "Unexpected EOF", errType: EndOfFileError}
@@ -324,7 +330,7 @@ func (p *Parser) parseWhileStatement() *ast.WhileStatement {
 		p.nextToken()
 	}
 
-	ws.Body = p.parseBlockStatement()
+	ws.Body = p.parseBlockStatement(token.End)
 
 	return ws
 }


### PR DESCRIPTION
I refactored parseBlockStatement to give end tokens as an argument.  

For example, ` if statement` has to stop parsing block when the parser encounters `elsif`, `else`, `end`. On the other hand, `def statement` has to stop parsing block statement only if the parser encounters `end` like so.

Thank you!