### PR TITLE
Refactor thread

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -22,7 +22,7 @@ func builtinArrayClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
@@ -48,7 +48,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a[-7] # => nil
 			// ```
 			Name: "[]",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					return arr.index(t, args)
@@ -65,7 +65,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a * ',' # => "1,2,3"
 			// ```
 			Name: "*",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 arguments. got=%d", len(args))
@@ -91,7 +91,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// b + [3, 4]  # => [1, 2, 4, 4]
 			// ```
 			Name: "+",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 arguments. got=%d", len(args))
@@ -127,7 +127,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a[-2] = 5  # => [10, nil, 5, 20]
 			// ```
 			Name: "[]=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					// First arg is index
@@ -198,7 +198,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// end            # => false
 			// ```
 			Name: "any?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 
@@ -240,7 +240,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a.at(-4) # => nil
 			// ```
 			Name: "at",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					return arr.index(t, args)
@@ -256,7 +256,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a       # => []
 			// ```
 			Name: "clear",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
@@ -278,7 +278,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a # => [1, 2, 3, 4, 5, 6]
 			// ```
 			Name: "concat",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 
@@ -311,7 +311,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// # => 4
 			// ```
 			Name: "count",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					var count int
@@ -381,7 +381,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a       # => ["a"]
 			// ```
 			Name: "delete_at",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
@@ -424,7 +424,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Object]
 			Name: "dig",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) == 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1+ arguments, got 0")
@@ -451,7 +451,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// # => "cc"
 			// ```
 			Name: "each",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
@@ -477,7 +477,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "each_index",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
@@ -510,7 +510,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "empty?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 0 {
@@ -530,7 +530,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 		{
 			// Returns the first element of the array.
 			Name: "first",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) > 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0..1 argument. got=%d", len(args))
@@ -575,7 +575,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Array]
 			Name: "flatten",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 
@@ -600,7 +600,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param separator [String]
 			// @return [String]
 			Name: "join",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 
@@ -631,7 +631,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 		{
 			// Returns the last element of the array.
 			Name: "last",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) > 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0..1 argument. got=%d", len(args))
@@ -669,7 +669,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "length",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 0 {
@@ -693,7 +693,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// # => ["aa", "bb", "cc"]
 			// ```
 			Name: "map",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					var elements = make([]Object, len(arr.Elements))
@@ -725,7 +725,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a     # => [1, 2]
 			// ```
 			Name: "pop",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 0 {
@@ -745,7 +745,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a.push(4) # => [1, 2, 3, 4]
 			// ```
 			Name: "push",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					arr := receiver.(*ArrayObject)
@@ -771,7 +771,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// # => 20
 			// ```
 			Name: "reduce",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					if blockFrame == nil {
@@ -813,7 +813,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a.reverse # => [7, 2, 1]
 			// ```
 			Name: "reverse",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 arguments. got=%d", len(args))
@@ -839,7 +839,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// # => "aa"
 			// ```
 			Name: "reverse_each",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
@@ -878,7 +878,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a.rotate(3) # => ["d", "a", "b", "c"]
 			// ```
 			Name: "rotate",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) > 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0..1 argument. got=%d", len(args))
@@ -919,7 +919,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// # => [3, 4, 5]
 			// ```
 			Name: "select",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					var elements []Object
@@ -953,7 +953,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a       # => [2, 3]
 			// ```
 			Name: "shift",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
@@ -973,7 +973,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a            # => [0, 1, 2]
 			// ```
 			Name: "unshift",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					return arr.unshift(args)
@@ -990,7 +990,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// a.values_at()      # => []
 			// ```
 			Name: "values_at",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					var elements = make([]Object, len(args))

--- a/vm/array.go
+++ b/vm/array.go
@@ -23,7 +23,7 @@ func builtinArrayClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
@@ -49,7 +49,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "[]",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					return arr.index(t, args)
 				}
@@ -66,7 +66,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "*",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 arguments. got=%d", len(args))
 					}
@@ -92,7 +92,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "+",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 arguments. got=%d", len(args))
 					}
@@ -128,7 +128,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "[]=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					// First arg is index
 					// Second arg is assigned value
@@ -199,7 +199,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "any?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 
 					if blockFrame == nil {
@@ -241,7 +241,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "at",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					return arr.index(t, args)
 				}
@@ -257,7 +257,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "clear",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}
@@ -279,7 +279,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "concat",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 
 					for _, arg := range args {
@@ -312,7 +312,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "count",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					var count int
 
@@ -382,7 +382,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "delete_at",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
 					}
@@ -425,7 +425,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "dig",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) == 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1+ arguments, got 0")
 					}
@@ -452,7 +452,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "each",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}
@@ -478,7 +478,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "each_index",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}
@@ -511,7 +511,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "empty?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
@@ -531,7 +531,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// Returns the first element of the array.
 			Name: "first",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) > 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0..1 argument. got=%d", len(args))
 					}
@@ -576,7 +576,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "flatten",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 
 					if len(args) != 0 {
@@ -601,7 +601,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "join",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 
 					var sep string
@@ -632,7 +632,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// Returns the last element of the array.
 			Name: "last",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) > 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0..1 argument. got=%d", len(args))
 					}
@@ -670,7 +670,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "length",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
@@ -694,7 +694,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "map",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					var elements = make([]Object, len(arr.Elements))
 
@@ -726,7 +726,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "pop",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
@@ -746,7 +746,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "push",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					arr := receiver.(*ArrayObject)
 					return arr.push(args)
@@ -772,7 +772,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "reduce",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					if blockFrame == nil {
 						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
@@ -814,7 +814,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "reverse",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 arguments. got=%d", len(args))
 					}
@@ -840,7 +840,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "reverse_each",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}
@@ -879,7 +879,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "rotate",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) > 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0..1 argument. got=%d", len(args))
 					}
@@ -920,7 +920,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "select",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					var elements []Object
 
@@ -954,7 +954,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "shift",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}
@@ -974,7 +974,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "unshift",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					return arr.unshift(args)
 				}
@@ -991,7 +991,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "values_at",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					var elements = make([]Object, len(args))
 

--- a/vm/array.go
+++ b/vm/array.go
@@ -24,7 +24,7 @@ func builtinArrayClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					return t.unsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
 		},

--- a/vm/array.go
+++ b/vm/array.go
@@ -24,7 +24,7 @@ func builtinArrayClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.initUnsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError(instruction, "#new", receiver)
 				}
 			},
 		},
@@ -51,7 +51,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
-					return arr.index(t, args)
+					return arr.index(t, args, instruction)
 				}
 			},
 		},
@@ -68,7 +68,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 arguments. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 arguments. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -76,7 +76,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					copiesNumber, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
 					}
 
 					return arr.concatenateCopies(t, copiesNumber)
@@ -94,14 +94,14 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 arguments. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 arguments. got=%d", len(args))
 					}
 
 					otherArrayArg := args[0]
 					otherArray, ok := otherArrayArg.(*ArrayObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.ArrayClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.ArrayClass, args[0].Class().Name)
 					}
 
 					selfArray := receiver.(*ArrayObject)
@@ -133,7 +133,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					// First arg is index
 					// Second arg is assigned value
 					if len(args) != 2 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 2 arguments. got=%d", len(args))
 					}
 
 					i := args[0]
@@ -141,7 +141,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					indexValue := index.value
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -149,7 +149,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					// Negative index value condition
 					if indexValue < 0 {
 						if len(arr.Elements) < -indexValue {
-							return t.vm.initErrorObject(errors.ArgumentError, "Index is too small for array. got=%s", i.Class().Name)
+							return t.vm.initErrorObject(errors.ArgumentError, instruction, "Index is too small for array. got=%s", i.Class().Name)
 						}
 						arr.Elements[len(arr.Elements)+indexValue] = args[1]
 						return arr.Elements[len(arr.Elements)+indexValue]
@@ -203,7 +203,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					arr := receiver.(*ArrayObject)
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					if len(arr.Elements) == 0 {
@@ -243,7 +243,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
-					return arr.index(t, args)
+					return arr.index(t, args, instruction)
 				}
 			},
 		},
@@ -259,7 +259,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -286,7 +286,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 						addAr, ok := arg.(*ArrayObject)
 
 						if !ok {
-							return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.ArrayClass, arg.Class().Name)
+							return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.ArrayClass, arg.Class().Name)
 						}
 
 						for _, el := range addAr.Elements {
@@ -317,7 +317,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					var count int
 
 					if len(args) > 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument, got=%v", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument, got=%v", len(args))
 					}
 
 					if blockFrame != nil {
@@ -384,14 +384,14 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%d", len(args))
 					}
 
 					i := args[0]
 					index, ok := i.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -427,11 +427,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) == 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1+ arguments, got 0")
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expected 1+ arguments, got 0")
 					}
 
 					array := receiver.(*ArrayObject)
-					value := array.dig(t, args)
+					value := array.dig(t, args, instruction)
 
 					return value
 				}
@@ -454,11 +454,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -480,11 +480,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -514,7 +514,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -533,7 +533,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) > 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0..1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0..1 argument. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -550,11 +550,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					arg, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
 					}
 
 					if arg.value < 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect argument to be positive value. got=%d", arg.value)
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect argument to be positive value. got=%d", arg.value)
 					}
 
 					if arrLength > arg.value {
@@ -580,7 +580,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					arr := receiver.(*ArrayObject)
 
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					newElements := arr.flatten()
@@ -611,12 +611,12 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 						arg, ok := args[0].(*StringObject)
 
 						if !ok {
-							return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+							return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 						}
 
 						sep = arg.value
 					} else {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 or 1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 or 1 argument. got=%d", len(args))
 					}
 
 					elements := []string{}
@@ -634,7 +634,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) > 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0..1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0..1 argument. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -647,11 +647,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					arg, ok := args[0].(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
 					}
 
 					if arg.value < 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect argument to be positive value. got=%d", arg.value)
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect argument to be positive value. got=%d", arg.value)
 					}
 
 					if arrLength > arg.value {
@@ -673,7 +673,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -699,7 +699,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					var elements = make([]Object, len(arr.Elements))
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					// If it's an empty array, pop the block's call frame
@@ -729,7 +729,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -775,7 +775,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arr := receiver.(*ArrayObject)
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					// If it's an empty array, pop the block's call frame
@@ -792,7 +792,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 						prev = args[0]
 						start = 0
 					} else {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 or 1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 or 1 argument. got=%d", len(args))
 					}
 
 					for i := start; i < len(arr.Elements); i++ {
@@ -816,7 +816,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 arguments. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 arguments. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -842,11 +842,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -881,7 +881,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) > 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0..1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0..1 argument. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -892,7 +892,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					if len(args) != 0 {
 						arg, ok := args[0].(*IntegerObject)
 						if !ok {
-							return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+							return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
 						}
 						rotate = arg.value
 					}
@@ -925,7 +925,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 					var elements []Object
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					// If it's an empty array, pop the block's call frame
@@ -956,7 +956,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					arr := receiver.(*ArrayObject)
@@ -999,7 +999,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 						index, ok := arg.(*IntegerObject)
 
 						if !ok {
-							return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, arg.Class().Name)
+							return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, arg.Class().Name)
 						}
 
 						if index.value >= len(arr.Elements) {
@@ -1095,12 +1095,12 @@ func (a *ArrayObject) concatenateCopies(t *thread, n *IntegerObject) Object {
 }
 
 // recursive indexed access - see ArrayObject#dig documentation.
-func (a *ArrayObject) dig(t *thread, keys []Object) Object {
+func (a *ArrayObject) dig(t *thread, keys []Object, instruction *instruction) Object {
 	currentKey := keys[0]
 	intCurrentKey, ok := currentKey.(*IntegerObject)
 
 	if !ok {
-		return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, currentKey.Class().Name)
+		return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, currentKey.Class().Name)
 	}
 
 	normalizedIndex := a.normalizeIndex(intCurrentKey)
@@ -1119,23 +1119,23 @@ func (a *ArrayObject) dig(t *thread, keys []Object) Object {
 	diggableCurrentValue, ok := currentValue.(Diggable)
 
 	if !ok {
-		return t.vm.initErrorObject(errors.TypeError, "Expect target to be Diggable, got %s", currentValue.Class().Name)
+		return t.vm.initErrorObject(errors.TypeError, instruction, "Expect target to be Diggable, got %s", currentValue.Class().Name)
 	}
 
-	return diggableCurrentValue.dig(t, nextKeys)
+	return diggableCurrentValue.dig(t, nextKeys, instruction)
 }
 
 // Retrieves an object in an array using Integer index; common to `[]` and `at()`.
-func (a *ArrayObject) index(t *thread, args []Object) Object {
+func (a *ArrayObject) index(t *thread, args []Object, instruction *instruction) Object {
 	if len(args) != 1 {
-		return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 arguments. got=%d", len(args))
+		return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 arguments. got=%d", len(args))
 	}
 
 	i := args[0]
 	index, ok := i.(*IntegerObject)
 
 	if !ok {
-		return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+		return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
 	}
 
 	normalizedIndex := a.normalizeIndex(index)

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -113,15 +113,15 @@ func TestArrayDigMethod(t *testing.T) {
 
 func TestArrayDigMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`[1, 2].dig`, "ArgumentError: Expected 1+ arguments, got 0", 1},
-		{`[1, 2].dig(0, 1)`, "TypeError: Expect target to be Diggable, got Integer", 1},
+		{`[1, 2].dig`, "ArgumentError: Expected 1+ arguments, got 0", 1, 1},
+		{`[1, 2].dig(0, 1)`, "TypeError: Expect target to be Diggable, got Integer", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -240,14 +240,14 @@ func TestArrayStarOperator(t *testing.T) {
 
 func TestArrayStarOperatorFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`[1, 2] * nil`, "TypeError: Expect argument to be Integer. got: Null", 1},
+		{`[1, 2] * nil`, "TypeError: Expect argument to be Integer. got: Null", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -284,14 +284,14 @@ func TestArrayPlusOperator(t *testing.T) {
 
 func TestArrayPlusOperatorFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`[1, 2] + true`, "TypeError: Expect argument to be Array. got: Boolean", 1},
+		{`[1, 2] + true`, "TypeError: Expect argument to be Array. got: Boolean", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -339,14 +339,14 @@ func TestArrayAnyMethod(t *testing.T) {
 
 func TestArrayAnyMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`[].any?`, "InternalError: Can't yield without a block", 1},
+		{`[].any?`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -401,17 +401,17 @@ func TestArrayAtMethod(t *testing.T) {
 
 func TestArrayAtMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`[1, 2, 3].at`, "ArgumentError: Expect 1 arguments. got=0", 1},
-		{`[1, 2, 3].at(2, 3)`, "ArgumentError: Expect 1 arguments. got=2", 1},
-		{`[1, 2, 3].at(true)`, "TypeError: Expect argument to be Integer. got: Boolean", 1},
-		{`[1, 2, 3].at(1..3)`, "TypeError: Expect argument to be Integer. got: Range", 1},
+		{`[1, 2, 3].at`, "ArgumentError: Expect 1 arguments. got=0", 1, 1},
+		{`[1, 2, 3].at(2, 3)`, "ArgumentError: Expect 1 arguments. got=2", 1, 1},
+		{`[1, 2, 3].at(true)`, "TypeError: Expect argument to be Integer. got: Boolean", 1, 1},
+		{`[1, 2, 3].at(1..3)`, "TypeError: Expect argument to be Integer. got: Range", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -442,15 +442,15 @@ func TestArrayClearMethod(t *testing.T) {
 
 func TestArrayClearMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`['Maxwell', 'Alexius'].clear(123)`, "ArgumentError: Expect 0 argument. got=1", 1},
-		{`['Taipei', 101].clear(1, 0, 1)`, "ArgumentError: Expect 0 argument. got=3", 1},
+		{`['Maxwell', 'Alexius'].clear(123)`, "ArgumentError: Expect 0 argument. got=1", 1, 1},
+		{`['Taipei', 101].clear(1, 0, 1)`, "ArgumentError: Expect 0 argument. got=3", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -487,17 +487,17 @@ func TestArrayConcatMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`a = [1, 2]
 		a.concat(3)
-		`, "TypeError: Expect argument to be Array. got: Integer", 2},
+		`, "TypeError: Expect argument to be Array. got: Integer", 2, 1},
 		{`a = []
 		a.concat("a")
-		`, "TypeError: Expect argument to be Array. got: String", 2},
+		`, "TypeError: Expect argument to be Array. got: String", 2, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -560,14 +560,14 @@ func TestArrayCountMethodFail(t *testing.T) {
 		{
 			`a = [1, 2]
 		a.count(3, 3)
-		`, "ArgumentError: Expect 1 argument, got=2", 2},
+		`, "ArgumentError: Expect 1 argument, got=2", 2, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -643,17 +643,17 @@ func TestArrayDeleteAtMethod(t *testing.T) {
 
 func TestArrayDeleteAtMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`[1, 2, 3].delete_at`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`[1, 2, 3].delete_at(2, 3)`, "ArgumentError: Expect 1 argument. got=2", 1},
-		{`[1, 2, 3].delete_at(true)`, "TypeError: Expect argument to be Integer. got: Boolean", 1},
-		{`[1, 2, 3].delete_at(1..3)`, "TypeError: Expect argument to be Integer. got: Range", 1},
+		{`[1, 2, 3].delete_at`, "ArgumentError: Expect 1 argument. got=0", 1, 1},
+		{`[1, 2, 3].delete_at(2, 3)`, "ArgumentError: Expect 1 argument. got=2", 1, 1},
+		{`[1, 2, 3].delete_at(true)`, "TypeError: Expect argument to be Integer. got: Boolean", 1, 1},
+		{`[1, 2, 3].delete_at(1..3)`, "TypeError: Expect argument to be Integer. got: Range", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -690,19 +690,19 @@ func TestArrayEachMethod(t *testing.T) {
 
 func TestArrayEachMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`['M', 'A', 'X', 'W', 'E', 'L', 'L'].each`, "InternalError: Can't yield without a block", 1},
+		{`['M', 'A', 'X', 'W', 'E', 'L', 'L'].each`, "InternalError: Can't yield without a block", 1, 1},
 		{`
 		['T', 'A', 'I', 'P', 'E', 'I'].each(101) do |char|
 		  puts char
 		end
-		`, "ArgumentError: Expect 0 argument. got=1", 2},
+		`, "ArgumentError: Expect 0 argument. got=1", 2, 2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -739,19 +739,19 @@ func TestArrayEachIndexMethod(t *testing.T) {
 
 func TestArrayEachIndexMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`['M', 'A', 'X', 'W', 'E', 'L', 'L'].each_index`, "InternalError: Can't yield without a block", 1},
+		{`['M', 'A', 'X', 'W', 'E', 'L', 'L'].each_index`, "InternalError: Can't yield without a block", 1, 1},
 		{`
 		['T', 'A', 'I', 'P', 'E', 'I'].each_index(101) do |char|
 		  puts char
 		end
-		`, "ArgumentError: Expect 0 argument. got=1", 2},
+		`, "ArgumentError: Expect 0 argument. got=1", 2, 2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -791,15 +791,15 @@ func TestArrayEmptyMethod(t *testing.T) {
 
 func TestArrayEmptyMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`[1, 2, 3].empty?(123)`, "ArgumentError: Expect 0 argument. got=1", 1},
-		{`['T', 'A', 'I', 'P', 'E', 'I'].empty?(1, 0, 1)`, "ArgumentError: Expect 0 argument. got=3", 1},
+		{`[1, 2, 3].empty?(123)`, "ArgumentError: Expect 0 argument. got=1", 1, 1},
+		{`['T', 'A', 'I', 'P', 'E', 'I'].empty?(1, 0, 1)`, "ArgumentError: Expect 0 argument. got=3", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -855,20 +855,20 @@ func TestArrayFirstMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`a = [1, 2]
 		a.first("a")
-		`, "TypeError: Expect argument to be Integer. got: String", 2},
+		`, "TypeError: Expect argument to be Integer. got: String", 2, 1},
 		{`a = [1, 2]
 		a.first(1, 2, 3)
-		`, "ArgumentError: Expect 0..1 argument. got=3", 2},
+		`, "ArgumentError: Expect 0..1 argument. got=3", 2, 1},
 		{`a = [1, 2]
 		a.first(-1)
-		`, "ArgumentError: Expect argument to be positive value. got=-1", 2},
+		`, "ArgumentError: Expect argument to be positive value. got=-1", 2, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -905,14 +905,14 @@ func TestArrayFlattenMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`a = [1, 2]
 		a.flatten(1)
-		`, "ArgumentError: Expect 0 argument. got=1", 2},
+		`, "ArgumentError: Expect 0 argument. got=1", 2, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -949,17 +949,17 @@ func TestArrayJoinMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`a = [1, 2]
 		a.join(",", "-")
-		`, "ArgumentError: Expect 0 or 1 argument. got=2", 2},
+		`, "ArgumentError: Expect 0 or 1 argument. got=2", 2, 1},
 		{`a = [1, 2]
 		a.join(1)
-		`, "TypeError: Expect argument to be String. got: Integer", 2},
+		`, "TypeError: Expect argument to be String. got: Integer", 2, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1000,20 +1000,20 @@ func TestArrayLastMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`a = [1, 2]
 		a.last("l")
-		`, "TypeError: Expect argument to be Integer. got: String", 2},
+		`, "TypeError: Expect argument to be Integer. got: String", 2, 1},
 		{`a = [1, 2]
 		a.last(1, 2, 3)
-		`, "ArgumentError: Expect 0..1 argument. got=3", 2},
+		`, "ArgumentError: Expect 0..1 argument. got=3", 2, 1},
 		{`a = [1, 2]
 		a.last(-1)
-		`, "ArgumentError: Expect argument to be positive value. got=-1", 2},
+		`, "ArgumentError: Expect argument to be positive value. got=-1", 2, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1053,14 +1053,14 @@ func TestArrayLengthMethod(t *testing.T) {
 
 func TestArrayLengthMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`[1, 2, 3].length(10)`, "ArgumentError: Expect 0 argument. got=1", 1},
+		{`[1, 2, 3].length(10)`, "ArgumentError: Expect 0 argument. got=1", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1225,19 +1225,19 @@ func TestArrayReduceMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`a = [1, 2]
 		a.reduce(1)
-		`, "InternalError: Can't yield without a block", 2},
+		`, "InternalError: Can't yield without a block", 2, 1},
 		{`a = [1, 2]
 		a.reduce(1, 2) do |prev, n|
 			prev + n
 		end
-		`, "ArgumentError: Expect 0 or 1 argument. got=2", 2},
+		`, "ArgumentError: Expect 0 or 1 argument. got=2", 2, 2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1298,19 +1298,19 @@ func TestArrayReverseEachMethod(t *testing.T) {
 
 func TestArrayReverseEachMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`['M', 'A'].reverse_each`, "InternalError: Can't yield without a block", 1},
+		{`['M', 'A'].reverse_each`, "InternalError: Can't yield without a block", 1, 1},
 		{`
 		['T', 'A'].reverse_each(101) do |char|
 		  puts char
 		end
-		`, "ArgumentError: Expect 0 argument. got=1", 2},
+		`, "ArgumentError: Expect 0 argument. got=1", 2, 2},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1343,16 +1343,16 @@ func TestArrayRotateMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`a = [1, 2]
 		a.rotate("a")
-		`, "TypeError: Expect argument to be Integer. got: String", 2},
+		`, "TypeError: Expect argument to be Integer. got: String", 2, 1},
 		{`a = [1, 2]
-		a.rotate(1, 2, 3)`, "ArgumentError: Expect 0..1 argument. got=3", 2},
+		a.rotate(1, 2, 3)`, "ArgumentError: Expect 0..1 argument. got=3", 2, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1433,14 +1433,14 @@ func TestArrayShiftMethodFail(t *testing.T) {
 		a.shift(3, 3, 4, 5)
 		`,
 			"ArgumentError: Expect 0 argument. got=4",
-			2},
+			2, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1540,14 +1540,14 @@ func TestArrayValuesAtMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`a = ["a", "b", "c"]
 			a.values_at("-")
-		`, "TypeError: Expect argument to be Integer. got: String", 2},
+		`, "TypeError: Expect argument to be Integer. got: String", 2, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -26,7 +26,7 @@ func builtinBooleanClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
@@ -47,7 +47,7 @@ func builtinBooleanInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "==",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if receiver == args[0] {
@@ -67,7 +67,7 @@ func builtinBooleanInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "!=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if receiver != args[0] {
@@ -86,7 +86,7 @@ func builtinBooleanInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "!",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					rightValue := receiver.(*BooleanObject).value

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -28,7 +28,7 @@ func builtinBooleanClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					return t.unsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
 		},

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -28,7 +28,7 @@ func builtinBooleanClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.initUnsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError(instruction, "#new", receiver)
 				}
 			},
 		},

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -27,7 +27,7 @@ func builtinBooleanClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
@@ -48,7 +48,7 @@ func builtinBooleanInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if receiver == args[0] {
 						return TRUE
@@ -68,7 +68,7 @@ func builtinBooleanInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "!=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if receiver != args[0] {
 						return TRUE
@@ -87,7 +87,7 @@ func builtinBooleanInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "!",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					rightValue := receiver.(*BooleanObject).value
 

--- a/vm/call_frame.go
+++ b/vm/call_frame.go
@@ -19,6 +19,8 @@ type baseFrame struct {
 	isBlock    bool
 	blockFrame *normalCallFrame
 	sync.RWMutex
+	sourceLine int
+	fileName   string
 }
 
 type callFrame interface {
@@ -29,6 +31,8 @@ type callFrame interface {
 	EP() *normalCallFrame
 	Locals() []*Pointer
 	LocalPtr() int
+	SourceLine() int
+	FileName() string
 
 	getLCL(index, depth int) *Pointer
 	insertLCL(index, depth int, value Object)
@@ -39,8 +43,8 @@ type callFrame interface {
 
 type goMethodCallFrame struct {
 	*baseFrame
-	method builtinMethodBody
-	name   string
+	method     builtinMethodBody
+	name       string
 }
 
 type normalCallFrame struct {
@@ -72,6 +76,14 @@ func (b *baseFrame) Locals() []*Pointer {
 
 func (b *baseFrame) LocalPtr() int {
 	return b.lPr
+}
+
+func (b *baseFrame) SourceLine() int {
+	return b.sourceLine
+}
+
+func (b *baseFrame) FileName() string {
+	return b.fileName
 }
 
 // We use lock on every local variable retrieval and insertion.
@@ -189,10 +201,10 @@ func (cfs *callFrameStack) top() callFrame {
 	return nil
 }
 
-func newNormalCallFrame(is *instructionSet) *normalCallFrame {
-	return &normalCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 15), lPr: 0}, instructionSet: is, pc: 0}
+func newNormalCallFrame(is *instructionSet, filename string) *normalCallFrame {
+	return &normalCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 15), lPr: 0, fileName: filename}, instructionSet: is, pc: 0}
 }
 
-func newGoMethodCallFrame(m builtinMethodBody, n string) *goMethodCallFrame {
-	return &goMethodCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 15), lPr: 0}, method: m, name: n}
+func newGoMethodCallFrame(m builtinMethodBody, n, filename string) *goMethodCallFrame {
+	return &goMethodCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 15), lPr: 0, fileName: filename}, method: m, name: n}
 }

--- a/vm/call_frame.go
+++ b/vm/call_frame.go
@@ -43,8 +43,8 @@ type callFrame interface {
 
 type goMethodCallFrame struct {
 	*baseFrame
-	method     builtinMethodBody
-	name       string
+	method builtinMethodBody
+	name   string
 }
 
 type normalCallFrame struct {

--- a/vm/call_frame.go
+++ b/vm/call_frame.go
@@ -39,6 +39,7 @@ type callFrame interface {
 	storeConstant(constName string, constant interface{}) *Pointer
 	lookupConstant(constName string) *Pointer
 	inspect() string
+	stopExecution()
 }
 
 type goMethodCallFrame struct {
@@ -47,11 +48,21 @@ type goMethodCallFrame struct {
 	name   string
 }
 
+func (cf *goMethodCallFrame) stopExecution() {}
+
 type normalCallFrame struct {
 	*baseFrame
 	instructionSet *instructionSet
 	// program counter
 	pc int
+}
+
+func (n *normalCallFrame) instructionsCount() int {
+	return len(n.instructionSet.instructions)
+}
+
+func (n *normalCallFrame) stopExecution() {
+	n.pc = n.instructionsCount()
 }
 
 func (b *baseFrame) Self() Object {

--- a/vm/call_object.go
+++ b/vm/call_object.go
@@ -12,11 +12,11 @@ type callObject struct {
 	argSet       *bytecode.ArgSet
 	argIndex     int
 	lastArgIndex int
-	callFrame    *callFrame
+	callFrame    *normalCallFrame
 }
 
-func newCallObject(receiver Object, method *MethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *callFrame) *callObject {
-	cf := newCallFrame(method.instructionSet)
+func newCallObject(receiver Object, method *MethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame) *callObject {
+	cf := newNormalCallFrame(method.instructionSet)
 	cf.self = receiver
 	cf.blockFrame = blockFrame
 

--- a/vm/call_object.go
+++ b/vm/call_object.go
@@ -1,0 +1,176 @@
+package vm
+
+import (
+	"fmt"
+	"github.com/goby-lang/goby/compiler/bytecode"
+)
+
+type callObject struct {
+	method       *MethodObject
+	receiverPtr  int
+	argCount     int
+	argSet       *bytecode.ArgSet
+	argIndex     int
+	lastArgIndex int
+	callFrame    *callFrame
+}
+
+func newCallObject(receiver Object, method *MethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *callFrame) *callObject {
+	cf := newCallFrame(method.instructionSet)
+	cf.self = receiver
+	cf.blockFrame = blockFrame
+
+	return &callObject{
+		method:      method,
+		receiverPtr: receiverPtr,
+		argCount:    argCount,
+		argSet:      argSet,
+		// This is only for normal/optioned arguments
+		lastArgIndex: -1,
+		callFrame:    cf,
+	}
+}
+
+func (co *callObject) instructionSet() *instructionSet {
+	return co.method.instructionSet
+}
+
+func (co *callObject) paramTypes() []int {
+	return co.instructionSet().paramTypes.Types()
+}
+
+func (co *callObject) paramNames() []string {
+	return co.instructionSet().paramTypes.Names()
+}
+
+func (co *callObject) methodName() string {
+	return co.method.Name
+}
+
+func (co *callObject) argTypes() []int {
+	if co.argSet == nil {
+		return []int{}
+	}
+
+	return co.argSet.Types()
+}
+
+func (co *callObject) argPtr() int {
+	return co.receiverPtr + 1
+}
+
+func (co *callObject) argPosition() int {
+	return co.argPtr() + co.argIndex
+}
+
+func (co *callObject) assignNormalArguments(stack []*Pointer) {
+	for i, paramType := range co.paramTypes() {
+		if paramType == bytecode.NormalArg {
+			co.callFrame.insertLCL(i, 0, stack[co.argPosition()].Target)
+			co.argIndex++
+		}
+	}
+}
+
+func (co *callObject) assignNormalAndOptionedArguments(paramIndex int, stack []*Pointer) {
+	/*
+		Find first usable value as normal argument, for example:
+
+		```ruby
+		  def foo(x, y:); end
+
+		  foo(y: 100, 10)
+		```
+
+		In the example we can see that 'x' is the first parameter,
+		but in the method call it's the second argument.
+
+		This loop is for skipping other types of arguments and get the correct argument index.
+	*/
+	for argIndex, at := range co.argTypes() {
+		if co.lastArgIndex < argIndex && (at == bytecode.NormalArg || at == bytecode.OptionedArg) {
+			co.callFrame.insertLCL(paramIndex, 0, stack[co.argPtr()+argIndex].Target)
+
+			// Store latest index value (and compare them to current argument index)
+			// This is to make sure we won't get same argument's index twice.
+			co.lastArgIndex = argIndex
+			break
+		}
+	}
+}
+
+func (co *callObject) assignKeywordArguments(stack []*Pointer) (err error) {
+	for argIndex, argType := range co.argTypes() {
+		if argType == bytecode.RequiredKeywordArg || argType == bytecode.OptionalKeywordArg {
+			argName := co.argSet.Names()[argIndex]
+			paramIndex, ok := co.hasKeywordParam(argName)
+
+			if ok {
+				co.callFrame.insertLCL(paramIndex, 0, stack[co.argPtr()+argIndex].Target)
+			} else {
+				err = fmt.Errorf("unknown key %s for method %s", argName, co.methodName())
+			}
+		}
+	}
+
+	return
+}
+
+func (co *callObject) assignSplatArgument(stack []*Pointer, arr *ArrayObject) {
+	index := len(co.paramTypes()) - 1
+
+	for co.argIndex < co.argCount {
+		arr.Elements = append(arr.Elements, stack[co.argPosition()].Target)
+		co.argIndex++
+	}
+
+	co.callFrame.insertLCL(index, 0, arr)
+}
+
+func (co *callObject) hasKeywordParam(name string) (index int, result bool) {
+	for paramIndex, paramType := range co.paramTypes() {
+		paramName := co.paramNames()[paramIndex]
+
+		if paramName == name && (paramType == bytecode.RequiredKeywordArg || paramType == bytecode.OptionalKeywordArg) {
+			index = paramIndex
+			result = true
+			return
+		}
+	}
+
+	return
+}
+
+func (co *callObject) hasKeywordArgument(name string) (index int, result bool) {
+	for argIndex, argType := range co.argTypes() {
+		argName := co.argSet.Names()[argIndex]
+
+		if argName == name && (argType == bytecode.RequiredKeywordArg || argType == bytecode.OptionalKeywordArg) {
+			index = argIndex
+			result = true
+			return
+		}
+	}
+
+	return
+}
+
+func (co *callObject) normalParamsCount() (n int) {
+	for _, at := range co.paramTypes() {
+		if at == bytecode.NormalArg {
+			n++
+		}
+	}
+
+	return
+}
+
+func (co *callObject) normalArgsCount() (n int) {
+	for _, at := range co.argTypes() {
+		if at == bytecode.NormalArg {
+			n++
+		}
+	}
+
+	return
+}

--- a/vm/call_object.go
+++ b/vm/call_object.go
@@ -15,10 +15,11 @@ type callObject struct {
 	callFrame    *normalCallFrame
 }
 
-func newCallObject(receiver Object, method *MethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame) *callObject {
-	cf := newNormalCallFrame(method.instructionSet)
+func newCallObject(receiver Object, method *MethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame, sourceLine int, fileName string) *callObject {
+	cf := newNormalCallFrame(method.instructionSet, fileName)
 	cf.self = receiver
 	cf.blockFrame = blockFrame
+	cf.sourceLine = sourceLine
 
 	return &callObject{
 		method:      method,

--- a/vm/call_object.go
+++ b/vm/call_object.go
@@ -15,8 +15,8 @@ type callObject struct {
 	callFrame    *normalCallFrame
 }
 
-func newCallObject(receiver Object, method *MethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame, sourceLine int, fileName string) *callObject {
-	cf := newNormalCallFrame(method.instructionSet, fileName)
+func newCallObject(receiver Object, method *MethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame, sourceLine int) *callObject {
+	cf := newNormalCallFrame(method.instructionSet, method.instructionSet.filename)
 	cf.self = receiver
 	cf.blockFrame = blockFrame
 	cf.sourceLine = sourceLine

--- a/vm/channel.go
+++ b/vm/channel.go
@@ -19,7 +19,7 @@ func builtinChannelClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					c := &ChannelObject{baseObj: &baseObj{class: t.vm.topLevelClass(classes.ChannelClass)}, Chan: make(chan int)}
 					return c
 				}
@@ -34,7 +34,7 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "close",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					c := receiver.(*ChannelObject)
 
 					close(c.Chan)
@@ -46,7 +46,7 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "deliver",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					id := t.vm.channelObjectMap.storeObj(args[0])
 
 					c := receiver.(*ChannelObject)
@@ -60,7 +60,7 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "receive",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					c := receiver.(*ChannelObject)
 
 					num := <-c.Chan

--- a/vm/channel.go
+++ b/vm/channel.go
@@ -18,7 +18,7 @@ func builtinChannelClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					c := &ChannelObject{baseObj: &baseObj{class: t.vm.topLevelClass(classes.ChannelClass)}, Chan: make(chan int)}
 					return c
@@ -33,7 +33,7 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "close",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					c := receiver.(*ChannelObject)
 
@@ -45,7 +45,7 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "deliver",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					id := t.vm.channelObjectMap.storeObj(args[0])
 
@@ -59,7 +59,7 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "receive",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					c := receiver.(*ChannelObject)
 

--- a/vm/class.go
+++ b/vm/class.go
@@ -677,9 +677,9 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			Name: "block_given?",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
-					cf := t.callFrameStack.top()
+					cf := t.callFrameStack.callFrames[t.cfp-2]
 
-					if cf.blockFrame == nil {
+					if cf.BlockFrame() == nil {
 						return FALSE
 					}
 

--- a/vm/class.go
+++ b/vm/class.go
@@ -65,7 +65,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @param *args [String] One or more quoted method names for 'getter/setter'
 			// @return [Null]
 			Name: "attr_accessor",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*RClass)
 					r.setAttrAccessor(args)
@@ -101,7 +101,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @param *args [String] One or more quoted method names for 'getter'
 			// @return [Null]
 			Name: "attr_reader",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*RClass)
 					r.setAttrReader(args)
@@ -137,7 +137,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @param *args [String] One or more quoted method names for 'setter'
 			// @return [Null]
 			Name: "attr_writer",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*RClass)
 					r.setAttrWriter(args)
@@ -202,7 +202,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @param module [Class] Module name to include
 			// @return [Null]
 			Name: "include",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					var class *RClass
 					module, ok := args[0].(*RClass)
@@ -231,7 +231,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "extend",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					var class *RClass
 					module, ok := args[0].(*RClass)
@@ -264,7 +264,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @param class [Class] Receiver
 			// @return [String] Converted receiver name
 			Name: "name",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -302,7 +302,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @param class [Class] Receiver
 			// @return [Object] Created object
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					class, ok := receiver.(*RClass)
 
@@ -351,7 +351,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @param class [Class] Receiver
 			// @return [Object] Superclass object of the receiver
 			Name: "superclass",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -375,7 +375,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "ancestors",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					c, ok := receiver.(*RClass)
 
@@ -400,7 +400,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "singleton_class",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return receiver.SingletonClass()
 				}
@@ -428,7 +428,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [@boolean]
 			Name: "==",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					className := receiver.Class().Name
 					compareClassName := args[0].Class().Name
@@ -461,7 +461,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [@boolean]
 			Name: "!=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					className := receiver.Class().Name
 					compareClassName := args[0].Class().Name
@@ -494,7 +494,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param filename [String] Quoted file name of the library, without extension
 			// @return [Boolean] Result of loading module
 			Name: "require",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					libName := args[0].(*StringObject).value
 					initFunc, ok := standardLibraries[libName]
@@ -522,7 +522,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param path/name [String] Quoted file path to library plus name, without extension
 			// @return [Boolean] Result of loading module
 			Name: "require_relative",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					callerDir := path.Dir(t.vm.currentFilePath())
 					filepath := args[0].(*StringObject).value
@@ -560,7 +560,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param *args [Class] String literals, or other objects that can be converted into String.
 			// @return [Null]
 			Name: "puts",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					for _, arg := range args {
@@ -586,7 +586,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param object [Object] Receiver (required)
 			// @return [Class] The class of the receiver
 			Name: "class",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					switch r := receiver.(type) {
@@ -609,7 +609,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param object [Object] object that return boolean value to invert
 			// @return [Object] Inverted boolean value
 			Name: "!",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					return FALSE
@@ -629,7 +629,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param sec [Integer] time to wait in sec
 			// @return [Integer] actual time slept in sec
 			Name: "sleep",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
@@ -647,7 +647,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param n/a []
 			// @return [String] Object's string representation.
 			Name: "to_s",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.vm.initStringObject(receiver.toString())
 				}
@@ -675,7 +675,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param n/a []
 			// @return [Boolean] true/false
 			Name: "block_given?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					cf := t.callFrameStack.callFrames[t.cfp-2]
 
@@ -689,7 +689,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "send",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "no method name given")
@@ -701,7 +701,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
 
-					t.sendMethod(name.value, len(args), blockFrame)
+					t.sendMethod(name.value, len(args), blockFrame, instruction)
 
 					return t.stack.top().Target
 				}
@@ -709,7 +709,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "thread",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if blockFrame == nil {
 						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
@@ -746,7 +746,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param n/a []
 			// @return [Boolean]
 			Name: "is_a?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
@@ -790,7 +790,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param n/a []
 			// @return [Boolean]
 			Name: "nil?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -801,7 +801,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "instance_variable_get",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arg, isStr := args[0].(*StringObject)
 
@@ -821,7 +821,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "instance_variable_set",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got: %d", len(args))
@@ -842,7 +842,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "methods",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					methods := []Object{}
 					set := map[string]interface{}{}
@@ -1135,7 +1135,7 @@ func (c *RClass) ancestors() []*RClass {
 func generateAttrWriteMethod(attrName string) *BuiltinMethodObject {
 	return &BuiltinMethodObject{
 		Name: attrName + "=",
-		Fn: func(receiver Object) builtinMethodBody {
+		Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 			return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 				v := receiver.instanceVariableSet("@"+attrName, args[0])
 				return v
@@ -1147,7 +1147,7 @@ func generateAttrWriteMethod(attrName string) *BuiltinMethodObject {
 func generateAttrReadMethod(attrName string) *BuiltinMethodObject {
 	return &BuiltinMethodObject{
 		Name: attrName,
-		Fn: func(receiver Object) builtinMethodBody {
+		Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 			return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 				v, ok := receiver.instanceVariableGet("@" + attrName)
 

--- a/vm/class.go
+++ b/vm/class.go
@@ -66,7 +66,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @return [Null]
 			Name: "attr_accessor",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*RClass)
 					r.setAttrAccessor(args)
 
@@ -102,7 +102,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @return [Null]
 			Name: "attr_reader",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*RClass)
 					r.setAttrReader(args)
 
@@ -138,7 +138,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @return [Null]
 			Name: "attr_writer",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*RClass)
 					r.setAttrWriter(args)
 
@@ -203,7 +203,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @return [Null]
 			Name: "include",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					var class *RClass
 					module, ok := args[0].(*RClass)
 
@@ -232,7 +232,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "extend",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					var class *RClass
 					module, ok := args[0].(*RClass)
 
@@ -265,7 +265,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @return [String] Converted receiver name
 			Name: "name",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -303,7 +303,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @return [Object] Created object
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					class, ok := receiver.(*RClass)
 
 					if !ok {
@@ -352,7 +352,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @return [Object] Superclass object of the receiver
 			Name: "superclass",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -376,7 +376,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "ancestors",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					c, ok := receiver.(*RClass)
 
 					if !ok {
@@ -401,7 +401,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "singleton_class",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return receiver.SingletonClass()
 				}
 			},
@@ -429,7 +429,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [@boolean]
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					className := receiver.Class().Name
 					compareClassName := args[0].Class().Name
 
@@ -462,7 +462,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [@boolean]
 			Name: "!=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					className := receiver.Class().Name
 					compareClassName := args[0].Class().Name
 
@@ -495,7 +495,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean] Result of loading module
 			Name: "require",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					libName := args[0].(*StringObject).value
 					initFunc, ok := standardLibraries[libName]
 
@@ -523,7 +523,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean] Result of loading module
 			Name: "require_relative",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					callerDir := path.Dir(t.vm.currentFilePath())
 					filepath := args[0].(*StringObject).value
 
@@ -561,7 +561,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Null]
 			Name: "puts",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					for _, arg := range args {
 						fmt.Println(arg.toString())
@@ -587,7 +587,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Class] The class of the receiver
 			Name: "class",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					switch r := receiver.(type) {
 					case Object:
@@ -610,7 +610,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object] Inverted boolean value
 			Name: "!",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					return FALSE
 				}
@@ -630,7 +630,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer] actual time slept in sec
 			Name: "sleep",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
 					}
@@ -648,7 +648,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [String] Object's string representation.
 			Name: "to_s",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.vm.initStringObject(receiver.toString())
 				}
 			},
@@ -676,7 +676,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean] true/false
 			Name: "block_given?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					cf := t.callFrameStack.top()
 
 					if cf.blockFrame == nil {
@@ -690,7 +690,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "send",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "no method name given")
 					}
@@ -710,7 +710,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "thread",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if blockFrame == nil {
 						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
 					}
@@ -747,7 +747,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "is_a?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
 					}
@@ -791,7 +791,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "nil?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -802,7 +802,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "instance_variable_get",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arg, isStr := args[0].(*StringObject)
 
 					if !isStr {
@@ -822,7 +822,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "instance_variable_set",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got: %d", len(args))
 					}
@@ -843,7 +843,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "methods",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					methods := []Object{}
 					set := map[string]interface{}{}
 					klasses := receiver.Class().ancestors()
@@ -1136,7 +1136,7 @@ func generateAttrWriteMethod(attrName string) *BuiltinMethodObject {
 	return &BuiltinMethodObject{
 		Name: attrName + "=",
 		Fn: func(receiver Object) builtinMethodBody {
-			return func(t *thread, args []Object, blockFrame *callFrame) Object {
+			return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 				v := receiver.instanceVariableSet("@"+attrName, args[0])
 				return v
 			}
@@ -1148,7 +1148,7 @@ func generateAttrReadMethod(attrName string) *BuiltinMethodObject {
 	return &BuiltinMethodObject{
 		Name: attrName,
 		Fn: func(receiver Object) builtinMethodBody {
-			return func(t *thread, args []Object, blockFrame *callFrame) Object {
+			return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 				v, ok := receiver.instanceVariableGet("@" + attrName)
 
 				if ok {

--- a/vm/class.go
+++ b/vm/class.go
@@ -208,7 +208,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 					module, ok := args[0].(*RClass)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, "Expect argument to be a module. got=%v", args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, "Expect argument to be a module. got=%v", args[0].Class().Name)
 					}
 
 					switch r := receiver.(type) {
@@ -237,7 +237,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 					module, ok := args[0].(*RClass)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, "Expect argument to be a module. got=%v", args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, "Expect argument to be a module. got=%v", args[0].Class().Name)
 					}
 
 					class = receiver.SingletonClass()
@@ -267,13 +267,13 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					n, ok := receiver.(*RClass)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.UndefinedMethodError, "Undefined Method '%s' for %s", "#name", receiver.toString())
+						return t.vm.initErrorObject(errors.UndefinedMethodError, instruction, "Undefined Method '%s' for %s", "#name", receiver.toString())
 					}
 
 					name := n.ReturnName()
@@ -307,7 +307,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 					class, ok := receiver.(*RClass)
 
 					if !ok {
-						return t.initUnsupportedMethodError("#new", receiver)
+						return t.initUnsupportedMethodError(instruction, "#new", receiver)
 					}
 
 					instance := class.initializeInstance()
@@ -354,13 +354,13 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					c, ok := receiver.(*RClass)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.UndefinedMethodError, "Undefined Method '%s' for %s", "#superclass", receiver.toString())
+						return t.vm.initErrorObject(errors.UndefinedMethodError, instruction, "Undefined Method '%s' for %s", "#superclass", receiver.toString())
 					}
 
 					superClass := c.returnSuperClass()
@@ -380,7 +380,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 					c, ok := receiver.(*RClass)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.UndefinedMethodError, "Undefined Method '%s' for %s", "#ancestors", receiver.toString())
+						return t.vm.initErrorObject(errors.UndefinedMethodError, instruction, "Undefined Method '%s' for %s", "#ancestors", receiver.toString())
 					}
 
 					a := c.ancestors()
@@ -500,7 +500,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 					initFunc, ok := standardLibraries[libName]
 
 					if !ok {
-						return t.vm.initErrorObject(errors.InternalError, "Can't require \"%s\"", libName)
+						return t.vm.initErrorObject(errors.InternalError, instruction, "Can't require \"%s\"", libName)
 					}
 
 					initFunc(t.vm)
@@ -532,7 +532,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 					file, err := ioutil.ReadFile(filepath + ".gb")
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					t.vm.execRequiredFile(filepath, file)
@@ -632,7 +632,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got: %d", len(args))
 					}
 
 					int := args[0].(*IntegerObject)
@@ -692,13 +692,13 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "no method name given")
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "no method name given")
 					}
 
 					name, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
 
 					t.sendMethod(name.value, len(args), blockFrame, instruction)
@@ -712,7 +712,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					newT := t.vm.newThread()
@@ -749,14 +749,14 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got: %d", len(args))
 					}
 
 					c := args[0]
 					gobyClass, ok := c.(*RClass)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.ClassClass, c.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.ClassClass, c.Class().Name)
 					}
 
 					receiverClass := receiver.Class()
@@ -793,7 +793,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 					return FALSE
 				}
@@ -806,7 +806,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 					arg, isStr := args[0].(*StringObject)
 
 					if !isStr {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
 
 					obj, ok := receiver.instanceVariableGet(arg.value)
@@ -824,14 +824,14 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 2 arguments. got: %d", len(args))
 					}
 
 					argName, isStr := args[0].(*StringObject)
 					obj := args[1]
 
 					if !isStr {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
 
 					receiver.instanceVariableSet(argName.value, obj)

--- a/vm/class.go
+++ b/vm/class.go
@@ -307,7 +307,7 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 					class, ok := receiver.(*RClass)
 
 					if !ok {
-						return t.unsupportedMethodError("#new", receiver)
+						return t.initUnsupportedMethodError("#new", receiver)
 					}
 
 					instance := class.initializeInstance()

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -665,18 +665,18 @@ func TestGeneralIsNilMethod(t *testing.T) {
 
 func TestGeneralIsNilMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`123.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`"Fail".nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`[1, 2, 3].nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2, c: 3 }.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`(1..10).nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`123.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`"Fail".nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`[1, 2, 3].nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`{ a: 1, b: 2, c: 3 }.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`(1..10).nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -799,19 +799,19 @@ func TestGeneralIsAMethod(t *testing.T) {
 
 func TestGeneralIsAMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`123.is_a?`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`Class.is_a?`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`123.is_a?(123, 456)`, "ArgumentError: Expect 1 argument. got: 2", 1},
-		{`123.is_a?(Integer, String)`, "ArgumentError: Expect 1 argument. got: 2", 1},
-		{`123.is_a?(true)`, "TypeError: Expect argument to be Class. got: Boolean", 1},
-		{`Class.is_a?(true)`, "TypeError: Expect argument to be Class. got: Boolean", 1},
+		{`123.is_a?`, "ArgumentError: Expect 1 argument. got: 0", 1, 1},
+		{`Class.is_a?`, "ArgumentError: Expect 1 argument. got: 0", 1, 1},
+		{`123.is_a?(123, 456)`, "ArgumentError: Expect 1 argument. got: 2", 1, 1},
+		{`123.is_a?(Integer, String)`, "ArgumentError: Expect 1 argument. got: 2", 1, 1},
+		{`123.is_a?(true)`, "TypeError: Expect argument to be Class. got: Boolean", 1, 1},
+		{`Class.is_a?(true)`, "TypeError: Expect argument to be Class. got: Boolean", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -842,18 +842,18 @@ func TestClassNameClassMethod(t *testing.T) {
 
 func TestClassNameClassMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Taipei".name`, "UndefinedMethodError: Undefined Method 'name' for Taipei", 1},
-		{`123.name`, "UndefinedMethodError: Undefined Method 'name' for 123", 1},
-		{`true.name`, "UndefinedMethodError: Undefined Method 'name' for true", 1},
-		{`Integer.name(Integer)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`String.name(Hash, Array)`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`"Taipei".name`, "UndefinedMethodError: Undefined Method 'name' for Taipei", 1, 1},
+		{`123.name`, "UndefinedMethodError: Undefined Method 'name' for 123", 1, 1},
+		{`true.name`, "UndefinedMethodError: Undefined Method 'name' for true", 1, 1},
+		{`Integer.name(Integer)`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`String.name(Hash, Array)`, "ArgumentError: Expect 0 argument. got: 2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -891,18 +891,18 @@ func TestClassSuperclassClassMethod(t *testing.T) {
 
 func TestClassSuperclassClassMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Taipei".superclass`, "UndefinedMethodError: Undefined Method 'superclass' for Taipei", 1},
-		{`123.superclass`, "UndefinedMethodError: Undefined Method 'superclass' for 123", 1},
-		{`true.superclass`, "UndefinedMethodError: Undefined Method 'superclass' for true", 1},
-		{`Integer.superclass(Integer)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`String.superclass(Hash, Array)`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`"Taipei".superclass`, "UndefinedMethodError: Undefined Method 'superclass' for Taipei", 1, 1},
+		{`123.superclass`, "UndefinedMethodError: Undefined Method 'superclass' for 123", 1, 1},
+		{`true.superclass`, "UndefinedMethodError: Undefined Method 'superclass' for true", 1, 1},
+		{`Integer.superclass(Integer)`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`String.superclass(Hash, Array)`, "ArgumentError: Expect 0 argument. got: 2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/db.go
+++ b/vm/db.go
@@ -35,7 +35,7 @@ func builtinDBClassMethods() []*BuiltinMethodObject {
 			//
 			Name: "get_connection",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 2, len(args))
 					}
@@ -84,7 +84,7 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 			//
 			Name: "close",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					conn, err := getDBConn(t, receiver)
 
 					if err != nil {
@@ -106,7 +106,7 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "run",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument.")
 					}
@@ -164,7 +164,7 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 			//
 			Name: "exec",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument.")
 					}
@@ -227,7 +227,7 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 			//
 			Name: "query",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument.")
 					}

--- a/vm/db.go
+++ b/vm/db.go
@@ -37,25 +37,25 @@ func builtinDBClassMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
-						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 2, len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, errors.WrongNumberOfArgumentFormat, 2, len(args))
 					}
 
 					driverName, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect database's driver name to be a String object. got: %s", args[0].Class().Name)
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect database's driver name to be a String object. got: %s", args[0].Class().Name)
 					}
 
 					dataSource, ok := args[1].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect database's data source to be a String object. got: %s", args[1].Class().Name)
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect database's data source to be a String object. got: %s", args[1].Class().Name)
 					}
 
 					conn, err := sqlx.Open(driverName.value, dataSource.value)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					connObj := t.vm.initObjectFromGoType(conn)
@@ -88,14 +88,14 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 					conn, err := getDBConn(t, receiver)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					err = conn.Close()
 
 					if err != nil {
 						if err != nil {
-							return t.vm.initErrorObject(errors.InternalError, "Error happens when closing DB connection: %s", err.Error())
+							return t.vm.initErrorObject(errors.InternalError, instruction, "Error happens when closing DB connection: %s", err.Error())
 						}
 					}
 
@@ -108,13 +108,13 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument.")
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect at least 1 argument.")
 					}
 
 					conn, err := getDBConn(t, receiver)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					queryString := args[0].(*StringObject).value
@@ -127,7 +127,7 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 					_, err = conn.Exec(queryString, execArgs...)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return TRUE
@@ -166,13 +166,13 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument.")
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect at least 1 argument.")
 					}
 
 					conn, err := getDBConn(t, receiver)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					queryString := args[0].(*StringObject).value
@@ -188,7 +188,7 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 					err = conn.QueryRow(fmt.Sprintf("%s RETURNING id", queryString), execArgs...).Scan(&id)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return t.vm.initIntegerObject(id)
@@ -229,13 +229,13 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument.")
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect at least 1 argument.")
 					}
 
 					conn, err := getDBConn(t, receiver)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					queryString := args[0].(*StringObject).value
@@ -248,7 +248,7 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 					rows, err := conn.Queryx(queryString, execArgs...)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					results := []Object{}
@@ -259,7 +259,7 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 						err = rows.MapScan(row)
 
 						if err != nil {
-							return t.vm.initErrorObject(errors.InternalError, err.Error())
+							return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 						}
 
 						data := map[string]Object{}

--- a/vm/db.go
+++ b/vm/db.go
@@ -34,7 +34,7 @@ func builtinDBClassMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			//
 			Name: "get_connection",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 2, len(args))
@@ -83,7 +83,7 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			//
 			Name: "close",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					conn, err := getDBConn(t, receiver)
 
@@ -105,7 +105,7 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "run",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument.")
@@ -163,7 +163,7 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			//
 			Name: "exec",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument.")
@@ -226,7 +226,7 @@ func builtinDBInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			//
 			Name: "query",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument.")

--- a/vm/diggable.go
+++ b/vm/diggable.go
@@ -2,5 +2,5 @@ package vm
 
 // Diggable represents a class that support the #dig method.
 type Diggable interface {
-	dig(t *thread, keys []Object) Object
+	dig(t *thread, keys []Object, instruction *instruction) Object
 }

--- a/vm/error.go
+++ b/vm/error.go
@@ -30,7 +30,7 @@ type Error struct {
 
 // Functions for initialization -----------------------------------------
 
-func (vm *VM) initErrorObject(errorType, format string, args ...interface{}) *Error {
+func (vm *VM) initErrorObject(errorType string, instruction *instruction, format string, args ...interface{}) *Error {
 	errClass := vm.objectClass.getClassConstant(errorType)
 
 	t := vm.mainThread
@@ -43,23 +43,20 @@ func (vm *VM) initErrorObject(errorType, format string, args ...interface{}) *Er
 			t.callFrameStack.pop()
 			cf = t.callFrameStack.top().(*normalCallFrame)
 		}
-
-		return &Error{
-			baseObj: &baseObj{class: errClass},
-			// Add 1 to source line because it's zero indexed
-			Message: fmt.Sprintf("%s. At %s:%d", fmt.Sprintf(errorType+": "+format, args...), cf.fileName, cf.sourceLine+1),
-			Type:    errorType,
-		}
 	case *goMethodCallFrame:
 		t.callFrameStack.pop()
-	default:
-		return nil
+	}
+
+	msg := fmt.Sprintf("%s. At %s:%d", fmt.Sprintf(errorType+": "+format, args...), cf.FileName(), instruction.sourceLine)
+
+	if instruction == nil {
+		msg = fmt.Sprintf("%s. At %s", fmt.Sprintf(errorType+": "+format, args...), cf.FileName())
 	}
 
 	return &Error{
 		baseObj: &baseObj{class: errClass},
 		// Add 1 to source line because it's zero indexed
-		Message: fmt.Sprintf("%s. At %s:%d", fmt.Sprintf(errorType+": "+format, args...), cf.FileName(), cf.SourceLine()),
+		Message: msg,
 		Type:    errorType,
 	}
 }

--- a/vm/error.go
+++ b/vm/error.go
@@ -44,25 +44,24 @@ func (vm *VM) initErrorObject(errorType, format string, args ...interface{}) *Er
 			cf = t.callFrameStack.top().(*normalCallFrame)
 		}
 
-		i := cf.instructionSet.instructions[cf.pc-1]
-
 		return &Error{
 			baseObj: &baseObj{class: errClass},
 			// Add 1 to source line because it's zero indexed
-			Message: fmt.Sprintf("%s. At %s:%d", fmt.Sprintf(errorType+": "+format, args...), cf.instructionSet.filename, i.sourceLine+1),
+			Message: fmt.Sprintf("%s. At %s:%d", fmt.Sprintf(errorType+": "+format, args...), cf.fileName, cf.sourceLine+1),
 			Type:    errorType,
 		}
 	case *goMethodCallFrame:
-		return &Error{
-			baseObj: &baseObj{class: errClass},
-			// Add 1 to source line because it's zero indexed
-			Message: fmt.Sprintf("%s. At %s", fmt.Sprintf(errorType+": "+format, args...), cf.name),
-			Type:    errorType,
-		}
+		t.callFrameStack.pop()
 	default:
 		return nil
 	}
 
+	return &Error{
+		baseObj: &baseObj{class: errClass},
+		// Add 1 to source line because it's zero indexed
+		Message: fmt.Sprintf("%s. At %s:%d", fmt.Sprintf(errorType+": "+format, args...), cf.FileName(), cf.SourceLine()),
+		Type:    errorType,
+	}
 }
 
 func (vm *VM) initErrorClasses() {

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -9,7 +9,7 @@ func TestErrorLineNumber(t *testing.T) {
 	tests := []errorTestCase{
 		{`a
 		123
-		`, "UndefinedMethodError: Undefined Method 'a' for <Instance of: Object>", 1},
+		`, "UndefinedMethodError: Undefined Method 'a' for <Instance of: Object>", 1, 1},
 		{`class Foo
 		 end
 
@@ -17,28 +17,28 @@ func TestErrorLineNumber(t *testing.T) {
 		 a.bar = "fuz"
 		 a.z
 		`, "UndefinedMethodError: Undefined Method 'bar=' for <Instance of: Foo>",
-			5},
+			5, 1},
 	}
 
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
 
 func TestUndefinedMethodError(t *testing.T) {
 	tests := []errorTestCase{
-		{`a`, "UndefinedMethodError: Undefined Method 'a' for <Instance of: Object>", 1},
+		{`a`, "UndefinedMethodError: Undefined Method 'a' for <Instance of: Object>", 1, 1},
 		{`class Foo
 		 end
 
 		 a = Foo.new
 		 a.bar = "fuz"
 		`, "UndefinedMethodError: Undefined Method 'bar=' for <Instance of: Foo>",
-			5},
+			5, 1},
 		{`class Foo
 		   attr_reader("foo")
 		 end
@@ -46,7 +46,7 @@ func TestUndefinedMethodError(t *testing.T) {
 		 a = Foo.new
 		 a.bar = "fuz"
 		`, "UndefinedMethodError: Undefined Method 'bar=' for <Instance of: Foo>",
-			6},
+			6, 1},
 		{`class Foo
 		  attr_reader("bar")
 		end
@@ -54,14 +54,14 @@ func TestUndefinedMethodError(t *testing.T) {
 		a = Foo.new
 		a.bar = "fuz"
 		`, "UndefinedMethodError: Undefined Method 'bar=' for <Instance of: Foo>",
-			6},
+			6, 1},
 	}
 
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 
@@ -69,19 +69,19 @@ func TestUndefinedMethodError(t *testing.T) {
 
 func TestUnsupportedMethodError(t *testing.T) {
 	tests := []errorTestCase{
-		{`String.new`, "UnsupportedMethodError: Unsupported Method #new for String", 1},
-		{`Integer.new`, "UnsupportedMethodError: Unsupported Method #new for Integer", 1},
-		{`Hash.new`, "UnsupportedMethodError: Unsupported Method #new for Hash", 1},
-		{`Array.new`, "UnsupportedMethodError: Unsupported Method #new for Array", 1},
-		{`Boolean.new`, "UnsupportedMethodError: Unsupported Method #new for Boolean", 1},
-		{`Null.new`, "UnsupportedMethodError: Unsupported Method #new for Null", 1},
+		{`String.new`, "UnsupportedMethodError: Unsupported Method #new for String", 1, 1},
+		{`Integer.new`, "UnsupportedMethodError: Unsupported Method #new for Integer", 1, 1},
+		{`Hash.new`, "UnsupportedMethodError: Unsupported Method #new for Hash", 1, 1},
+		{`Array.new`, "UnsupportedMethodError: Unsupported Method #new for Array", 1, 1},
+		{`Boolean.new`, "UnsupportedMethodError: Unsupported Method #new for Boolean", 1, 1},
+		{`Null.new`, "UnsupportedMethodError: Unsupported Method #new for Null", 1, 1},
 	}
 
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -94,52 +94,52 @@ func TestArgumentError(t *testing.T) {
 		foo
 		`,
 			"ArgumentError: Expect at least 1 args for method 'foo'. got: 0",
-			4},
+			4, 1},
 		{`def foo(x)
 		end
 
 		foo(1, 2)
 		`,
 			"ArgumentError: Expect at most 1 args for method 'foo'. got: 2",
-			4},
+			4, 1},
 		{`def foo(x = 10)
 		end
 
 		foo(1, 2)
 		`,
 			"ArgumentError: Expect at most 1 args for method 'foo'. got: 2",
-			4},
+			4, 1},
 		{`def foo(x, y = 10)
 		end
 
 		foo(1, 2, 3)
 		`,
 			"ArgumentError: Expect at most 2 args for method 'foo'. got: 3",
-			4},
+			4, 1},
 		{`"1234567890".include? "123", Class`,
 			"ArgumentError: Expect 1 argument. got=2",
-			1},
+			1, 1},
 		{`"1234567890".include? "123", Class, String`,
 			"ArgumentError: Expect 1 argument. got=3",
-			1},
+			1, 1},
 		{`def foo(a, *b)
 		end
 
 		foo
 		`, "ArgumentError: Expect at least 1 args for method 'foo'. got: 0",
-			4},
+			4, 1},
 		{`def foo(a, b, *c)
 		end
 
 		foo(10)
 		`, "ArgumentError: Expect at least 2 args for method 'foo'. got: 1",
-			4},
+			4, 1},
 		{`def foo(a, b = 10, *c)
 		end
 
 		foo
 		`, "ArgumentError: Expect at least 1 args for method 'foo'. got: 0",
-			4},
+			4, 1},
 		{`def foo(a, b, c)
 		  a + b + c
 		end
@@ -148,14 +148,14 @@ func TestArgumentError(t *testing.T) {
 		foo(*arr)
 		`,
 			"ArgumentError: Expect at most 3 args for method 'foo'. got: 4",
-			6},
+			6, 1},
 	}
 
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -169,7 +169,7 @@ func TestKeywordArgumentError(t *testing.T) {
 		foo
 		`,
 			"ArgumentError: Method foo requires key argument x",
-			5},
+			5, 1},
 		{`def foo
 		  10
 		end
@@ -177,7 +177,7 @@ func TestKeywordArgumentError(t *testing.T) {
 		foo(y: 1)
 		`,
 			"ArgumentError: Expect at most 0 args for method 'foo'. got: 1",
-			5},
+			5, 1},
 		{`def foo(x)
 		  x
 		end
@@ -185,7 +185,7 @@ func TestKeywordArgumentError(t *testing.T) {
 		foo(y: 1)
 		`,
 			"ArgumentError: unknown key y for method foo",
-			5},
+			5, 1},
 		{`def foo(x = 10)
 		  x
 		end
@@ -193,7 +193,7 @@ func TestKeywordArgumentError(t *testing.T) {
 		foo(y: 1)
 		`,
 			"ArgumentError: unknown key y for method foo",
-			5},
+			5, 1},
 		{`def foo(x:)
 		  x
 		end
@@ -201,7 +201,7 @@ func TestKeywordArgumentError(t *testing.T) {
 		foo(y: 1)
 		`,
 			"ArgumentError: Method foo requires key argument x",
-			5},
+			5, 1},
 		{`def foo(x: 10)
 		  x
 		end
@@ -209,7 +209,7 @@ func TestKeywordArgumentError(t *testing.T) {
 		foo(y: 1)
 		`,
 			"ArgumentError: unknown key y for method foo",
-			5},
+			5, 1},
 		{`def foo(x: 10)
 		  x
 		end
@@ -217,14 +217,14 @@ func TestKeywordArgumentError(t *testing.T) {
 		foo(y: 1, x: 100)
 		`,
 			"ArgumentError: Expect at most 1 args for method 'foo'. got: 2",
-			5},
+			5, 1},
 	}
 
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -234,22 +234,22 @@ func TestConstantAlreadyInitializedError(t *testing.T) {
 		{`Foo = 10
 		Foo = 100
 		`, "ConstantAlreadyInitializedError: Constant Foo already been initialized. Can't assign value to a constant twice.",
-			2},
+			2, 1},
 		{`class Foo; end
 		Foo = 100
 		`, "ConstantAlreadyInitializedError: Constant Foo already been initialized. Can't assign value to a constant twice.",
-			2},
+			2, 1},
 		{`module Foo; end
 		Foo = 100
 		`, "ConstantAlreadyInitializedError: Constant Foo already been initialized. Can't assign value to a constant twice.",
-			2},
+			2, 1},
 	}
 
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -160,6 +160,75 @@ func TestArgumentError(t *testing.T) {
 	}
 }
 
+func TestKeywordArgumentError(t *testing.T) {
+	tests := []errorTestCase{
+		{`def foo(x:)
+		  x
+		end
+
+		foo
+		`,
+			"ArgumentError: Method foo requires key argument x",
+			5},
+		{`def foo
+		  10
+		end
+
+		foo(y: 1)
+		`,
+			"ArgumentError: Expect at most 0 args for method 'foo'. got: 1",
+			5},
+		{`def foo(x)
+		  x
+		end
+
+		foo(y: 1)
+		`,
+			"ArgumentError: unknown key y for method foo",
+			5},
+		{`def foo(x = 10)
+		  x
+		end
+
+		foo(y: 1)
+		`,
+			"ArgumentError: unknown key y for method foo",
+			5},
+		{`def foo(x:)
+		  x
+		end
+
+		foo(y: 1)
+		`,
+			"ArgumentError: Method foo requires key argument x",
+			5},
+		{`def foo(x: 10)
+		  x
+		end
+
+		foo(y: 1)
+		`,
+			"ArgumentError: unknown key y for method foo",
+			5},
+		{`def foo(x: 10)
+		  x
+		end
+
+		foo(y: 1, x: 100)
+		`,
+			"ArgumentError: Expect at most 1 args for method 'foo'. got: 2",
+			5},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, 1)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestConstantAlreadyInitializedError(t *testing.T) {
 	tests := []errorTestCase{
 		{`Foo = 10
@@ -188,7 +257,7 @@ func TestConstantAlreadyInitializedError(t *testing.T) {
 func checkError(t *testing.T, index int, evaluated Object, expectedErrMsg, fn string, line int) {
 	err, ok := evaluated.(*Error)
 	if !ok {
-		t.Errorf("At test case %d: Expect Error. got=%T (%+v)", index, evaluated, evaluated)
+		t.Fatalf("At test case %d: Expect Error. got=%T (%+v)", index, evaluated, evaluated)
 	}
 
 	expectedErrMsg = fmt.Sprintf("%s. At %s:%d", expectedErrMsg, fn, line)

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -2027,11 +2027,11 @@ func TestUnusedVariableFail(t *testing.T) {
 		{`
 		_ = 1
 		_
-		`, "UndefinedMethodError: Undefined Method '_' for <Instance of: Object>", 3},
+		`, "UndefinedMethodError: Undefined Method '_' for <Instance of: Object>", 3, 1},
 		{`
 		_, b = [1, 2]
 		_
-		`, "UndefinedMethodError: Undefined Method '_' for <Instance of: Object>", 3},
+		`, "UndefinedMethodError: Undefined Method '_' for <Instance of: Object>", 3, 1},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/file.go
+++ b/vm/file.go
@@ -65,7 +65,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 
 						err := os.Chmod(filename, os.FileMode(uint32(filemod)))
 						if err != nil {
-							return t.vm.initErrorObject(errors.InternalError, err.Error())
+							return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 						}
 					}
 
@@ -82,7 +82,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 						err := os.Remove(filename)
 
 						if err != nil {
-							return t.vm.initErrorObject(errors.InternalError, err.Error())
+							return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 						}
 					}
 
@@ -157,7 +157,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 					var perm os.FileMode
 
 					if len(args) < 1 {
-						return t.vm.initErrorObject(errors.InternalError, "Expect at least a filename to open file")
+						return t.vm.initErrorObject(errors.InternalError, instruction, "Expect at least a filename to open file")
 					}
 
 					if len(args) >= 1 {
@@ -170,7 +170,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 							md, ok := fileModeTable[m]
 
 							if !ok {
-								return t.vm.initErrorObject(errors.InternalError, "Unknown file mode: %s", m)
+								return t.vm.initErrorObject(errors.InternalError, instruction, "Unknown file mode: %s", m)
 							}
 
 							if md == syscall.O_RDWR || md == syscall.O_WRONLY {
@@ -190,7 +190,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 					f, err := os.OpenFile(fn, mode, perm)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					// TODO: Refactor this class retrieval mess
@@ -218,7 +218,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 
 					fileStats, err := os.Stat(filename)
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return t.vm.initIntegerObject(int(fileStats.Size()))
@@ -291,7 +291,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return t.vm.initStringObject(result)
@@ -312,7 +312,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 
 					fileStats, err := os.Stat(file.Name())
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return t.vm.initIntegerObject(int(fileStats.Size()))
@@ -328,7 +328,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 					length, err := file.Write([]byte(data))
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return t.vm.initIntegerObject(length)

--- a/vm/file.go
+++ b/vm/file.go
@@ -36,7 +36,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @param filepath [String]
 			// @return [String]
 			Name: "basename",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					filename := args[0].(*StringObject).value
 					return t.vm.initStringObject(filepath.Base(filename))
@@ -54,7 +54,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @param filename [String]
 			// @return [Integer]
 			Name: "chmod",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					filemod := args[0].(*IntegerObject).value
 					for i := 1; i < len(args); i++ {
@@ -75,7 +75,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "delete",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					for _, arg := range args {
 						filename := arg.(*StringObject).value
@@ -92,7 +92,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "exist?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					filename := args[0].(*StringObject).value
 					_, err := os.Stat(filename)
@@ -114,7 +114,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @param filename [String]
 			// @return [String]
 			Name: "extname",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					filename := args[0].(*StringObject).value
 					return t.vm.initStringObject(filepath.Ext(filename))
@@ -129,7 +129,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [String]
 			Name: "join",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					var elements []string
 					for i := 0; i < len(args); i++ {
@@ -150,7 +150,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @param filename [String]
 			// @return [File]
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					var fn string
 					var mode int
@@ -209,7 +209,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @param filename [String]
 			// @return [Integer]
 			Name: "size",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					filename := args[0].(*StringObject).value
 					if !filepath.IsAbs(filename) {
@@ -234,7 +234,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @param filepath [String]
 			// @return [Array]
 			Name: "split",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					filename := args[0].(*StringObject).value
 					dir, file := filepath.Split(filename)
@@ -254,7 +254,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "close",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					file := receiver.(*FileObject).File
 					file.Close()
@@ -265,7 +265,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "name",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					name := receiver.(*FileObject).File.Name()
 					return t.vm.initStringObject(name)
@@ -274,7 +274,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "read",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					var result string
 					var f []byte
@@ -306,7 +306,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "size",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					file := receiver.(*FileObject).File
 
@@ -321,7 +321,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "write",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					file := receiver.(*FileObject).File
 					data := args[0].(*StringObject).value

--- a/vm/file.go
+++ b/vm/file.go
@@ -37,7 +37,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "basename",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					filename := args[0].(*StringObject).value
 					return t.vm.initStringObject(filepath.Base(filename))
 				}
@@ -55,7 +55,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "chmod",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					filemod := args[0].(*IntegerObject).value
 					for i := 1; i < len(args); i++ {
 						filename := args[i].(*StringObject).value
@@ -76,7 +76,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "delete",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					for _, arg := range args {
 						filename := arg.(*StringObject).value
 						err := os.Remove(filename)
@@ -93,7 +93,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "exist?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					filename := args[0].(*StringObject).value
 					_, err := os.Stat(filename)
 
@@ -115,7 +115,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "extname",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					filename := args[0].(*StringObject).value
 					return t.vm.initStringObject(filepath.Ext(filename))
 				}
@@ -130,7 +130,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "join",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					var elements []string
 					for i := 0; i < len(args); i++ {
 						next := args[i].(*StringObject).value
@@ -151,7 +151,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @return [File]
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					var fn string
 					var mode int
 					var perm os.FileMode
@@ -210,7 +210,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "size",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					filename := args[0].(*StringObject).value
 					if !filepath.IsAbs(filename) {
 						filename = filepath.Join(t.vm.fileDir, filename)
@@ -235,7 +235,7 @@ func builtinFileClassMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "split",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					filename := args[0].(*StringObject).value
 					dir, file := filepath.Split(filename)
 
@@ -255,7 +255,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "close",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					file := receiver.(*FileObject).File
 					file.Close()
 
@@ -266,7 +266,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "name",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					name := receiver.(*FileObject).File.Name()
 					return t.vm.initStringObject(name)
 				}
@@ -275,7 +275,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "read",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					var result string
 					var f []byte
 					var err error
@@ -307,7 +307,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "size",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					file := receiver.(*FileObject).File
 
 					fileStats, err := os.Stat(file.Name())
@@ -322,7 +322,7 @@ func builtinFileInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "write",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					file := receiver.(*FileObject).File
 					data := args[0].(*StringObject).value
 					length, err := file.Write([]byte(data))

--- a/vm/float.go
+++ b/vm/float.go
@@ -29,7 +29,7 @@ func builtinFloatClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					return t.unsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
 		},

--- a/vm/float.go
+++ b/vm/float.go
@@ -28,7 +28,7 @@ func builtinFloatClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
@@ -48,7 +48,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Float]
 			Name: "+",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) float64 {
 						return leftValue + rightValue
 					}
@@ -66,7 +66,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Float]
 			Name: "%",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) float64 {
 						return math.Mod(leftValue, rightValue)
 					}
@@ -84,7 +84,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Float]
 			Name: "-",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) float64 {
 						return leftValue - rightValue
 					}
@@ -102,7 +102,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Float]
 			Name: "*",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) float64 {
 						return leftValue * rightValue
 					}
@@ -120,7 +120,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Float]
 			Name: "**",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) float64 {
 						return math.Pow(leftValue, rightValue)
 					}
@@ -138,7 +138,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Float]
 			Name: "/",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) float64 {
 						return leftValue / rightValue
 					}
@@ -157,7 +157,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: ">",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) bool {
 						return leftValue > rightValue
 					}
@@ -176,7 +176,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: ">=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) bool {
 						return leftValue >= rightValue
 					}
@@ -195,7 +195,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "<",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) bool {
 						return leftValue < rightValue
 					}
@@ -214,7 +214,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "<=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) bool {
 						return leftValue <= rightValue
 					}
@@ -234,7 +234,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Float]
 			Name: "<=>",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					rightNumeric, ok := args[0].(Numeric)
 
 					if !ok {
@@ -268,7 +268,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					result := receiver.(*FloatObject).equalityTest(args[0])
 
 					return toBooleanObject(result)
@@ -288,7 +288,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "!=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					result := !receiver.(*FloatObject).equalityTest(args[0])
 
 					return toBooleanObject(result)
@@ -304,7 +304,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "to_i",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*FloatObject)
 					newInt := t.vm.initIntegerObject(int(r.value))
 					newInt.flag = i
@@ -315,7 +315,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "ptr",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*FloatObject)
 					return t.vm.initGoObject(&r.value)
 				}

--- a/vm/float.go
+++ b/vm/float.go
@@ -29,7 +29,7 @@ func builtinFloatClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.initUnsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError(instruction, "#new", receiver)
 				}
 			},
 		},
@@ -53,7 +53,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return leftValue + rightValue
 					}
 
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, instruction)
 				}
 			},
 		},
@@ -71,7 +71,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return math.Mod(leftValue, rightValue)
 					}
 
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, instruction)
 				}
 			},
 		},
@@ -89,7 +89,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return leftValue - rightValue
 					}
 
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, instruction)
 				}
 			},
 		},
@@ -107,7 +107,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return leftValue * rightValue
 					}
 
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, instruction)
 				}
 			},
 		},
@@ -125,7 +125,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return math.Pow(leftValue, rightValue)
 					}
 
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, instruction)
 				}
 			},
 		},
@@ -143,7 +143,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return leftValue / rightValue
 					}
 
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, instruction)
 				}
 			},
 		},
@@ -162,7 +162,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return leftValue > rightValue
 					}
 
-					return receiver.(*FloatObject).numericComparison(t, args[0], operation)
+					return receiver.(*FloatObject).numericComparison(t, args[0], operation, instruction)
 				}
 			},
 		},
@@ -181,7 +181,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return leftValue >= rightValue
 					}
 
-					return receiver.(*FloatObject).numericComparison(t, args[0], operation)
+					return receiver.(*FloatObject).numericComparison(t, args[0], operation, instruction)
 				}
 			},
 		},
@@ -200,7 +200,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return leftValue < rightValue
 					}
 
-					return receiver.(*FloatObject).numericComparison(t, args[0], operation)
+					return receiver.(*FloatObject).numericComparison(t, args[0], operation, instruction)
 				}
 			},
 		},
@@ -219,7 +219,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return leftValue <= rightValue
 					}
 
-					return receiver.(*FloatObject).numericComparison(t, args[0], operation)
+					return receiver.(*FloatObject).numericComparison(t, args[0], operation, instruction)
 				}
 			},
 		},
@@ -238,7 +238,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 					rightNumeric, ok := args[0].(Numeric)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
 					}
 
 					leftValue := receiver.(*FloatObject).value
@@ -354,12 +354,13 @@ func (f *FloatObject) floatValue() float64 {
 	return f.value
 }
 
+// TODO: Remove instruction argument
 // Apply the passed arithmetic operation, while performing type conversion.
-func (f *FloatObject) arithmeticOperation(t *thread, rightObject Object, operation func(leftValue float64, rightValue float64) float64) Object {
+func (f *FloatObject) arithmeticOperation(t *thread, rightObject Object, operation func(leftValue float64, rightValue float64) float64, instruction *instruction) Object {
 	rightNumeric, ok := rightObject.(Numeric)
 
 	if !ok {
-		return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", rightObject.Class().Name)
+		return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, "Numeric", rightObject.Class().Name)
 	}
 
 	leftValue := f.value
@@ -385,12 +386,13 @@ func (f *FloatObject) equalityTest(rightObject Object) bool {
 	return leftValue == rightValue
 }
 
+// TODO: Remove instruction argument
 // Apply the passed numeric comparison, while performing type conversion.
-func (f *FloatObject) numericComparison(t *thread, rightObject Object, operation func(leftValue float64, rightValue float64) bool) Object {
+func (f *FloatObject) numericComparison(t *thread, rightObject Object, operation func(leftValue float64, rightValue float64) bool, instruction *instruction) Object {
 	rightNumeric, ok := rightObject.(Numeric)
 
 	if !ok {
-		return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "Numeric", rightObject.Class().Name)
+		return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, "Numeric", rightObject.Class().Name)
 	}
 
 	leftValue := f.value

--- a/vm/float.go
+++ b/vm/float.go
@@ -27,7 +27,7 @@ func builtinFloatClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
@@ -47,7 +47,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "+",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) float64 {
 						return leftValue + rightValue
@@ -65,7 +65,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "%",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) float64 {
 						return math.Mod(leftValue, rightValue)
@@ -83,7 +83,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "-",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) float64 {
 						return leftValue - rightValue
@@ -101,7 +101,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "*",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) float64 {
 						return leftValue * rightValue
@@ -119,7 +119,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "**",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) float64 {
 						return math.Pow(leftValue, rightValue)
@@ -137,7 +137,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "/",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) float64 {
 						return leftValue / rightValue
@@ -156,7 +156,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: ">",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) bool {
 						return leftValue > rightValue
@@ -175,7 +175,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: ">=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) bool {
 						return leftValue >= rightValue
@@ -194,7 +194,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "<",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) bool {
 						return leftValue < rightValue
@@ -213,7 +213,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "<=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					operation := func(leftValue float64, rightValue float64) bool {
 						return leftValue <= rightValue
@@ -233,7 +233,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "<=>",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					rightNumeric, ok := args[0].(Numeric)
 
@@ -267,7 +267,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "==",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					result := receiver.(*FloatObject).equalityTest(args[0])
 
@@ -287,7 +287,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "!=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					result := !receiver.(*FloatObject).equalityTest(args[0])
 
@@ -303,7 +303,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "to_i",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*FloatObject)
 					newInt := t.vm.initIntegerObject(int(r.value))
@@ -314,7 +314,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "ptr",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*FloatObject)
 					return t.vm.initGoObject(&r.value)

--- a/vm/float_test.go
+++ b/vm/float_test.go
@@ -68,17 +68,17 @@ func TestFloatArithmeticOperationWithInteger(t *testing.T) {
 
 func TestFloatArithmeticOperationFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`'1'.to_f + "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`'1'.to_f - "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`'1'.to_f ** "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`'1'.to_f / "t"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`'1'.to_f + "p"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`'1'.to_f - "m"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`'1'.to_f ** "p"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`'1'.to_f / "t"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -147,18 +147,18 @@ func TestFloatComparisonWithInteger(t *testing.T) {
 
 func TestFloatComparisonFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`'1'.to_f > "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`'1'.to_f >= "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`'1'.to_f < "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`'1'.to_f <= "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`'1'.to_f <=> "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`'1'.to_f > "m"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`'1'.to_f >= "m"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`'1'.to_f < "m"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`'1'.to_f <= "m"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`'1'.to_f <=> "m"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/go_map.go
+++ b/vm/go_map.go
@@ -34,7 +34,7 @@ func builtinGoMapClassMethods() []*BuiltinMethodObject {
 					hash, ok := args[0].(*HashObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.HashClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.HashClass, args[0].Class().Name)
 					}
 
 					for k, v := range hash.Pairs {
@@ -56,7 +56,7 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					m := receiver.(*GoMap)
@@ -77,13 +77,13 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got: %d", len(args))
 					}
 
 					key, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
 
 					m := receiver.(*GoMap).data
@@ -109,13 +109,13 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 2 argument. got: %d", len(args))
 					}
 
 					key, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
 
 					m := receiver.(*GoMap).data

--- a/vm/go_map.go
+++ b/vm/go_map.go
@@ -24,7 +24,7 @@ func builtinGoMapClassMethods() []*BuiltinMethodObject {
 			// @return [GoMap]
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					m := make(map[string]interface{})
 
 					if len(args) == 0 {
@@ -54,7 +54,7 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_hash",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -75,7 +75,7 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "get",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
 					}
@@ -107,7 +107,7 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "set",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 argument. got: %d", len(args))
 					}

--- a/vm/go_map.go
+++ b/vm/go_map.go
@@ -23,7 +23,7 @@ func builtinGoMapClassMethods() []*BuiltinMethodObject {
 			//
 			// @return [GoMap]
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					m := make(map[string]interface{})
 
@@ -53,7 +53,7 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "to_hash",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -74,7 +74,7 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "get",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
@@ -106,7 +106,7 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "set",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 argument. got: %d", len(args))

--- a/vm/go_object.go
+++ b/vm/go_object.go
@@ -29,7 +29,7 @@ func builtinGoObjectInstanceMethods() []*BuiltinMethodObject {
 					s, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
 
 					funcName := s.value
@@ -38,7 +38,7 @@ func builtinGoObjectInstanceMethods() []*BuiltinMethodObject {
 					funcArgs, err := convertToGoFuncArgs(args[1:])
 
 					if err != nil {
-						t.vm.initErrorObject(errors.TypeError, err.Error())
+						t.vm.initErrorObject(errors.TypeError, instruction, err.Error())
 					}
 
 					result := metago.CallFunc(r.data, funcName, funcArgs...)

--- a/vm/go_object.go
+++ b/vm/go_object.go
@@ -24,7 +24,7 @@ func builtinGoObjectInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "go_func",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					s, ok := args[0].(*StringObject)
 

--- a/vm/go_object.go
+++ b/vm/go_object.go
@@ -25,7 +25,7 @@ func builtinGoObjectInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "go_func",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					s, ok := args[0].(*StringObject)
 
 					if !ok {

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -52,7 +52,7 @@ func builtinHashClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
@@ -86,7 +86,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Object]
 			Name: "[]",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 1 {
@@ -130,7 +130,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Object] The value
 			Name: "[]=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					// First arg is index
@@ -180,7 +180,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// end            # => false
 			// ```
 			Name: "any?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -225,7 +225,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "clear",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -251,7 +251,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Object]
 			Name: "default",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expected 0 argument, got: %d", len(args))
@@ -281,7 +281,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Object]
 			Name: "default=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1 argument, got %d", len(args))
@@ -313,7 +313,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Hash]
 			Name: "delete",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
@@ -350,7 +350,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Hash]
 			Name: "delete_if",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -400,7 +400,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Object]
 			Name: "dig",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) == 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1+ arguments, got 0")
@@ -429,7 +429,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Hash]
 			Name: "each",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 arguments. got: %d", len(args))
@@ -475,7 +475,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "each_key",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -520,7 +520,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			//
 			Name: "each_value",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -559,7 +559,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "empty?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -582,7 +582,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "eql?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
@@ -615,7 +615,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Object]
 			Name: "fetch",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if !(len(args) == 1 || len(args) == 2) {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1 or 2 arguments, got %d", len(args))
@@ -667,7 +667,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "has_key?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
@@ -702,7 +702,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "has_value?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
@@ -729,7 +729,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "keys",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -754,7 +754,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "length",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -780,7 +780,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "map_values",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -815,7 +815,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Hash]
 			Name: "merge",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument. got: %d", len(args))
@@ -862,7 +862,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// end            # => { }
 			// ```
 			Name: "select",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -914,7 +914,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "sorted_keys",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -947,7 +947,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "to_a",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					h := receiver.(*HashObject)
@@ -997,7 +997,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "to_json",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -1019,7 +1019,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "to_s",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -1046,7 +1046,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "transform_values",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -1081,7 +1081,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "values",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
@@ -1105,7 +1105,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "values_at",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					hash := receiver.(*HashObject)
 					var result []Object

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -54,7 +54,7 @@ func builtinHashClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					return t.unsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
 		},

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -54,7 +54,7 @@ func builtinHashClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.initUnsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError(instruction, "#new", receiver)
 				}
 			},
 		},
@@ -90,14 +90,14 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got: %d", len(args))
 					}
 
 					i := args[0]
 					key, ok := i.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
 					}
 
 					h := receiver.(*HashObject)
@@ -136,14 +136,14 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 					// First arg is index
 					// Second arg is assigned value
 					if len(args) != 2 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 2 arguments. got: %d", len(args))
 					}
 
 					k := args[0]
 					key, ok := k.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, k.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, k.Class().Name)
 					}
 
 					h := receiver.(*HashObject)
@@ -183,11 +183,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					hash := receiver.(*HashObject)
@@ -228,7 +228,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					h := receiver.(*HashObject)
@@ -254,7 +254,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expected 0 argument, got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expected 0 argument, got: %d", len(args))
 					}
 
 					hash := receiver.(*HashObject)
@@ -284,14 +284,14 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1 argument, got %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expected 1 argument, got %d", len(args))
 					}
 
 					// Arrays and Hashes are generally a mistake, since a single instance would be used for all the accesses
 					// via default.
 					switch args[0].(type) {
 					case *HashObject, *ArrayObject:
-						return t.vm.initErrorObject(errors.ArgumentError, "Arrays and Hashes are not accepted as default values")
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Arrays and Hashes are not accepted as default values")
 					}
 
 					hash := receiver.(*HashObject)
@@ -316,7 +316,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got: %d", len(args))
 					}
 
 					h := receiver.(*HashObject)
@@ -324,7 +324,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 					deleteKey, ok := d.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, d.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, d.Class().Name)
 					}
 
 					deleteKeyValue := deleteKey.value
@@ -353,11 +353,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					hash := receiver.(*HashObject)
@@ -403,11 +403,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) == 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1+ arguments, got 0")
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expected 1+ arguments, got 0")
 					}
 
 					hash := receiver.(*HashObject)
-					value := hash.dig(t, args)
+					value := hash.dig(t, args, instruction)
 
 					return value
 				}
@@ -432,11 +432,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 arguments. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 arguments. got: %d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					h := receiver.(*HashObject)
@@ -478,11 +478,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					h := receiver.(*HashObject)
@@ -523,11 +523,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					h := receiver.(*HashObject)
@@ -562,7 +562,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					h := receiver.(*HashObject)
@@ -585,7 +585,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got: %d", len(args))
 					}
 
 					h := receiver.(*HashObject)
@@ -618,16 +618,16 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if !(len(args) == 1 || len(args) == 2) {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1 or 2 arguments, got %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expected 1 or 2 arguments, got %d", len(args))
 					} else if len(args) == 2 && blockFrame != nil {
-						return t.vm.initErrorObject(errors.ArgumentError, "The default argument can't be passed along with a block")
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "The default argument can't be passed along with a block")
 					}
 
 					hash := receiver.(*HashObject)
 					key, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, key.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, key.Class().Name)
 					}
 
 					value, ok := hash.Pairs[key.value]
@@ -648,7 +648,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 						return t.builtinMethodYield(blockFrame, key).Target
 					}
 
-					return t.vm.initErrorObject(errors.ArgumentError, "The value was not found, and no block has been provided")
+					return t.vm.initErrorObject(errors.ArgumentError, instruction, "The value was not found, and no block has been provided")
 				}
 			},
 		},
@@ -670,7 +670,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got: %d", len(args))
 					}
 
 					h := receiver.(*HashObject)
@@ -678,7 +678,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 					input, ok := i.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
 					}
 
 					if _, ok := h.Pairs[input.value]; ok {
@@ -705,7 +705,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got: %d", len(args))
 					}
 
 					h := receiver.(*HashObject)
@@ -732,7 +732,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					h := receiver.(*HashObject)
@@ -757,7 +757,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					h := receiver.(*HashObject)
@@ -783,11 +783,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					h := receiver.(*HashObject)
@@ -818,7 +818,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect at least 1 argument. got: %d", len(args))
 					}
 
 					h := receiver.(*HashObject)
@@ -830,7 +830,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 					for _, obj := range args {
 						hashObj, ok := obj.(*HashObject)
 						if !ok {
-							return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.HashClass, obj.Class().Name)
+							return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.HashClass, obj.Class().Name)
 						}
 						for k, v := range hashObj.Pairs {
 							result[k] = v
@@ -865,11 +865,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					sourceHash := receiver.(*HashObject)
@@ -917,7 +917,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					h := receiver.(*HashObject)
@@ -956,12 +956,12 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 					if len(args) == 0 {
 						sorted = false
 					} else if len(args) > 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0..1 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0..1 argument. got: %d", len(args))
 					} else {
 						s := args[0]
 						st, ok := s.(*BooleanObject)
 						if !ok {
-							return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.BooleanClass, s.Class().Name)
+							return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.BooleanClass, s.Class().Name)
 						}
 						sorted = st.value
 					}
@@ -1000,7 +1000,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					r := receiver.(*HashObject)
@@ -1022,7 +1022,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					h := receiver.(*HashObject)
@@ -1049,11 +1049,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					h := receiver.(*HashObject)
@@ -1084,7 +1084,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 
 					h := receiver.(*HashObject)
@@ -1114,7 +1114,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 						stringObjectKey, ok := objectKey.(*StringObject)
 
 						if !ok {
-							return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, objectKey.Class().Name)
+							return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, objectKey.Class().Name)
 						}
 
 						value, ok := hash.Pairs[stringObjectKey.value]
@@ -1226,13 +1226,14 @@ func (h *HashObject) copy() Object {
 	return newHash
 }
 
+// TODO: Remove instruction argument
 // recursive indexed access - see ArrayObject#dig documentation.
-func (h *HashObject) dig(t *thread, keys []Object) Object {
+func (h *HashObject) dig(t *thread, keys []Object, instruction *instruction) Object {
 	currentKey := keys[0]
 	stringCurrentKey, ok := currentKey.(*StringObject)
 
 	if !ok {
-		return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, currentKey.Class().Name)
+		return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, currentKey.Class().Name)
 	}
 
 	nextKeys := keys[1:]
@@ -1249,10 +1250,10 @@ func (h *HashObject) dig(t *thread, keys []Object) Object {
 	diggableCurrentValue, ok := currentValue.(Diggable)
 
 	if !ok {
-		return t.vm.initErrorObject(errors.TypeError, "Expect target to be Diggable, got %s", currentValue.Class().Name)
+		return t.vm.initErrorObject(errors.TypeError, instruction, "Expect target to be Diggable, got %s", currentValue.Class().Name)
 	}
 
-	return diggableCurrentValue.dig(t, nextKeys)
+	return diggableCurrentValue.dig(t, nextKeys, instruction)
 }
 
 // Other helper functions ----------------------------------------------

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -53,7 +53,7 @@ func builtinHashClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
@@ -87,7 +87,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "[]",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
@@ -131,7 +131,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object] The value
 			Name: "[]=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					// First arg is index
 					// Second arg is assigned value
@@ -181,7 +181,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "any?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -226,7 +226,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "clear",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -252,7 +252,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "default",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expected 0 argument, got: %d", len(args))
 					}
@@ -282,7 +282,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "default=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1 argument, got %d", len(args))
 					}
@@ -314,7 +314,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "delete",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
 					}
@@ -351,7 +351,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "delete_if",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -401,7 +401,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "dig",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) == 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1+ arguments, got 0")
 					}
@@ -430,7 +430,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "each",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 arguments. got: %d", len(args))
 					}
@@ -476,7 +476,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "each_key",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -521,7 +521,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			Name: "each_value",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -560,7 +560,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "empty?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -583,7 +583,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "eql?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
 					}
@@ -616,7 +616,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "fetch",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if !(len(args) == 1 || len(args) == 2) {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expected 1 or 2 arguments, got %d", len(args))
 					} else if len(args) == 2 && blockFrame != nil {
@@ -668,7 +668,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "has_key?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
 					}
@@ -703,7 +703,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "has_value?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
 					}
@@ -730,7 +730,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "keys",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -755,7 +755,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "length",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -781,7 +781,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "map_values",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -816,7 +816,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "merge",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument. got: %d", len(args))
 					}
@@ -863,7 +863,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "select",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -915,7 +915,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "sorted_keys",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -948,7 +948,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "to_a",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					h := receiver.(*HashObject)
 					var sorted bool
@@ -998,7 +998,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_json",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -1020,7 +1020,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_s",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -1047,7 +1047,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "transform_values",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -1082,7 +1082,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "values",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}
@@ -1106,7 +1106,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "values_at",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					hash := receiver.(*HashObject)
 					var result []Object
 

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -181,16 +181,16 @@ func TestHashAccessWithDefaultOperation(t *testing.T) {
 
 func TestHashAccessOperationFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }[]`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`{ a: 1, b: 2 }[true]`, "TypeError: Expect argument to be String. got: Boolean", 1},
-		{`{ a: 1, b: 2 }[true] = 1`, "TypeError: Expect argument to be String. got: Boolean", 1},
+		{`{ a: 1, b: 2 }[]`, "ArgumentError: Expect 1 argument. got: 0", 1, 1},
+		{`{ a: 1, b: 2 }[true]`, "TypeError: Expect argument to be String. got: Boolean", 1, 1},
+		{`{ a: 1, b: 2 }[true] = 1`, "TypeError: Expect argument to be String. got: Boolean", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -282,15 +282,15 @@ func TestHashAnyMethod(t *testing.T) {
 
 func TestHashAnyMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{  }.any?(123) do end`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{  }.any?`, "InternalError: Can't yield without a block", 1},
+		{`{  }.any?(123) do end`, "ArgumentError: Expect 0 argument. got: 1", 1, 2},
+		{`{  }.any?`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -324,15 +324,15 @@ func TestHashClearMethod(t *testing.T) {
 
 func TestHashClearMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.clear(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.clear(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.clear(123)`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`{ a: 1, b: 2 }.clear(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -364,16 +364,16 @@ func TestHashDefaultOperation(t *testing.T) {
 
 func TestHashDefaultSetOperationFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ }.default = *[1, 2]`, "ArgumentError: Expected 1 argument, got 2", 1},
-		{`{ }.default = []`, "ArgumentError: Arrays and Hashes are not accepted as default values", 1},
-		{`{ }.default = {}`, "ArgumentError: Arrays and Hashes are not accepted as default values", 1},
+		{`{ }.default = *[1, 2]`, "ArgumentError: Expected 1 argument, got 2", 1, 1},
+		{`{ }.default = []`, "ArgumentError: Arrays and Hashes are not accepted as default values", 1, 1},
+		{`{ }.default = {}`, "ArgumentError: Arrays and Hashes are not accepted as default values", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -432,17 +432,17 @@ func TestHashDeleteMethod(t *testing.T) {
 
 func TestHashDeleteMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: "Hello", c: true }.delete`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`{ a: 1, b: "Hello", c: true }.delete("a", "b")`, "ArgumentError: Expect 1 argument. got: 2", 1},
-		{`{ a: 1, b: "Hello", c: true }.delete(123)`, "TypeError: Expect argument to be String. got: Integer", 1},
-		{`{ a: 1, b: "Hello", c: true }.delete(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
+		{`{ a: 1, b: "Hello", c: true }.delete`, "ArgumentError: Expect 1 argument. got: 0", 1, 1},
+		{`{ a: 1, b: "Hello", c: true }.delete("a", "b")`, "ArgumentError: Expect 1 argument. got: 2", 1, 1},
+		{`{ a: 1, b: "Hello", c: true }.delete(123)`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
+		{`{ a: 1, b: "Hello", c: true }.delete(true)`, "TypeError: Expect argument to be String. got: Boolean", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -488,15 +488,15 @@ func TestHashDeleteIfMethod(t *testing.T) {
 
 func TestHashDeleteIfMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ }.delete_if(123) do end`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ }.delete_if`, "InternalError: Can't yield without a block", 1},
+		{`{ }.delete_if(123) do end`, "ArgumentError: Expect 0 argument. got: 1", 1, 2},
+		{`{ }.delete_if`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -528,15 +528,15 @@ func TestHashDigMethod(t *testing.T) {
 
 func TestHashDigMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: [], b: 2 }.dig`, "ArgumentError: Expected 1+ arguments, got 0", 1},
-		{`{ a: 1, b: 2 }.dig(:a, :b)`, "TypeError: Expect target to be Diggable, got Integer", 1},
+		{`{ a: [], b: 2 }.dig`, "ArgumentError: Expected 1+ arguments, got 0", 1, 1},
+		{`{ a: 1, b: 2 }.dig(:a, :b)`, "TypeError: Expect target to be Diggable, got Integer", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -591,15 +591,15 @@ func TestHashEachMethod(t *testing.T) {
 func TestHashEachMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`{ a: 1, b: 2}.each("Hello") do end
-		`, "ArgumentError: Expect 0 arguments. got: 1", 1},
-		{`{ a: 1, b: 2}.each`, "InternalError: Can't yield without a block", 1},
+		`, "ArgumentError: Expect 0 arguments. got: 1", 1, 2},
+		{`{ a: 1, b: 2}.each`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -654,15 +654,15 @@ func TestHashEachKeyMethodFail(t *testing.T) {
 		{`{ a: 1, b: 2, c: 3 }.each_key("Hello") do |key|
 		  puts key
 		end
-		`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2, c: 3 }.each_key`, "InternalError: Can't yield without a block", 1},
+		`, "ArgumentError: Expect 0 argument. got: 1", 1, 2},
+		{`{ a: 1, b: 2, c: 3 }.each_key`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -750,15 +750,15 @@ func TestHashEachValueMethodFail(t *testing.T) {
 		{`{ a: 1, b: 2, c: 3 }.each_value("Hello") do |value|
 		  puts value
 		end
-		`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2, c: 3 }.each_value`, "InternalError: Can't yield without a block", 1},
+		`, "ArgumentError: Expect 0 argument. got: 1", 1, 2},
+		{`{ a: 1, b: 2, c: 3 }.each_value`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -783,15 +783,15 @@ func TestHashEmptyMethod(t *testing.T) {
 
 func TestHashEmptyMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.empty?(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.empty?(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.empty?(123)`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`{ a: 1, b: 2 }.empty?(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -826,15 +826,15 @@ func TestHashEqualMethod(t *testing.T) {
 
 func TestHashEqualMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.eql?`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`{ a: 1, b: 2 }.eql?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.eql?`, "ArgumentError: Expect 1 argument. got: 0", 1, 1},
+		{`{ a: 1, b: 2 }.eql?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -866,17 +866,17 @@ func TestHashFetchMethod(t *testing.T) {
 
 func TestHashFetchMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ spaghetti: "eat" }.fetch()`, "ArgumentError: Expected 1 or 2 arguments, got 0", 1},
-		{`{ spaghetti: "eat" }.fetch("a", "b", "c")`, "ArgumentError: Expected 1 or 2 arguments, got 3", 1},
-		{`{ spaghetti: "eat" }.fetch("a", "b") do end`, "ArgumentError: The default argument can't be passed along with a block", 1},
-		{`{ spaghetti: "eat" }.fetch("pizza")`, "ArgumentError: The value was not found, and no block has been provided", 1},
+		{`{ spaghetti: "eat" }.fetch()`, "ArgumentError: Expected 1 or 2 arguments, got 0", 1, 1},
+		{`{ spaghetti: "eat" }.fetch("a", "b", "c")`, "ArgumentError: Expected 1 or 2 arguments, got 3", 1, 1},
+		{`{ spaghetti: "eat" }.fetch("a", "b") do end`, "ArgumentError: The default argument can't be passed along with a block", 1, 2},
+		{`{ spaghetti: "eat" }.fetch("pizza")`, "ArgumentError: The value was not found, and no block has been provided", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -901,17 +901,17 @@ func TestHashHasKeyMethod(t *testing.T) {
 
 func TestHashHasKeyMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.has_key?`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`{ a: 1, b: 2 }.has_key?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 1},
-		{`{ a: 1, b: 2 }.has_key?(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
-		{`{ a: 1, b: 2 }.has_key?(123)`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`{ a: 1, b: 2 }.has_key?`, "ArgumentError: Expect 1 argument. got: 0", 1, 1},
+		{`{ a: 1, b: 2 }.has_key?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 1, 1},
+		{`{ a: 1, b: 2 }.has_key?(true)`, "TypeError: Expect argument to be String. got: Boolean", 1, 1},
+		{`{ a: 1, b: 2 }.has_key?(123)`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -941,15 +941,15 @@ func TestHashHasValueMethod(t *testing.T) {
 
 func TestHashHasValueMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.has_value?`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`{ a: 1, b: 2 }.has_value?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.has_value?`, "ArgumentError: Expect 1 argument. got: 0", 1, 1},
+		{`{ a: 1, b: 2 }.has_value?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -984,15 +984,15 @@ func TestHashKeysMethod(t *testing.T) {
 
 func TestHashKeysMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.keys(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.keys(123)`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`{ a: 1, b: 2 }.keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1021,15 +1021,15 @@ func TestHashLengthMethod(t *testing.T) {
 
 func TestHashLengthMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.length(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.length(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.length(123)`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`{ a: 1, b: 2 }.length(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1104,15 +1104,15 @@ func TestHashMapValuesMethodFail(t *testing.T) {
 		{`{ a: 1, b: 2, c: 3 }.map_values("Hello") do |value|
 		  value * 3
 		end
-		`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2, c: 3 }.map_values`, "InternalError: Can't yield without a block", 1},
+		`, "ArgumentError: Expect 0 argument. got: 1", 1, 2},
+		{`{ a: 1, b: 2, c: 3 }.map_values`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1152,16 +1152,16 @@ func TestHashMergeMethod(t *testing.T) {
 
 func TestHashMergeMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.merge`, "ArgumentError: Expect at least 1 argument. got: 0", 1},
-		{`{ a: 1, b: 2 }.merge(true, { hello: "World" })`, "TypeError: Expect argument to be Hash. got: Boolean", 1},
-		{`{ a: 1, b: 2 }.merge({ hello: "World" }, 123, "Hello")`, "TypeError: Expect argument to be Hash. got: Integer", 1},
+		{`{ a: 1, b: 2 }.merge`, "ArgumentError: Expect at least 1 argument. got: 0", 1, 1},
+		{`{ a: 1, b: 2 }.merge(true, { hello: "World" })`, "TypeError: Expect argument to be Hash. got: Boolean", 1, 1},
+		{`{ a: 1, b: 2 }.merge({ hello: "World" }, 123, "Hello")`, "TypeError: Expect argument to be Hash. got: Integer", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1234,30 +1234,30 @@ func TestHashSelectMethod(t *testing.T) {
 
 func TestHashSelectMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ }.select(123) do end`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ }.select`, "InternalError: Can't yield without a block", 1},
+		{`{ }.select(123) do end`, "ArgumentError: Expect 0 argument. got: 1", 1, 2},
+		{`{ }.select`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
 
 func TestHashSortedKeysMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.sorted_keys(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.sorted_keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.sorted_keys(123)`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`{ a: 1, b: 2 }.sorted_keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1320,15 +1320,15 @@ func TestHashToArrayMethod(t *testing.T) {
 
 func TestHashToArrayMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.to_a(true, { hello: "World" })`, "ArgumentError: Expect 0..1 argument. got: 2", 1},
-		{`{ a: 1, b: 2 }.to_a(123)`, "TypeError: Expect argument to be Boolean. got: Integer", 1},
+		{`{ a: 1, b: 2 }.to_a(true, { hello: "World" })`, "ArgumentError: Expect 0..1 argument. got: 2", 1, 1},
+		{`{ a: 1, b: 2 }.to_a(123)`, "TypeError: Expect argument to be Boolean. got: Integer", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1486,15 +1486,15 @@ func TestHashToJSONMethodWithBasicTypes(t *testing.T) {
 
 func TestHashToJSONMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.to_json(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.to_json(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.to_json(123)`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`{ a: 1, b: 2 }.to_json(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1520,15 +1520,15 @@ func TestHashToStringMethod(t *testing.T) {
 
 func TestHashToStringMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.to_s(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.to_s(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.to_s(123)`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`{ a: 1, b: 2 }.to_s(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1603,15 +1603,15 @@ func TestHashTransformValuesMethodFail(t *testing.T) {
 		{`{ a: 1, b: 2, c: 3 }.transform_values("Hello") do |value|
 		  value * 3
 		end
-		`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2, c: 3 }.transform_values`, "InternalError: Can't yield without a block", 1},
+		`, "ArgumentError: Expect 0 argument. got: 1", 1, 2},
+		{`{ a: 1, b: 2, c: 3 }.transform_values`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1649,15 +1649,15 @@ func TestHashValuesMethod(t *testing.T) {
 
 func TestHashValuesMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.values(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.values(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.values(123)`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
+		{`{ a: 1, b: 2 }.values(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1689,14 +1689,14 @@ func TestHashValuesAtMethod(t *testing.T) {
 
 func TestHashValuesAtMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.values_at(123)`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`{ a: 1, b: 2 }.values_at(123)`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/http.go
+++ b/vm/http.go
@@ -23,7 +23,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 		{
 			// Sends a GET request to the target and returns the HTTP response as a string. Will error on non-200 responses, for more control over http requests look at the `start` method.
 			Name: "get",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arg0, ok := args[0].(*StringObject)
 					if !ok {
@@ -67,7 +67,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 		}, {
 			// Sends a POST request to the target with type header and body. Returns the HTTP response as a string. Will error on non-200 responses, for more control over http requests look at the `start` method.
 			Name: "post",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 3 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 3, len(args))
@@ -112,7 +112,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 		}, {
 			// Sends a HEAD request to the target with type header and body. Returns the HTTP headers as a map[string]string. Will error on non-200 responses, for more control over http requests look at the `start` method.
 			Name: "head",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arg0, ok := args[0].(*StringObject)
 					if !ok {
@@ -155,7 +155,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 		}, {
 			// Starts an HTTP client. This method requires a block which takes a Net::HTTP::Client object. The return value of this method is the last evaluated value of the provided block.
 			Name: "start",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 0 {

--- a/vm/http.go
+++ b/vm/http.go
@@ -24,7 +24,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 			// Sends a GET request to the target and returns the HTTP response as a string. Will error on non-200 responses, for more control over http requests look at the `start` method.
 			Name: "get",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arg0, ok := args[0].(*StringObject)
 					if !ok {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
@@ -68,7 +68,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 			// Sends a POST request to the target with type header and body. Returns the HTTP response as a string. Will error on non-200 responses, for more control over http requests look at the `start` method.
 			Name: "post",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 3 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 3, len(args))
 					}
@@ -113,7 +113,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 			// Sends a HEAD request to the target with type header and body. Returns the HTTP headers as a map[string]string. Will error on non-200 responses, for more control over http requests look at the `start` method.
 			Name: "head",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arg0, ok := args[0].(*StringObject)
 					if !ok {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
@@ -156,7 +156,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 			// Starts an HTTP client. This method requires a block which takes a Net::HTTP::Client object. The return value of this method is the last evaluated value of the provided block.
 			Name: "start",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 arguments. got=%v", strconv.Itoa(len(args)))

--- a/vm/http.go
+++ b/vm/http.go
@@ -27,7 +27,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arg0, ok := args[0].(*StringObject)
 					if !ok {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
 					}
 
 					uri, err := url.Parse(arg0.value)
@@ -38,7 +38,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 						for i, v := range args[1:] {
 							argn, ok := v.(*StringObject)
 							if !ok {
-								return t.vm.initErrorObject(errors.ArgumentError, "Splat arguments must be a string, got: %s for argument %d", v.Class().Name, i)
+								return t.vm.initErrorObject(errors.ArgumentError, instruction, "Splat arguments must be a string, got: %s for argument %d", v.Class().Name, i)
 							}
 							arr = append(arr, argn.value)
 						}
@@ -48,17 +48,17 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 
 					resp, err := http.Get(uri.String())
 					if err != nil {
-						return t.vm.initErrorObject(errors.HTTPError, "Could not complete request, %s", err)
+						return t.vm.initErrorObject(errors.HTTPError, instruction, "Could not complete request, %s", err)
 					}
 					if resp.StatusCode != http.StatusOK {
-						return t.vm.initErrorObject(errors.HTTPError, "Non-200 response, %s (%d)", resp.Status, resp.StatusCode)
+						return t.vm.initErrorObject(errors.HTTPError, instruction, "Non-200 response, %s (%d)", resp.Status, resp.StatusCode)
 					}
 
 					content, err := ioutil.ReadAll(resp.Body)
 					resp.Body.Close()
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return t.vm.initStringObject(string(content))
@@ -70,40 +70,40 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 3 {
-						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 3, len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, errors.WrongNumberOfArgumentFormat, 3, len(args))
 					}
 
 					arg0, ok := args[0].(*StringObject)
 					if !ok {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
 					}
 					host := arg0.value
 
 					arg1, ok := args[1].(*StringObject)
 					if !ok {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect argument 1 to be string, got: %s", args[0].Class().Name)
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect argument 1 to be string, got: %s", args[0].Class().Name)
 					}
 					contentType := arg1.value
 
 					arg2, ok := args[2].(*StringObject)
 					if !ok {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect argument 2 to be string, got: %s", args[0].Class().Name)
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect argument 2 to be string, got: %s", args[0].Class().Name)
 					}
 					body := arg2.value
 
 					resp, err := http.Post(host, contentType, strings.NewReader(body))
 					if err != nil {
-						return t.vm.initErrorObject(errors.HTTPError, "Could not complete request, %s", err)
+						return t.vm.initErrorObject(errors.HTTPError, instruction, "Could not complete request, %s", err)
 					}
 					if resp.StatusCode != http.StatusOK {
-						return t.vm.initErrorObject(errors.HTTPError, "Non-200 response, %s (%d)", resp.Status, resp.StatusCode)
+						return t.vm.initErrorObject(errors.HTTPError, instruction, "Non-200 response, %s (%d)", resp.Status, resp.StatusCode)
 					}
 
 					content, err := ioutil.ReadAll(resp.Body)
 					resp.Body.Close()
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return t.vm.initStringObject(string(content))
@@ -116,7 +116,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					arg0, ok := args[0].(*StringObject)
 					if !ok {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
 					}
 
 					uri, err := url.Parse(arg0.value)
@@ -127,7 +127,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 						for i, v := range args[1:] {
 							argn, ok := v.(*StringObject)
 							if !ok {
-								return t.vm.initErrorObject(errors.ArgumentError, "Splat arguments must be a string, got: %s for argument %d", v.Class().Name, i)
+								return t.vm.initErrorObject(errors.ArgumentError, instruction, "Splat arguments must be a string, got: %s for argument %d", v.Class().Name, i)
 							}
 							arr = append(arr, argn.value)
 						}
@@ -137,10 +137,10 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 
 					resp, err := http.Head(uri.String())
 					if err != nil {
-						return t.vm.initErrorObject(errors.HTTPError, "Could not complete request, %s", err)
+						return t.vm.initErrorObject(errors.HTTPError, instruction, "Could not complete request, %s", err)
 					}
 					if resp.StatusCode != http.StatusOK {
-						return t.vm.initErrorObject(errors.HTTPError, "Non-200 response, %s (%d)", resp.Status, resp.StatusCode)
+						return t.vm.initErrorObject(errors.HTTPError, instruction, "Non-200 response, %s (%d)", resp.Status, resp.StatusCode)
 					}
 
 					ret := t.vm.initHashObject(map[string]Object{})
@@ -159,7 +159,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 arguments. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 arguments. got=%v", strconv.Itoa(len(args)))
 					}
 
 					gobyClient := httpClientClass.initializeInstance()

--- a/vm/http_client.go
+++ b/vm/http_client.go
@@ -21,7 +21,7 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Sends a GET request to the target and returns a `Net::HTTP::Response` object.
 			Name: "get",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 1, len(args))
 					}
@@ -48,7 +48,7 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Sends a POST request to the target and returns a `Net::HTTP::Response` object.
 			Name: "post",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 3 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 3, len(args))
 					}
@@ -87,7 +87,7 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Sends a HEAD request to the target and returns a `Net::HTTP::Response` object.
 			Name: "head",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 1, len(args))
 					}
@@ -114,7 +114,7 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Returns a blank `Net::HTTP::Request` object to be sent with the`exec` method
 			Name: "request",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return httpRequestClass.initializeInstance()
 				}
 			},
@@ -122,7 +122,7 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Sends a passed `Net::HTTP::Request` object and returns a `Net::HTTP::Response` object
 			Name: "exec",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 1, len(args))
 					}

--- a/vm/http_client.go
+++ b/vm/http_client.go
@@ -23,22 +23,22 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 1, len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, errors.WrongNumberOfArgumentFormat, 1, len(args))
 					}
 
 					u, ok := args[0].(*StringObject)
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
 					}
 
 					resp, err := goClient.Get(u.value)
 					if err != nil {
-						return t.vm.initErrorObject(errors.HTTPError, "Could not complete request, %s", err)
+						return t.vm.initErrorObject(errors.HTTPError, instruction, "Could not complete request, %s", err)
 					}
 
 					gobyResp, err := responseGoToGoby(t, resp)
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return gobyResp
@@ -50,34 +50,34 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 3 {
-						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 3, len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, errors.WrongNumberOfArgumentFormat, 3, len(args))
 					}
 
 					u, ok := args[0].(*StringObject)
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
 					}
 
 					contentType, ok := args[1].(*StringObject)
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
 					}
 
 					body, ok := args[2].(*StringObject)
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
 					}
 
 					bodyR := strings.NewReader(body.value)
 
 					resp, err := goClient.Post(u.value, contentType.value, bodyR)
 					if err != nil {
-						return t.vm.initErrorObject(errors.HTTPError, "Could not complete request, %s", err)
+						return t.vm.initErrorObject(errors.HTTPError, instruction, "Could not complete request, %s", err)
 					}
 
 					gobyResp, err := responseGoToGoby(t, resp)
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return gobyResp
@@ -89,22 +89,22 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 1, len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, errors.WrongNumberOfArgumentFormat, 1, len(args))
 					}
 
 					u, ok := args[0].(*StringObject)
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
 					}
 
 					resp, err := goClient.Head(u.value)
 					if err != nil {
-						return t.vm.initErrorObject(errors.HTTPError, "Could not complete request, %s", err)
+						return t.vm.initErrorObject(errors.HTTPError, instruction, "Could not complete request, %s", err)
 					}
 
 					gobyResp, err := responseGoToGoby(t, resp)
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return gobyResp
@@ -124,27 +124,27 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 1, len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, errors.WrongNumberOfArgumentFormat, 1, len(args))
 					}
 
 					if args[0].Class().Name != httpRequestClass.Name {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "HTTP Response", args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, "HTTP Response", args[0].Class().Name)
 					}
 
 					goReq, err := requestGobyToGo(args[0])
 					if err != nil {
-						return t.vm.initErrorObject(errors.ArgumentError, err.Error())
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, err.Error())
 					}
 
 					goResp, err := goClient.Do(goReq)
 					if err != nil {
-						return t.vm.initErrorObject(errors.HTTPError, "Could not complete request, %s", err)
+						return t.vm.initErrorObject(errors.HTTPError, instruction, "Could not complete request, %s", err)
 					}
 
 					gobyResp, err := responseGoToGoby(t, goResp)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return gobyResp

--- a/vm/http_client.go
+++ b/vm/http_client.go
@@ -20,7 +20,7 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 		{
 			// Sends a GET request to the target and returns a `Net::HTTP::Response` object.
 			Name: "get",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 1, len(args))
@@ -47,7 +47,7 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 		}, {
 			// Sends a POST request to the target and returns a `Net::HTTP::Response` object.
 			Name: "post",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 3 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 3, len(args))
@@ -86,7 +86,7 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 		}, {
 			// Sends a HEAD request to the target and returns a `Net::HTTP::Response` object.
 			Name: "head",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 1, len(args))
@@ -113,7 +113,7 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 		}, {
 			// Returns a blank `Net::HTTP::Request` object to be sent with the`exec` method
 			Name: "request",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return httpRequestClass.initializeInstance()
 				}
@@ -121,7 +121,7 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 		}, {
 			// Sends a passed `Net::HTTP::Request` object and returns a `Net::HTTP::Response` object
 			Name: "exec",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 1, len(args))

--- a/vm/http_client_test.go
+++ b/vm/http_client_test.go
@@ -89,7 +89,7 @@ func TestHTTPClientObjectFail(t *testing.T) {
 		end
 
 		res
-		`, "HTTPError: Could not complete request, Get http://127.0.0.1:3001: dial tcp 127.0.0.1:3001: getsockopt: connection refused", 5},
+		`, "HTTPError: Could not complete request, Get http://127.0.0.1:3001: dial tcp 127.0.0.1:3001: getsockopt: connection refused", 5, 4},
 		{`
 		require "net/http"
 
@@ -98,14 +98,14 @@ func TestHTTPClientObjectFail(t *testing.T) {
 		end
 
 		res
-		`, "HTTPError: Could not complete request, Get http://127.0.0.1:3001: dial tcp 127.0.0.1:3001: getsockopt: connection refused", 5},
+		`, "HTTPError: Could not complete request, Get http://127.0.0.1:3001: dial tcp 127.0.0.1:3001: getsockopt: connection refused", 5, 4},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 3)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/http_test.go
+++ b/vm/http_test.go
@@ -98,67 +98,67 @@ func TestHTTPObjectFail(t *testing.T) {
 		require "net/http"
 
 		Net::HTTP.get("http://127.0.0.1:3000/error")
-		`, "HTTPError: Non-200 response, 404 Not Found (404)", 4},
+		`, "HTTPError: Non-200 response, 404 Not Found (404)", 4, 1},
 		{`
 		require "net/http"
 
 		Net::HTTP.get("http://127.0.0.1:3001")
-		`, "HTTPError: Could not complete request, Get http://127.0.0.1:3001: dial tcp 127.0.0.1:3001: getsockopt: connection refused", 4},
+		`, "HTTPError: Could not complete request, Get http://127.0.0.1:3001: dial tcp 127.0.0.1:3001: getsockopt: connection refused", 4, 1},
 		//Argument errors for get()
 		{`
 		require "net/http"
 
 		Net::HTTP.get(42)
-		`, "ArgumentError: Expect argument 0 to be string, got: Integer", 4},
+		`, "ArgumentError: Expect argument 0 to be string, got: Integer", 4, 1},
 		{`
 		require "net/http"
 
 		Net::HTTP.get("http://127.0.0.1:3000/error", 40, 2)
-		`, "ArgumentError: Splat arguments must be a string, got: Integer for argument 0", 4},
+		`, "ArgumentError: Splat arguments must be a string, got: Integer for argument 0", 4, 1},
 		//HTTPErrors for post()
 		{`
 		require "net/http"
 
 		Net::HTTP.post("http://127.0.0.1:3000/error", "text/plain", "Let me down")
-		`, "HTTPError: Non-200 response, 404 Not Found (404)", 4},
+		`, "HTTPError: Non-200 response, 404 Not Found (404)", 4, 1},
 		{`
 		require "net/http"
 
 		Net::HTTP.post("http://127.0.0.1:3001", "text/plain", "Let me down")
-		`, "HTTPError: Could not complete request, Post http://127.0.0.1:3001: dial tcp 127.0.0.1:3001: getsockopt: connection refused", 4},
+		`, "HTTPError: Could not complete request, Post http://127.0.0.1:3001: dial tcp 127.0.0.1:3001: getsockopt: connection refused", 4, 1},
 		//Argument errors for post()
 		{`
 		require "net/http"
 
 		Net::HTTP.post("http://127.0.0.1:3001", "text/plain", "Let me down", "again")
-		`, "ArgumentError: Expect 3 arguments. got: 4", 4},
+		`, "ArgumentError: Expect 3 arguments. got: 4", 4, 1},
 		{`
 		require "net/http"
 
 		Net::HTTP.post(42, "text/plain", "Let me down")
-		`, "ArgumentError: Expect argument 0 to be string, got: Integer", 4},
+		`, "ArgumentError: Expect argument 0 to be string, got: Integer", 4, 1},
 		//HTTPErrors for head()
 		{`
 		require "net/http"
 
 		Net::HTTP.head("http://127.0.0.1:3000/error")
-		`, "HTTPError: Non-200 response, 404 Not Found (404)", 4},
+		`, "HTTPError: Non-200 response, 404 Not Found (404)", 4, 1},
 		{`
 		require "net/http"
 
 		Net::HTTP.head("http://127.0.0.1:3001")
-		`, "HTTPError: Could not complete request, Head http://127.0.0.1:3001: dial tcp 127.0.0.1:3001: getsockopt: connection refused", 4},
+		`, "HTTPError: Could not complete request, Head http://127.0.0.1:3001: dial tcp 127.0.0.1:3001: getsockopt: connection refused", 4, 1},
 		//Argument errors for head()
 		{`
 		require "net/http"
 
 		Net::HTTP.head(42)
-		`, "ArgumentError: Expect argument 0 to be string, got: Integer", 4},
+		`, "ArgumentError: Expect argument 0 to be string, got: Integer", 4, 1},
 		{`
 		require "net/http"
 
 		Net::HTTP.head("http://127.0.0.1:3000/error", 40, 2)
-		`, "ArgumentError: Splat arguments must be a string, got: Integer for argument 0", 4},
+		`, "ArgumentError: Splat arguments must be a string, got: Integer for argument 0", 4, 1},
 	}
 
 	//block until server is ready
@@ -168,7 +168,7 @@ func TestHTTPObjectFail(t *testing.T) {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/inspection_methods.go
+++ b/vm/inspection_methods.go
@@ -30,9 +30,9 @@ func (is *instructionSet) inspect() string {
 
 func (cf *goMethodCallFrame) inspect() string {
 	if cf.ep != nil {
-		return fmt.Sprintf("Name: %s. is block: %t. ep: %d", cf.method.Name, cf.isBlock, len(cf.ep.locals))
+		return fmt.Sprintf("Name: %s. is block: %t. ep: %d", cf.name, cf.isBlock, len(cf.ep.locals))
 	}
-	return fmt.Sprintf("Name: %s. is block: %t", cf.method.Name, cf.isBlock)
+	return fmt.Sprintf("Name: %s. is block: %t", cf.name, cf.isBlock)
 }
 
 func (cf *normalCallFrame) inspect() string {

--- a/vm/inspection_methods.go
+++ b/vm/inspection_methods.go
@@ -28,7 +28,14 @@ func (is *instructionSet) inspect() string {
 	return out.String()
 }
 
-func (cf *callFrame) inspect() string {
+func (cf *goMethodCallFrame) inspect() string {
+	if cf.ep != nil {
+		return fmt.Sprintf("Name: %s. is block: %t. ep: %d", cf.method.Name, cf.isBlock, len(cf.ep.locals))
+	}
+	return fmt.Sprintf("Name: %s. is block: %t", cf.method.Name, cf.isBlock)
+}
+
+func (cf *normalCallFrame) inspect() string {
 	if cf.ep != nil {
 		return fmt.Sprintf("Name: %s. is block: %t. ep: %d", cf.instructionSet.name, cf.isBlock, len(cf.ep.locals))
 	}

--- a/vm/inspection_methods.go
+++ b/vm/inspection_methods.go
@@ -29,17 +29,14 @@ func (is *instructionSet) inspect() string {
 }
 
 func (cf *goMethodCallFrame) inspect() string {
-	if cf.ep != nil {
-		return fmt.Sprintf("Name: %s. is block: %t. ep: %d", cf.name, cf.isBlock, len(cf.ep.locals))
-	}
-	return fmt.Sprintf("Name: %s. is block: %t", cf.name, cf.isBlock)
+	return fmt.Sprintf("Go method frame. File name: %s. Method name: %s.", cf.FileName(), cf.name)
 }
 
 func (cf *normalCallFrame) inspect() string {
 	if cf.ep != nil {
-		return fmt.Sprintf("Name: %s. is block: %t. ep: %d", cf.instructionSet.name, cf.isBlock, len(cf.ep.locals))
+		return fmt.Sprintf("Normal frame. File name: %s. IS name: %s. is block: %t. ep: %d", cf.FileName(), cf.instructionSet.name, cf.isBlock, len(cf.ep.locals))
 	}
-	return fmt.Sprintf("Name: %s. is block: %t", cf.instructionSet.name, cf.isBlock)
+	return fmt.Sprintf("Normal frame. File name: %s. IS name: %s. is block: %t", cf.FileName(), cf.instructionSet.name, cf.isBlock)
 }
 
 func (cfs *callFrameStack) inspect() string {

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -471,7 +471,7 @@ var builtinActions = map[operationType]*action{
 
 			switch m := method.(type) {
 			case *MethodObject:
-				callObj := newCallObject(receiver, m, receiverPr, argCount, argSet, blockFrame, i.sourceLine, cf.fileName)
+				callObj := newCallObject(receiver, m, receiverPr, argCount, argSet, blockFrame, i.sourceLine)
 				t.evalMethodObject(callObj, i)
 			case *BuiltinMethodObject:
 				t.evalBuiltinMethod(receiver, m, receiverPr, argCount, argSet, blockFrame, i, cf.fileName)

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -427,7 +427,7 @@ var builtinActions = map[operationType]*action{
 			is := t.getClassIS(subjectName, cf.instructionSet.filename)
 
 			t.stack.pop()
-			c := newNormalCallFrame(is)
+			c := newNormalCallFrame(is, cf.FileName())
 			c.self = classPtr.Target
 			t.callFrameStack.push(c)
 			t.startFromTopFrame()
@@ -443,6 +443,7 @@ var builtinActions = map[operationType]*action{
 			methodName := args[0].(string)
 			argCount := args[1].(int)
 			argSet := args[3].(*bytecode.ArgSet)
+			sourceLine := args[4].(int)
 
 			if arr, ok := t.stack.top().Target.(*ArrayObject); ok && arr.splat {
 				// Pop array
@@ -471,10 +472,10 @@ var builtinActions = map[operationType]*action{
 
 			switch m := method.(type) {
 			case *MethodObject:
-				callObj := newCallObject(receiver, m, receiverPr, argCount, argSet, blockFrame)
+				callObj := newCallObject(receiver, m, receiverPr, argCount, argSet, blockFrame, sourceLine, cf.fileName)
 				t.evalMethodObject(callObj)
 			case *BuiltinMethodObject:
-				t.evalBuiltinMethod(receiver, m, receiverPr, argCount, argSet, blockFrame)
+				t.evalBuiltinMethod(receiver, m, receiverPr, argCount, argSet, blockFrame, sourceLine, cf.fileName)
 			case *Error:
 				t.pushErrorObject(errors.InternalError, m.toString())
 			}
@@ -521,7 +522,7 @@ var builtinActions = map[operationType]*action{
 				blockFrame = cf.blockFrame.ep.blockFrame
 			}
 
-			c := newNormalCallFrame(blockFrame.instructionSet)
+			c := newNormalCallFrame(blockFrame.instructionSet, blockFrame.instructionSet.filename)
 			c.blockFrame = blockFrame
 			c.ep = blockFrame.ep
 			c.self = receiver

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -540,26 +540,9 @@ var builtinActions = map[operationType]*action{
 	bytecode.Leave: {
 		name: bytecode.Leave,
 		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
-			//fmt.Println(t.callFrameStack.inspect())
-			//fmt.Println("Before leave--------------------------------")
-			cf = t.callFrameStack.pop()
-			cf.pc = len(cf.instructionSet.instructions)
-			//fmt.Println(t.callFrameStack.inspect())
-
-			/*
-				Remove top frame if it's a block frame
-
-				Block execution frame <- This was popped when executing leave
-				---------------------
-				Block frame           <- So this frame is useless
-				---------------------
-				Main frame
-			*/
-			topFrame := t.callFrameStack.top()
-			if topFrame != nil && topFrame.isBlock {
-				cf = t.callFrameStack.pop()
-				cf.pc = len(cf.instructionSet.instructions)
-			}
+			frame := t.callFrameStack.pop()
+			normalFrame := frame.(*normalCallFrame)
+			normalFrame.pc = len(normalFrame.instructionSet.instructions)
 		},
 	},
 }

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -227,7 +227,7 @@ var builtinActions = map[operationType]*action{
 			arr, ok := t.stack.pop().Target.(*ArrayObject)
 
 			if !ok {
-				t.returnError(errors.TypeError, "Expect stack top's value to be an Array when executing 'expandarray' instruction.")
+				t.pushErrorObject(errors.TypeError, "Expect stack top's value to be an Array when executing 'expandarray' instruction.")
 				return
 			}
 
@@ -357,7 +357,7 @@ var builtinActions = map[operationType]*action{
 			is, ok := t.getMethodIS(methodName, cf.instructionSet.filename)
 
 			if !ok {
-				t.returnError(errors.InternalError, "Can't get method %s's instruction set.", methodName)
+				t.pushErrorObject(errors.InternalError, "Can't get method %s's instruction set.", methodName)
 				return
 			}
 
@@ -411,12 +411,12 @@ var builtinActions = map[operationType]*action{
 					inheritedClass, ok := superClass.Target.(*RClass)
 
 					if !ok {
-						t.returnError(errors.InternalError, "Constant %s is not a class. got=%s", superClassName, string(superClass.Target.Class().ReturnName()))
+						t.pushErrorObject(errors.InternalError, "Constant %s is not a class. got=%s", superClassName, string(superClass.Target.Class().ReturnName()))
 						return
 					}
 
 					if inheritedClass.isModule {
-						t.returnError(errors.InternalError, "Module inheritance is not supported: %s", inheritedClass.Name)
+						t.pushErrorObject(errors.InternalError, "Module inheritance is not supported: %s", inheritedClass.Name)
 						return
 					}
 
@@ -476,7 +476,7 @@ var builtinActions = map[operationType]*action{
 			case *BuiltinMethodObject:
 				t.evalBuiltinMethod(receiver, m, receiverPr, argCount, argSet, blockFrame)
 			case *Error:
-				t.returnError(errors.InternalError, m.toString())
+				t.pushErrorObject(errors.InternalError, m.toString())
 			}
 		},
 	},
@@ -489,7 +489,7 @@ var builtinActions = map[operationType]*action{
 			receiver := t.stack.Data[receiverPr].Target
 
 			if cf.blockFrame == nil {
-				t.returnError(errors.InternalError, "Can't yield without a block")
+				t.pushErrorObject(errors.InternalError, "Can't yield without a block")
 				return
 			}
 

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-type operation func(t *thread, cf *normalCallFrame, args ...interface{})
+type operation func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{})
 
 type operationType = string
 
@@ -43,34 +43,34 @@ func (is *instructionSet) define(line int, a *action, params ...interface{}) *in
 var builtinActions = map[operationType]*action{
 	bytecode.Pop: {
 		name: bytecode.Pop,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			t.stack.pop()
 		},
 	},
 	bytecode.Dup: {
 		name: bytecode.Dup,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			obj := t.stack.top().Target
 			t.stack.push(&Pointer{Target: obj})
 		},
 	},
 	bytecode.PutBoolean: {
 		name: bytecode.PutObject,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			object := t.vm.initObjectFromGoType(args[0])
 			t.stack.push(&Pointer{Target: object})
 		},
 	},
 	bytecode.PutObject: {
 		name: bytecode.PutObject,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			object := t.vm.initObjectFromGoType(args[0])
 			t.stack.push(&Pointer{Target: object})
 		},
 	},
 	bytecode.GetConstant: {
 		name: bytecode.GetConstant,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			constName := args[0].(string)
 			c := t.vm.lookupConstant(cf, constName)
 
@@ -91,7 +91,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.GetLocal: {
 		name: bytecode.GetLocal,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			depth := args[0].(int)
 			index := args[1].(int)
 
@@ -107,7 +107,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.GetInstanceVariable: {
 		name: bytecode.GetInstanceVariable,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			variableName := args[0].(string)
 			v, ok := cf.self.instanceVariableGet(variableName)
 			if !ok {
@@ -121,7 +121,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.SetInstanceVariable: {
 		name: bytecode.SetInstanceVariable,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			variableName := args[0].(string)
 			p := t.stack.pop()
 			cf.self.instanceVariableSet(variableName, p.Target)
@@ -144,7 +144,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.SetLocal: {
 		name: bytecode.SetLocal,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			var optioned bool
 			p := t.stack.pop()
 			depth := args[0].(int)
@@ -182,7 +182,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.SetConstant: {
 		name: bytecode.SetConstant,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			constName := args[0].(string)
 			c := t.vm.lookupConstant(cf, constName)
 			v := t.stack.pop()
@@ -198,7 +198,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.NewRange: {
 		name: bytecode.NewRange,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			rangeEnd := t.stack.pop().Target.(*IntegerObject).value
 			rangeStart := t.stack.pop().Target.(*IntegerObject).value
 
@@ -207,7 +207,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.NewArray: {
 		name: bytecode.NewArray,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			argCount := args[0].(int)
 			elems := []Object{}
 
@@ -222,7 +222,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.ExpandArray: {
 		name: bytecode.ExpandArray,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			arrLength := args[0].(int)
 			arr, ok := t.stack.pop().Target.(*ArrayObject)
 
@@ -251,7 +251,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.SplatArray: {
 		name: bytecode.SplatArray,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			obj := t.stack.top().Target
 			arr, ok := obj.(*ArrayObject)
 
@@ -264,7 +264,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.NewHash: {
 		name: bytecode.NewHash,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			argCount := args[0].(int)
 			pairs := map[string]Object{}
 
@@ -280,7 +280,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.BranchUnless: {
 		name: bytecode.BranchUnless,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			v := t.stack.pop()
 			bool, isBool := v.Target.(*BooleanObject)
 
@@ -305,7 +305,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.BranchIf: {
 		name: bytecode.BranchIf,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			v := t.stack.pop()
 			bool, isBool := v.Target.(*BooleanObject)
 
@@ -326,32 +326,32 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.Jump: {
 		name: bytecode.Jump,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			cf.pc = args[0].(int)
 		},
 	},
 	bytecode.PutSelf: {
 		name: bytecode.PutSelf,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			t.stack.push(&Pointer{Target: cf.self})
 		},
 	},
 	bytecode.PutString: {
 		name: bytecode.PutString,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			object := t.vm.initObjectFromGoType(args[0])
 			t.stack.push(&Pointer{Target: object})
 		},
 	},
 	bytecode.PutNull: {
 		name: bytecode.PutNull,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			t.stack.push(&Pointer{Target: NULL})
 		},
 	},
 	bytecode.DefMethod: {
 		name: bytecode.DefMethod,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			argCount := args[0].(int)
 			methodName := t.stack.pop().Target.(*StringObject).value
 			is, ok := t.getMethodIS(methodName, cf.instructionSet.filename)
@@ -374,7 +374,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.DefSingletonMethod: {
 		name: bytecode.DefSingletonMethod,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			argCount := args[0].(int)
 			methodName := t.stack.pop().Target.(*StringObject).value
 			is, _ := t.getMethodIS(methodName, cf.instructionSet.filename)
@@ -395,7 +395,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.DefClass: {
 		name: bytecode.DefClass,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			subject := strings.Split(args[0].(string), ":")
 			subjectType, subjectName := subject[0], subject[1]
 
@@ -437,13 +437,12 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.Send: {
 		name: bytecode.Send,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			var method Object
 
 			methodName := args[0].(string)
 			argCount := args[1].(int)
 			argSet := args[3].(*bytecode.ArgSet)
-			sourceLine := args[4].(int)
 
 			if arr, ok := t.stack.top().Target.(*ArrayObject); ok && arr.splat {
 				// Pop array
@@ -472,10 +471,10 @@ var builtinActions = map[operationType]*action{
 
 			switch m := method.(type) {
 			case *MethodObject:
-				callObj := newCallObject(receiver, m, receiverPr, argCount, argSet, blockFrame, sourceLine, cf.fileName)
+				callObj := newCallObject(receiver, m, receiverPr, argCount, argSet, blockFrame, i.sourceLine, cf.fileName)
 				t.evalMethodObject(callObj)
 			case *BuiltinMethodObject:
-				t.evalBuiltinMethod(receiver, m, receiverPr, argCount, argSet, blockFrame, sourceLine, cf.fileName)
+				t.evalBuiltinMethod(receiver, m, receiverPr, argCount, argSet, blockFrame, i, cf.fileName)
 			case *Error:
 				t.pushErrorObject(errors.InternalError, m.toString())
 			}
@@ -483,7 +482,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.InvokeBlock: {
 		name: bytecode.InvokeBlock,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			argCount := args[0].(int)
 			argPr := t.sp - argCount
 			receiverPr := argPr - 1
@@ -540,7 +539,7 @@ var builtinActions = map[operationType]*action{
 	},
 	bytecode.Leave: {
 		name: bytecode.Leave,
-		operation: func(t *thread, cf *normalCallFrame, args ...interface{}) {
+		operation: func(t *thread, i *instruction, cf *normalCallFrame, args ...interface{}) {
 			frame := t.callFrameStack.pop()
 			normalFrame := frame.(*normalCallFrame)
 			normalFrame.pc = len(normalFrame.instructionSet.instructions)

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -471,7 +471,8 @@ var builtinActions = map[operationType]*action{
 
 			switch m := method.(type) {
 			case *MethodObject:
-				t.evalMethodObject(receiver, m, receiverPr, argCount, argSet, blockFrame)
+				callObj := newCallObject(receiver, m, receiverPr, argCount, argSet, blockFrame)
+				t.evalMethodObject(callObj)
 			case *BuiltinMethodObject:
 				t.evalBuiltinMethod(receiver, m, receiverPr, argCount, argSet, blockFrame)
 			case *Error:

--- a/vm/instruction_translator.go
+++ b/vm/instruction_translator.go
@@ -119,6 +119,7 @@ func (it *instructionTranslator) transferInstruction(is *instructionSet, i *byte
 			params = append(params, it.parseParam(param))
 		}
 		params = append(params, i.ArgSet)
+		params = append(params, i.SourceLine()+1)
 	default:
 		for _, param := range i.Params {
 			params = append(params, it.parseParam(param))

--- a/vm/instruction_translator.go
+++ b/vm/instruction_translator.go
@@ -119,7 +119,6 @@ func (it *instructionTranslator) transferInstruction(is *instructionSet, i *byte
 			params = append(params, it.parseParam(param))
 		}
 		params = append(params, i.ArgSet)
-		params = append(params, i.SourceLine()+1)
 	default:
 		for _, param := range i.Params {
 			params = append(params, it.parseParam(param))
@@ -127,5 +126,5 @@ func (it *instructionTranslator) transferInstruction(is *instructionSet, i *byte
 	}
 
 	vmI := is.define(i.Line(), action, params...)
-	vmI.sourceLine = i.SourceLine()
+	vmI.sourceLine = i.SourceLine() + 1
 }

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -50,7 +50,7 @@ func builtinIntegerClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					return t.unsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
 		},

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -49,7 +49,7 @@ func builtinIntegerClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
@@ -69,7 +69,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Numeric]
 			Name: "+",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intOperation := func(leftValue int, rightValue int) int {
 						return leftValue + rightValue
 					}
@@ -90,7 +90,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Numeric]
 			Name: "%",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intOperation := func(leftValue int, rightValue int) int {
 						return leftValue % rightValue
 					}
@@ -111,7 +111,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Numeric]
 			Name: "-",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intOperation := func(leftValue int, rightValue int) int {
 						return leftValue - rightValue
 					}
@@ -132,7 +132,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Numeric]
 			Name: "*",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intOperation := func(leftValue int, rightValue int) int {
 						return leftValue * rightValue
 					}
@@ -153,7 +153,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Numeric]
 			Name: "**",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intOperation := func(leftValue int, rightValue int) int {
 						return int(math.Pow(float64(leftValue), float64(rightValue)))
 					}
@@ -174,7 +174,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Numeric]
 			Name: "/",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intOperation := func(leftValue int, rightValue int) int {
 						return leftValue / rightValue
 					}
@@ -196,7 +196,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: ">",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intComparison := func(leftValue int, rightValue int) bool {
 						return leftValue > rightValue
 					}
@@ -218,7 +218,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: ">=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intComparison := func(leftValue int, rightValue int) bool {
 						return leftValue >= rightValue
 					}
@@ -240,7 +240,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "<",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intComparison := func(leftValue int, rightValue int) bool {
 						return leftValue < rightValue
 					}
@@ -262,7 +262,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "<=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intComparison := func(leftValue int, rightValue int) bool {
 						return leftValue <= rightValue
 					}
@@ -285,7 +285,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "<=>",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					rightObject := args[0]
 
 					switch rightObject.(type) {
@@ -332,7 +332,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					result := receiver.(*IntegerObject).equalityTest(args[0])
 
 					return toBooleanObject(result)
@@ -352,7 +352,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "!=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					result := !receiver.(*IntegerObject).equalityTest(args[0])
 
 					return toBooleanObject(result)
@@ -369,7 +369,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "even?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					i := receiver.(*IntegerObject)
 					even := i.value%2 == 0
@@ -391,7 +391,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_f",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newFloat := t.vm.initFloatObject(float64(r.value))
 					return newFloat
@@ -407,7 +407,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "to_i",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return receiver
 				}
 			},
@@ -421,7 +421,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_s",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					int := receiver.(*IntegerObject)
 
@@ -438,7 +438,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "next",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					i := receiver.(*IntegerObject)
 					return t.vm.initIntegerObject(i.value + 1)
 				}
@@ -454,7 +454,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "odd?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					i := receiver.(*IntegerObject)
 					odd := i.value%2 != 0
@@ -475,7 +475,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "pred",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					i := receiver.(*IntegerObject)
 					return t.vm.initIntegerObject(i.value - 1)
 				}
@@ -493,7 +493,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "times",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					n := receiver.(*IntegerObject)
 
 					if n.value < 0 {
@@ -515,7 +515,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_int",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
 					newInt.flag = i
@@ -526,7 +526,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_int8",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
 					newInt.flag = i8
@@ -537,7 +537,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_int16",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
 					newInt.flag = i16
@@ -548,7 +548,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_int32",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
 					newInt.flag = i32
@@ -559,7 +559,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_int64",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
 					newInt.flag = i64
@@ -570,7 +570,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_uint",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
 					newInt.flag = ui
@@ -581,7 +581,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_uint8",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
 					newInt.flag = ui8
@@ -592,7 +592,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_uint16",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
 					newInt.flag = ui16
@@ -603,7 +603,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_uint32",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
 					newInt.flag = ui32
@@ -614,7 +614,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_uint64",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
 					newInt.flag = ui64
@@ -625,7 +625,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_float32",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
 					newInt.flag = f32
@@ -636,7 +636,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_float64",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
 					newInt.flag = f64
@@ -647,7 +647,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "ptr",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					return t.vm.initGoObject(&r.value)
 				}

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -48,7 +48,7 @@ func builtinIntegerClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
@@ -68,7 +68,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Numeric]
 			Name: "+",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intOperation := func(leftValue int, rightValue int) int {
 						return leftValue + rightValue
@@ -89,7 +89,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Numeric]
 			Name: "%",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intOperation := func(leftValue int, rightValue int) int {
 						return leftValue % rightValue
@@ -110,7 +110,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Numeric]
 			Name: "-",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intOperation := func(leftValue int, rightValue int) int {
 						return leftValue - rightValue
@@ -131,7 +131,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Numeric]
 			Name: "*",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intOperation := func(leftValue int, rightValue int) int {
 						return leftValue * rightValue
@@ -152,7 +152,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Numeric]
 			Name: "**",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intOperation := func(leftValue int, rightValue int) int {
 						return int(math.Pow(float64(leftValue), float64(rightValue)))
@@ -173,7 +173,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Numeric]
 			Name: "/",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intOperation := func(leftValue int, rightValue int) int {
 						return leftValue / rightValue
@@ -195,7 +195,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: ">",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intComparison := func(leftValue int, rightValue int) bool {
 						return leftValue > rightValue
@@ -217,7 +217,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: ">=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intComparison := func(leftValue int, rightValue int) bool {
 						return leftValue >= rightValue
@@ -239,7 +239,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "<",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intComparison := func(leftValue int, rightValue int) bool {
 						return leftValue < rightValue
@@ -261,7 +261,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "<=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					intComparison := func(leftValue int, rightValue int) bool {
 						return leftValue <= rightValue
@@ -284,7 +284,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "<=>",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					rightObject := args[0]
 
@@ -331,7 +331,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "==",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					result := receiver.(*IntegerObject).equalityTest(args[0])
 
@@ -351,7 +351,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "!=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					result := !receiver.(*IntegerObject).equalityTest(args[0])
 
@@ -368,7 +368,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "even?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					i := receiver.(*IntegerObject)
@@ -390,7 +390,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		// @return [Float]
 		{
 			Name: "to_f",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newFloat := t.vm.initFloatObject(float64(r.value))
@@ -406,7 +406,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "to_i",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return receiver
 				}
@@ -420,7 +420,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [String]
 			Name: "to_s",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					int := receiver.(*IntegerObject)
@@ -437,7 +437,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "next",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					i := receiver.(*IntegerObject)
 					return t.vm.initIntegerObject(i.value + 1)
@@ -453,7 +453,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "odd?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					i := receiver.(*IntegerObject)
@@ -474,7 +474,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "pred",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					i := receiver.(*IntegerObject)
 					return t.vm.initIntegerObject(i.value - 1)
@@ -492,7 +492,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// a # => 3
 			// ```
 			Name: "times",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					n := receiver.(*IntegerObject)
 
@@ -514,7 +514,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_int",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
@@ -525,7 +525,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_int8",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
@@ -536,7 +536,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_int16",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
@@ -547,7 +547,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_int32",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
@@ -558,7 +558,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_int64",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
@@ -569,7 +569,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_uint",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
@@ -580,7 +580,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_uint8",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
@@ -591,7 +591,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_uint16",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
@@ -602,7 +602,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_uint32",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
@@ -613,7 +613,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_uint64",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
@@ -624,7 +624,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_float32",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
@@ -635,7 +635,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_float64",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					newInt := t.vm.initIntegerObject(r.value)
@@ -646,7 +646,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "ptr",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*IntegerObject)
 					return t.vm.initGoObject(&r.value)

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -90,17 +90,17 @@ func TestIntegerArithmeticOperationsPriority(t *testing.T) {
 
 func TestIntegerArithmeticOperationFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`1 + "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`1 - "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`1 ** "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`1 / "t"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1 + "p"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`1 - "m"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`1 ** "p"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`1 / "t"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -169,18 +169,18 @@ func TestIntegerComparisonWithFloat(t *testing.T) {
 
 func TestIntegerComparisonFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`1 > "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`1 >= "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`1 < "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`1 <= "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`1 <=> "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1 > "m"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`1 >= "m"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`1 < "m"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`1 <= "m"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
+		{`1 <=> "m"`, "TypeError: Expect argument to be Numeric. got: String", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -332,15 +332,15 @@ func TestIntegerTimesMethod(t *testing.T) {
 
 func TestIntegerTimesMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`(-2).times`, "InternalError: Expect integer greater than or equal 0. got: -2", 1},
-		{`2.times`, "InternalError: Can't yield without a block", 1},
+		{`(-2).times`, "InternalError: Expect integer greater than or equal 0. got: -2", 1, 1},
+		{`2.times`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/issue_vm.go
+++ b/vm/issue_vm.go
@@ -35,14 +35,8 @@ func PrintError(v *VM) {
 	t := v.mainThread
 	cf := t.callFrameStack.top()
 
-	// If program counter is 0 means we need to trace back to previous call frame
-	if cf.pc == 0 {
-		t.callFrameStack.pop()
-		cf = t.callFrameStack.top()
-	}
-
-	file := cf.instructionSet.filename
-	line := cf.instructionSet.instructions[cf.pc-1].Line
+	file := cf.FileName()
+	line := cf.SourceLine()
 
 	// Print lines in file surrounding error in markdown code block
 	f, osErr := os.Open(string(file))

--- a/vm/json.go
+++ b/vm/json.go
@@ -15,7 +15,7 @@ func builtinJSONClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "parse",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
@@ -56,7 +56,7 @@ func builtinJSONClassMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "validate",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))

--- a/vm/json.go
+++ b/vm/json.go
@@ -16,7 +16,7 @@ func builtinJSONClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "parse",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
@@ -57,7 +57,7 @@ func builtinJSONClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "validate",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}

--- a/vm/json.go
+++ b/vm/json.go
@@ -18,13 +18,13 @@ func builtinJSONClassMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					j, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
 
 					var obj jsonObj
@@ -38,7 +38,7 @@ func builtinJSONClassMethods() []*BuiltinMethodObject {
 						err = json.Unmarshal([]byte(jsonString), &objs)
 
 						if err != nil {
-							return t.vm.initErrorObject(errors.InternalError, "Can't parse string %s as json: %s", jsonString, err.Error())
+							return t.vm.initErrorObject(errors.InternalError, instruction, "Can't parse string %s as json: %s", jsonString, err.Error())
 						}
 
 						var objects []Object
@@ -59,13 +59,13 @@ func builtinJSONClassMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					j, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
 
 					var obj jsonObj

--- a/vm/match_data.go
+++ b/vm/match_data.go
@@ -32,7 +32,7 @@ func builtInMatchDataClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					return t.unsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
 		},

--- a/vm/match_data.go
+++ b/vm/match_data.go
@@ -30,7 +30,7 @@ func builtInMatchDataClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
@@ -53,7 +53,7 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "captures",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
@@ -84,7 +84,7 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "to_a",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))

--- a/vm/match_data.go
+++ b/vm/match_data.go
@@ -32,7 +32,7 @@ func builtInMatchDataClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.initUnsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError(instruction, "#new", receiver)
 				}
 			},
 		},
@@ -56,7 +56,7 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					matchData, _ := receiver.(*MatchDataObject)
@@ -87,7 +87,7 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					matchData, _ := receiver.(*MatchDataObject)

--- a/vm/match_data.go
+++ b/vm/match_data.go
@@ -31,7 +31,7 @@ func builtInMatchDataClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
@@ -54,7 +54,7 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "captures",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}
@@ -85,7 +85,7 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "to_a",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}

--- a/vm/match_data_test.go
+++ b/vm/match_data_test.go
@@ -43,15 +43,15 @@ func TestMatchDataCaptures(t *testing.T) {
 
 func TestMatchDataCapturesFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`'a1bca2'.match(1, 2)`, "ArgumentError: Expect 1 argument. got=2", 1},
-		{`'a1bca2'.match('a.')`, "TypeError: Expect argument to be Regexp. got: String", 1},
+		{`'a1bca2'.match(1, 2)`, "ArgumentError: Expect 1 argument. got=2", 1, 1},
+		{`'a1bca2'.match('a.')`, "TypeError: Expect argument to be Regexp. got: String", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -77,14 +77,14 @@ func TestMatchDataToA(t *testing.T) {
 
 func TestMatchDataToAFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`'a1bca2'.match(Regexp.new('a.')).to_a(1)`, "ArgumentError: Expect 0 argument. got=1", 1},
+		{`'a1bca2'.match(Regexp.new('a.')).to_a(1)`, "ArgumentError: Expect 0 argument. got=1", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/method.go
+++ b/vm/method.go
@@ -72,7 +72,7 @@ func (m *MethodObject) isKeywordArgIncluded() bool {
 type BuiltinMethodObject struct {
 	*baseObj
 	Name string
-	Fn   func(receiver Object) builtinMethodBody
+	Fn   func(receiver Object, instruction *instruction) builtinMethodBody
 }
 
 type builtinMethodBody func(*thread, []Object, *normalCallFrame) Object

--- a/vm/method.go
+++ b/vm/method.go
@@ -75,7 +75,7 @@ type BuiltinMethodObject struct {
 	Fn   func(receiver Object) builtinMethodBody
 }
 
-type builtinMethodBody func(*thread, []Object, *callFrame) Object
+type builtinMethodBody func(*thread, []Object, *normalCallFrame) Object
 
 // Polymorphic helper functions -----------------------------------------
 

--- a/vm/null.go
+++ b/vm/null.go
@@ -23,7 +23,7 @@ func builtinNullClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
@@ -44,7 +44,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "!",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					return TRUE
 				}
@@ -53,7 +53,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_i",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.vm.initIntegerObject(0)
 				}
 			},
@@ -61,7 +61,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_s",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.vm.initStringObject("")
 				}
 			},
@@ -76,7 +76,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
 					}
@@ -98,7 +98,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "!=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
 					}
@@ -120,7 +120,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "nil?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
 					}

--- a/vm/null.go
+++ b/vm/null.go
@@ -24,7 +24,7 @@ func builtinNullClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.initUnsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError(instruction, "#new", receiver)
 				}
 			},
 		},
@@ -78,7 +78,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got: %d", len(args))
 					}
 
 					if _, ok := args[0].(*NullObject); ok {
@@ -100,7 +100,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got: %d", len(args))
 					}
 
 					if _, ok := args[0].(*NullObject); !ok {
@@ -122,7 +122,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got: %d", len(args))
 					}
 					return TRUE
 				}

--- a/vm/null.go
+++ b/vm/null.go
@@ -24,7 +24,7 @@ func builtinNullClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					return t.unsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
 		},

--- a/vm/null.go
+++ b/vm/null.go
@@ -22,7 +22,7 @@ func builtinNullClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
@@ -43,7 +43,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			// # => true
 			// ```
 			Name: "!",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					return TRUE
@@ -52,7 +52,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_i",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.vm.initIntegerObject(0)
 				}
@@ -60,7 +60,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_s",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.vm.initStringObject("")
 				}
@@ -75,7 +75,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			// # => true
 			// ```
 			Name: "==",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
@@ -97,7 +97,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			// # => false
 			// ```
 			Name: "!=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got: %d", len(args))
@@ -119,7 +119,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			// # => true
 			// ```
 			Name: "nil?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got: %d", len(args))

--- a/vm/null_test.go
+++ b/vm/null_test.go
@@ -137,14 +137,14 @@ func TestNullAssignmentByOperation(t *testing.T) {
 
 func TestNullIsNilMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`nil.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`nil.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/plugin.go
+++ b/vm/plugin.go
@@ -27,7 +27,7 @@ func builtinPluginClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 1, len(args))
 					}
@@ -45,7 +45,7 @@ func builtinPluginClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "use",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					pkgPath := args[0].(*StringObject).value
 					_, pkgName := filepath.Split(pkgPath)
 					pkgName = strings.Split(pkgName, ".")[0]
@@ -70,7 +70,7 @@ func builtinPluginInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "compile",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*PluginObject)
 					context, ok := receiver.instanceVariableGet("@context")
 
@@ -123,7 +123,7 @@ func builtinPluginInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "go_func",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					s, ok := args[0].(*StringObject)
 
 					if !ok {

--- a/vm/plugin.go
+++ b/vm/plugin.go
@@ -29,13 +29,13 @@ func builtinPluginClassMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 1, len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, errors.WrongNumberOfArgumentFormat, 1, len(args))
 					}
 
 					name, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, "String", args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, "String", args[0].Class().Name)
 					}
 
 					return &PluginObject{fn: name.value, baseObj: &baseObj{class: t.vm.topLevelClass(classes.PluginClass), InstanceVariables: newEnvironment()}}
@@ -54,7 +54,7 @@ func builtinPluginClassMethods() []*BuiltinMethodObject {
 					p, err := compileAndOpenPlugin(soName, pkgPath)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					return t.vm.initPluginObject(pkgPath, p)
@@ -84,7 +84,7 @@ func builtinPluginInstanceMethods() []*BuiltinMethodObject {
 					ok, err := fileExists(pluginDir)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					if !ok {
@@ -101,7 +101,7 @@ func builtinPluginInstanceMethods() []*BuiltinMethodObject {
 					file, err := os.OpenFile(fn+".go", os.O_RDWR|os.O_CREATE, 0755)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, "Error when creating plugin: %s", err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, "Error when creating plugin: %s", err.Error())
 					}
 
 					file.WriteString(pluginContent)
@@ -111,7 +111,7 @@ func builtinPluginInstanceMethods() []*BuiltinMethodObject {
 					p, err := compileAndOpenPlugin(soName, file.Name())
 
 					if err != nil {
-						t.vm.initErrorObject(errors.InternalError, err.Error())
+						t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					r.plugin = p
@@ -127,7 +127,7 @@ func builtinPluginInstanceMethods() []*BuiltinMethodObject {
 					s, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
 
 					funcName := s.value
@@ -136,13 +136,13 @@ func builtinPluginInstanceMethods() []*BuiltinMethodObject {
 					f, err := p.Lookup(funcName)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					funcArgs, err := convertToGoFuncArgs(args[1:])
 
 					if err != nil {
-						t.vm.initErrorObject(errors.TypeError, err.Error())
+						t.vm.initErrorObject(errors.TypeError, instruction, err.Error())
 					}
 
 					funcValue := reflect.ValueOf(f)

--- a/vm/plugin.go
+++ b/vm/plugin.go
@@ -26,7 +26,7 @@ func builtinPluginClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, errors.WrongNumberOfArgumentFormat, 1, len(args))
@@ -44,7 +44,7 @@ func builtinPluginClassMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "use",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					pkgPath := args[0].(*StringObject).value
 					_, pkgName := filepath.Split(pkgPath)
@@ -69,7 +69,7 @@ func builtinPluginInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "compile",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*PluginObject)
 					context, ok := receiver.instanceVariableGet("@context")
@@ -122,7 +122,7 @@ func builtinPluginInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "go_func",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					s, ok := args[0].(*StringObject)
 

--- a/vm/range.go
+++ b/vm/range.go
@@ -40,7 +40,7 @@ func builtinRangeClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					return t.unsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
 		},

--- a/vm/range.go
+++ b/vm/range.go
@@ -39,7 +39,7 @@ func builtinRangeClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
@@ -61,7 +61,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					left := receiver.(*RangeObject)
 					r := args[0]
@@ -90,7 +90,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "!=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					left := receiver.(*RangeObject)
 					r := args[0]
@@ -151,7 +151,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "bsearch",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 
 					if ran.Start > ran.End || ran.Start < 0 {
@@ -239,7 +239,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Range]
 			Name: "each",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 
 					if blockFrame == nil {
@@ -274,7 +274,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "first",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 					return t.vm.initIntegerObject(ran.Start)
 				}
@@ -299,7 +299,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "include?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 
 					value := args[0].(*IntegerObject).value
@@ -326,7 +326,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "last",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 					return t.vm.initIntegerObject(ran.End)
 				}
@@ -344,7 +344,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "size",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 
 					if ran.Start <= ran.End {
@@ -387,7 +387,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Range]
 			Name: "step",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 
 					if blockFrame == nil {
@@ -431,7 +431,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "to_a",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ro := receiver.(*RangeObject)
 
 					elems := []Object{}
@@ -460,7 +460,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_s",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 
 					return t.vm.initStringObject(ran.toString())

--- a/vm/range.go
+++ b/vm/range.go
@@ -40,7 +40,7 @@ func builtinRangeClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.initUnsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError(instruction, "#new", receiver)
 				}
 			},
 		},
@@ -208,7 +208,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 								end = mid - 1
 							}
 						default:
-							return t.vm.initErrorObject(errors.TypeError, "Expect Integer or Boolean type. got=%s", r.Class().Name)
+							return t.vm.initErrorObject(errors.TypeError, instruction, "Expect Integer or Boolean type. got=%s", r.Class().Name)
 						}
 					}
 				}
@@ -243,7 +243,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 					ran := receiver.(*RangeObject)
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					if ran.Start <= ran.End {
@@ -391,7 +391,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 					ran := receiver.(*RangeObject)
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					stepValue := args[0].(*IntegerObject).value

--- a/vm/range.go
+++ b/vm/range.go
@@ -38,7 +38,7 @@ func builtinRangeClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
@@ -60,7 +60,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "==",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					left := receiver.(*RangeObject)
@@ -89,7 +89,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "!=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					left := receiver.(*RangeObject)
@@ -150,7 +150,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "bsearch",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 
@@ -238,7 +238,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Range]
 			Name: "each",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 
@@ -273,7 +273,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "first",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 					return t.vm.initIntegerObject(ran.Start)
@@ -298,7 +298,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "include?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 
@@ -325,7 +325,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "last",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 					return t.vm.initIntegerObject(ran.End)
@@ -343,7 +343,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "size",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 
@@ -386,7 +386,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Range]
 			Name: "step",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 
@@ -430,7 +430,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "to_a",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ro := receiver.(*RangeObject)
 
@@ -459,7 +459,7 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [String]
 			Name: "to_s",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					ran := receiver.(*RangeObject)
 

--- a/vm/range_test.go
+++ b/vm/range_test.go
@@ -203,13 +203,13 @@ func TestRangeBsearchMethodFail(t *testing.T) {
 		(0..4).bsearch do |i|
 			"Binary Search"
 		end
-		`, "TypeError: Expect Integer or Boolean type. got=String", 2},
+		`, "TypeError: Expect Integer or Boolean type. got=String", 2, 2},
 	}
 
 	for i, tt := range testsFail {
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/regexp.go
+++ b/vm/regexp.go
@@ -47,17 +47,17 @@ func builtInRegexpClassMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%d", len(args))
 					}
 
 					arg, ok := args[0].(*StringObject)
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
 					}
 
 					r := t.vm.initRegexpObject(args[0].toString())
 					if r == nil {
-						return t.vm.initErrorObject(errors.ArgumentError, "Invalid regexp: %v", args[0].toString())
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Invalid regexp: %v", args[0].toString())
 					}
 					return r
 				}
@@ -90,7 +90,7 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%d", len(args))
 					}
 
 					right, ok := args[0].(*RegexpObject)
@@ -123,13 +123,13 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%d", len(args))
 					}
 
 					arg := args[0]
 					input, ok := arg.(*StringObject)
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
 					}
 
 					re := receiver.(*RegexpObject).Regexp

--- a/vm/regexp.go
+++ b/vm/regexp.go
@@ -45,7 +45,7 @@ func builtInRegexpClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
 					}
@@ -87,7 +87,7 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
@@ -120,7 +120,7 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "match?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))

--- a/vm/regexp.go
+++ b/vm/regexp.go
@@ -44,7 +44,7 @@ func builtInRegexpClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
@@ -86,7 +86,7 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 			// @param regexp [Regexp]
 			// @return [Boolean]
 			Name: "==",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 1 {
@@ -119,7 +119,7 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 			// @param string [String]
 			// @return [Boolean]
 			Name: "match?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					if len(args) != 1 {

--- a/vm/regexp_test.go
+++ b/vm/regexp_test.go
@@ -171,15 +171,15 @@ func TestRegexpMatchQuestionMark(t *testing.T) {
 
 func TestRegexpMatchQuestionMarkFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`Regexp.new("abc").match?('a', 'b')`, "ArgumentError: Expect 1 argument. got=2", 1},
-		{`Regexp.new("abc").match?(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`Regexp.new("abc").match?('a', 'b')`, "ArgumentError: Expect 1 argument. got=2", 1, 1},
+		{`Regexp.new("abc").match?(1)`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/repl.go
+++ b/vm/repl.go
@@ -34,11 +34,11 @@ func (vm *VM) REPLExec(sets []*bytecode.InstructionSet) {
 	oldFrame := vm.mainThread.callFrameStack.pop()
 	cf := newNormalCallFrame(p.program)
 	cf.self = vm.mainObj
-	cf.locals = oldFrame.locals
-	cf.ep = oldFrame.ep
-	cf.isBlock = oldFrame.isBlock
-	cf.self = oldFrame.self
-	cf.lPr = oldFrame.lPr
+	cf.locals = oldFrame.Locals()
+	cf.ep = oldFrame.EP()
+	cf.isBlock = oldFrame.IsBlock()
+	cf.self = oldFrame.Self()
+	cf.lPr = oldFrame.LocalPtr()
 	vm.mainThread.callFrameStack.push(cf)
 	vm.startFromTopFrame()
 }

--- a/vm/repl.go
+++ b/vm/repl.go
@@ -11,7 +11,7 @@ func (vm *VM) InitForREPL() {
 	vm.SetMethodISIndexTable("")
 
 	// REPL should maintain a base call frame so that the whole program won't exit
-	cf := newCallFrame(&instructionSet{name: "REPL base"})
+	cf := newNormalCallFrame(&instructionSet{name: "REPL base"})
 	cf.self = vm.mainObj
 	vm.mode = REPLMode
 	vm.mainThread.callFrameStack.push(cf)
@@ -32,7 +32,7 @@ func (vm *VM) REPLExec(sets []*bytecode.InstructionSet) {
 	vm.blockTables[p.filename] = p.blockTable
 
 	oldFrame := vm.mainThread.callFrameStack.pop()
-	cf := newCallFrame(p.program)
+	cf := newNormalCallFrame(p.program)
 	cf.self = vm.mainObj
 	cf.locals = oldFrame.locals
 	cf.ep = oldFrame.ep

--- a/vm/repl.go
+++ b/vm/repl.go
@@ -7,11 +7,11 @@ import "github.com/goby-lang/goby/compiler/bytecode"
 // - Set vm to REPL mode
 // - Create and push main object frame
 func (vm *VM) InitForREPL() {
-	vm.SetClassISIndexTable("")
-	vm.SetMethodISIndexTable("")
+	vm.SetClassISIndexTable("REPL")
+	vm.SetMethodISIndexTable("REPL")
 
 	// REPL should maintain a base call frame so that the whole program won't exit
-	cf := newNormalCallFrame(&instructionSet{name: "REPL base"})
+	cf := newNormalCallFrame(&instructionSet{name: "REPL base"}, "REPL")
 	cf.self = vm.mainObj
 	vm.mode = REPLMode
 	vm.mainThread.callFrameStack.push(cf)
@@ -19,7 +19,7 @@ func (vm *VM) InitForREPL() {
 
 // REPLExec executes instructions differently from normal program execution.
 func (vm *VM) REPLExec(sets []*bytecode.InstructionSet) {
-	p := newInstructionTranslator("")
+	p := newInstructionTranslator("REPL")
 	p.vm = vm
 	p.transferInstructionSets(sets)
 
@@ -32,7 +32,7 @@ func (vm *VM) REPLExec(sets []*bytecode.InstructionSet) {
 	vm.blockTables[p.filename] = p.blockTable
 
 	oldFrame := vm.mainThread.callFrameStack.pop()
-	cf := newNormalCallFrame(p.program)
+	cf := newNormalCallFrame(p.program, p.filename)
 	cf.self = vm.mainObj
 	cf.locals = oldFrame.Locals()
 	cf.ep = oldFrame.EP()

--- a/vm/simple_server.go
+++ b/vm/simple_server.go
@@ -41,7 +41,7 @@ func builtinSimpleServerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "mount",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					path := args[0].(*StringObject).value
 					method := args[1].(*StringObject).value
 
@@ -54,7 +54,7 @@ func builtinSimpleServerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "static",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					prefix := args[0].(*StringObject).value
 					fileName := args[1].(*StringObject).value
 					router.PathPrefix(prefix).Handler(http.StripPrefix(prefix, http.FileServer(http.Dir(fileName))))
@@ -66,7 +66,7 @@ func builtinSimpleServerInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "start",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					var port string
 					var serveStatic bool
 					server := receiver.(*RObject)
@@ -136,7 +136,7 @@ func initSimpleServerClass(vm *VM) {
 
 // Other helper functions -----------------------------------------------
 
-func newHandler(t *thread, blockFrame *callFrame) func(http.ResponseWriter, *http.Request) {
+func newHandler(t *thread, blockFrame *normalCallFrame) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Go creates one goroutine per request, so we also need to create a new Goby thread for every request.
 		thread := t.vm.newThread()

--- a/vm/simple_server.go
+++ b/vm/simple_server.go
@@ -40,7 +40,7 @@ func builtinSimpleServerInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "mount",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					path := args[0].(*StringObject).value
 					method := args[1].(*StringObject).value
@@ -53,7 +53,7 @@ func builtinSimpleServerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "static",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					prefix := args[0].(*StringObject).value
 					fileName := args[1].(*StringObject).value
@@ -65,7 +65,7 @@ func builtinSimpleServerInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "start",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					var port string
 					var serveStatic bool

--- a/vm/stack.go
+++ b/vm/stack.go
@@ -20,7 +20,12 @@ func (s *stack) set(index int, pointer *Pointer) {
 
 	if err, ok := pointer.Target.(*Error); ok {
 		cf := t.callFrameStack.top()
-		cf.pc = len(cf.instructionSet.instructions)
+
+		// Stop program
+		switch cf := cf.(type) {
+		case *normalCallFrame:
+			cf.pc = len(cf.instructionSet.instructions)
+		}
 
 		if t.vm.mode == NormalMode {
 			if t.isMainThread() {
@@ -50,7 +55,11 @@ func (s *stack) push(v *Pointer) {
 	if err, ok := v.Target.(*Error); ok {
 		t := s.thread
 		cf := t.callFrameStack.top()
-		cf.pc = len(cf.instructionSet.instructions)
+		// Stop program
+		switch cf := cf.(type) {
+		case *normalCallFrame:
+			cf.pc = len(cf.instructionSet.instructions)
+		}
 
 		if t.vm.mode == NormalMode {
 			if t.isMainThread() {

--- a/vm/stack.go
+++ b/vm/stack.go
@@ -1,8 +1,6 @@
 package vm
 
 import (
-	"fmt"
-	"os"
 	"sync"
 )
 
@@ -16,25 +14,6 @@ type stack struct {
 }
 
 func (s *stack) set(index int, pointer *Pointer) {
-	t := s.thread
-
-	if err, ok := pointer.Target.(*Error); ok {
-		cf := t.callFrameStack.top()
-
-		// Stop program
-		switch cf := cf.(type) {
-		case *normalCallFrame:
-			cf.pc = len(cf.instructionSet.instructions)
-		}
-
-		if t.vm.mode == NormalMode {
-			if t.isMainThread() {
-				fmt.Println(err.Message)
-				os.Exit(1)
-			}
-		}
-	}
-
 	s.Lock()
 
 	defer s.Unlock()
@@ -50,23 +29,6 @@ func (s *stack) push(v *Pointer) {
 		s.Data = append(s.Data, v)
 	} else {
 		s.Data[s.thread.sp] = v
-	}
-
-	if err, ok := v.Target.(*Error); ok {
-		t := s.thread
-		cf := t.callFrameStack.top()
-		// Stop program
-		switch cf := cf.(type) {
-		case *normalCallFrame:
-			cf.pc = len(cf.instructionSet.instructions)
-		}
-
-		if t.vm.mode == NormalMode {
-			if t.isMainThread() {
-				fmt.Println(err.Message)
-				os.Exit(1)
-			}
-		}
 	}
 
 	s.thread.sp++

--- a/vm/string.go
+++ b/vm/string.go
@@ -50,7 +50,7 @@ func builtinStringClassMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "fmt",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument. got=%v", strconv.Itoa(len(args)))
@@ -82,7 +82,7 @@ func builtinStringClassMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "new",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
@@ -104,7 +104,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "+",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
@@ -129,7 +129,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "*",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
@@ -163,7 +163,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: ">",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
@@ -193,7 +193,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "<",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
@@ -224,7 +224,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "==",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
@@ -255,7 +255,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "=~",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
@@ -295,7 +295,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "<=>",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
@@ -329,7 +329,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "!=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
@@ -365,7 +365,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "[]",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
@@ -414,7 +414,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "[]=",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got=%v", strconv.Itoa(len(args)))
@@ -473,7 +473,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "capitalize",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
@@ -496,7 +496,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "chop",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
@@ -517,7 +517,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "concat",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
@@ -547,7 +547,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "count",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
@@ -569,7 +569,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "delete",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
@@ -597,7 +597,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "downcase",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
@@ -627,7 +627,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "each_byte",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
@@ -665,7 +665,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "each_char",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
@@ -699,7 +699,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "each_line",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
@@ -730,7 +730,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "empty?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
@@ -754,7 +754,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "end_with?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
@@ -794,7 +794,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "eql?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
@@ -828,7 +828,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "gsub",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got=%v", len(args))
@@ -864,7 +864,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Bool]
 			Name: "include?",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
@@ -904,7 +904,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "insert",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got=%d", len(args))
@@ -958,7 +958,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "length",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
@@ -984,7 +984,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "ljust",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 && len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
@@ -1041,7 +1041,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @param string [String]
 			// @return [MatchData]
 			Name: "match",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
@@ -1079,7 +1079,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "replace",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
@@ -1108,7 +1108,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "reverse",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
@@ -1139,7 +1139,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "rjust",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 && len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
@@ -1201,7 +1201,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "size",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
@@ -1250,7 +1250,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "slice",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
@@ -1329,7 +1329,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "split",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
@@ -1366,7 +1366,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "start_with",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
@@ -1407,7 +1407,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "strip",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
@@ -1439,7 +1439,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "to_a",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject)
@@ -1469,7 +1469,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Float]
 			Name: "to_f",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					str := receiver.(*StringObject).value
 
@@ -1502,7 +1502,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "to_i",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
@@ -1541,7 +1541,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "to_s",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
@@ -1559,7 +1559,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "upcase",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
@@ -1570,7 +1570,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 		},
 		{
 			Name: "to_bytes",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*StringObject)
 					return t.vm.initGoObject([]byte(r.value))

--- a/vm/string.go
+++ b/vm/string.go
@@ -53,13 +53,13 @@ func builtinStringClassMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect at least 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					formatObj, ok := args[0].(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
 
 					format := formatObj.value
@@ -73,7 +73,7 @@ func builtinStringClassMethods() []*BuiltinMethodObject {
 					count := len(re.FindAllString(format, -1))
 
 					if len(args[1:]) != count {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect %d string arguments. got=%d", count, len(args[1:]))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect %d string arguments. got=%d", count, len(args[1:]))
 					}
 
 					return t.vm.initStringObject(fmt.Sprintf(format, arguments...))
@@ -84,7 +84,7 @@ func builtinStringClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.initUnsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError(instruction, "#new", receiver)
 				}
 			},
 		},
@@ -112,7 +112,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
 					}
 
 					rightValue := right.value
@@ -137,11 +137,11 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					right, ok := r.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, r.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, r.Class().Name)
 					}
 
 					if right.value < 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Second argument must be greater than or equal to 0. got=%v", right.value)
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Second argument must be greater than or equal to 0. got=%v", right.value)
 					}
 
 					var result string
@@ -171,7 +171,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
 					}
 
 					rightValue := right.value
@@ -201,7 +201,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
 					}
 
 					rightValue := right.value
@@ -258,7 +258,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%d", len(args))
 					}
 
 					arg := args[0]
@@ -266,7 +266,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					regexp, ok := arg.(*RegexpObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.RegexpClass, arg.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.RegexpClass, arg.Class().Name)
 					}
 
 					text := receiver.(*StringObject).value
@@ -303,7 +303,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					right, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
 					}
 
 					rightValue := right.value
@@ -368,7 +368,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%d", len(args))
 					}
 
 					str := receiver.(*StringObject).value
@@ -376,7 +376,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					index, ok := i.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
 					}
 
 					indexValue := index.value
@@ -417,7 +417,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 2 arguments. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).value
@@ -425,28 +425,28 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					index, ok := i.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
 					}
 
 					indexValue := index.value
 					strLength := utf8.RuneCountInString(str)
 
 					if strLength < indexValue {
-						return t.vm.initErrorObject(errors.ArgumentError, "Index value out of range. got=%v", strconv.Itoa(indexValue))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Index value out of range. got=%v", strconv.Itoa(indexValue))
 					}
 
 					r := args[1]
 					replaceStr, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
 					}
 					replaceStrValue := replaceStr.value
 
 					// Negative Index Case
 					if indexValue < 0 {
 						if -indexValue > strLength {
-							return t.vm.initErrorObject(errors.ArgumentError, "Index value out of range. got=%v", strconv.Itoa(indexValue))
+							return t.vm.initErrorObject(errors.ArgumentError, instruction, "Index value out of range. got=%v", strconv.Itoa(indexValue))
 						}
 						// Change to positive index to replace the string
 						indexValue += strLength
@@ -520,7 +520,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).value
@@ -528,7 +528,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					concatStr, ok := c.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
 					}
 
 					return t.vm.initStringObject(str + concatStr.value)
@@ -572,7 +572,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).value
@@ -580,7 +580,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					deleteStr, ok := d.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, d.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, d.Class().Name)
 					}
 
 					return t.vm.initStringObject(strings.Replace(str, deleteStr.value, "", -1))
@@ -630,11 +630,11 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					str := receiver.(*StringObject).value
@@ -668,11 +668,11 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					str := receiver.(*StringObject).value
@@ -702,11 +702,11 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 0 argument. got=%d", len(args))
 					}
 
 					if blockFrame == nil {
-						return t.vm.initErrorObject(errors.InternalError, errors.CantYieldWithoutBlockFormat)
+						return t.vm.initErrorObject(errors.InternalError, instruction, errors.CantYieldWithoutBlockFormat)
 					}
 
 					str := receiver.(*StringObject).value
@@ -757,7 +757,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).value
@@ -765,7 +765,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					compareStr, ok := c.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
 					}
 
 					compareStrValue := compareStr.value
@@ -797,7 +797,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).value
@@ -831,7 +831,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got=%v", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 2 arguments. got=%v", len(args))
 					}
 
 					str := receiver.(*StringObject).value
@@ -840,14 +840,14 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					pattern, ok := p.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, "Expect pattern to be String. got: %s", p.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, "Expect pattern to be String. got: %s", p.Class().Name)
 					}
 
 					r := args[1]
 					replacement, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, "Expect replacement to be String. got: %s", r.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, "Expect replacement to be String. got: %s", r.Class().Name)
 					}
 
 					return t.vm.initStringObject(strings.Replace(str, pattern.value, replacement.value, -1))
@@ -867,7 +867,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).value
@@ -875,7 +875,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					includeStr, ok := i.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
 					}
 
 					if strings.Contains(str, includeStr.value) {
@@ -907,7 +907,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 2 arguments. got=%d", len(args))
 					}
 
 					str := receiver.(*StringObject).value
@@ -915,7 +915,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					index, ok := i.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
 					}
 
 					indexValue := index.value
@@ -923,13 +923,13 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					insertStr, ok := ins.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, "Expect insert string to be String. got: %s", ins.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, "Expect insert string to be String. got: %s", ins.Class().Name)
 					}
 					strLength := utf8.RuneCountInString(str)
 
 					if indexValue < 0 {
 						if -indexValue > strLength+1 {
-							return t.vm.initErrorObject(errors.ArgumentError, "Index value out of range. got=%v", indexValue)
+							return t.vm.initErrorObject(errors.ArgumentError, instruction, "Index value out of range. got=%v", indexValue)
 						} else if -indexValue == strLength+1 {
 							return t.vm.initStringObject(insertStr.value + str)
 						}
@@ -938,7 +938,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					if strLength < indexValue {
-						return t.vm.initErrorObject(errors.ArgumentError, "Index value out of range. got=%v", indexValue)
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Index value out of range. got=%v", indexValue)
 					}
 
 					// Support UTF-8 Encoding
@@ -987,7 +987,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 && len(args) != 2 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).value
@@ -996,7 +996,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					strLength, ok := l.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, "Expect justify width to be Integer. got: %s", l.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, "Expect justify width to be Integer. got: %s", l.Class().Name)
 					}
 
 					strLengthValue := strLength.value
@@ -1009,7 +1009,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 						padStr, ok := p.(*StringObject)
 
 						if !ok {
-							return t.vm.initErrorObject(errors.TypeError, "Expect padding string to be String. got: %s", p.Class().Name)
+							return t.vm.initErrorObject(errors.TypeError, instruction, "Expect padding string to be String. got: %s", p.Class().Name)
 						}
 
 						padStrValue = padStr.value
@@ -1044,14 +1044,14 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%d", len(args))
 					}
 
 					arg := args[0]
 					regexpObj, ok := arg.(*RegexpObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.RegexpClass, arg.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.RegexpClass, arg.Class().Name)
 					}
 
 					regexp := regexpObj.Regexp
@@ -1082,14 +1082,14 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					r := args[0]
 					replaceStr, ok := r.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
 					}
 
 					return t.vm.initStringObject(replaceStr.value)
@@ -1142,7 +1142,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 && len(args) != 2 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).value
@@ -1150,7 +1150,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					strLength, ok := l.(*IntegerObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, "Expect justify width to be Integer. got: %s", l.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, "Expect justify width to be Integer. got: %s", l.Class().Name)
 					}
 
 					strLengthValue := strLength.value
@@ -1163,7 +1163,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 						padStr, ok := p.(*StringObject)
 
 						if !ok {
-							return t.vm.initErrorObject(errors.TypeError, "Expect padding string to be String. got: %s", p.Class().Name)
+							return t.vm.initErrorObject(errors.TypeError, instruction, "Expect padding string to be String. got: %s", p.Class().Name)
 						}
 
 						padStrValue = padStr.value
@@ -1253,7 +1253,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).value
@@ -1312,7 +1312,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 						return t.vm.initStringObject(string([]rune(str)[intValue]))
 
 					default:
-						return t.vm.initErrorObject(errors.TypeError, "Expect slice range to be Range or Integer. got: %s", args[0].Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, "Expect slice range to be Range or Integer. got: %s", args[0].Class().Name)
 					}
 				}
 			},
@@ -1332,14 +1332,14 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					s := args[0]
 					seperator, ok := s.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, s.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, s.Class().Name)
 					}
 
 					str := receiver.(*StringObject).value
@@ -1369,7 +1369,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
-						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+						return t.vm.initErrorObject(errors.ArgumentError, instruction, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
 
 					str := receiver.(*StringObject).value
@@ -1377,7 +1377,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					compareStr, ok := c.(*StringObject)
 
 					if !ok {
-						return t.vm.initErrorObject(errors.TypeError, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
+						return t.vm.initErrorObject(errors.TypeError, instruction, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
 					}
 
 					compareStrValue := compareStr.value

--- a/vm/string.go
+++ b/vm/string.go
@@ -51,7 +51,7 @@ func builtinStringClassMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "fmt",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) < 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect at least 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
@@ -83,7 +83,7 @@ func builtinStringClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
@@ -105,7 +105,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "+",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
 					r := args[0]
@@ -130,7 +130,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "*",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
 					r := args[0]
@@ -164,7 +164,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: ">",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
 					r := args[0]
@@ -194,7 +194,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "<",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
 					r := args[0]
@@ -225,7 +225,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "==",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
 					r := args[0]
@@ -256,7 +256,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "=~",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
 					}
@@ -296,7 +296,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "<=>",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
 					r := args[0]
@@ -330,7 +330,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "!=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					leftValue := receiver.(*StringObject).value
 					right, ok := args[0].(*StringObject)
@@ -366,7 +366,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "[]",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
 					}
@@ -415,7 +415,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "[]=",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got=%v", strconv.Itoa(len(args)))
 					}
@@ -474,7 +474,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "capitalize",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
 					start := string([]rune(str)[0])
@@ -497,7 +497,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "chop",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
 					strLength := utf8.RuneCountInString(str)
@@ -518,7 +518,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "concat",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
@@ -548,7 +548,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "count",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
 
@@ -570,7 +570,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "delete",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
@@ -598,7 +598,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "downcase",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
 
@@ -628,7 +628,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "each_byte",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}
@@ -666,7 +666,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "each_char",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}
@@ -700,7 +700,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "each_line",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 0 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 0 argument. got=%d", len(args))
 					}
@@ -731,7 +731,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "empty?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
 
@@ -755,7 +755,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "end_with?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
@@ -795,7 +795,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "eql?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
@@ -829,7 +829,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "gsub",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got=%v", len(args))
 					}
@@ -865,7 +865,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Bool]
 			Name: "include?",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
@@ -905,7 +905,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "insert",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 2 arguments. got=%d", len(args))
 					}
@@ -959,7 +959,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "length",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
 
@@ -985,7 +985,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "ljust",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 && len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
 					}
@@ -1042,7 +1042,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [MatchData]
 			Name: "match",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%d", len(args))
 					}
@@ -1080,7 +1080,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "replace",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
@@ -1109,7 +1109,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "reverse",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
 
@@ -1140,7 +1140,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "rjust",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 && len(args) != 2 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
 					}
@@ -1202,7 +1202,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "size",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
 
@@ -1251,7 +1251,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "slice",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
@@ -1330,7 +1330,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "split",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
@@ -1367,7 +1367,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "start_with",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					if len(args) != 1 {
 						return t.vm.initErrorObject(errors.ArgumentError, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 					}
@@ -1408,7 +1408,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "strip",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
 
@@ -1440,7 +1440,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_a",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject)
 					strLength := utf8.RuneCountInString(str.value)
@@ -1470,7 +1470,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Float]
 			Name: "to_f",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					str := receiver.(*StringObject).value
 
 					for i, char := range str {
@@ -1503,7 +1503,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "to_i",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
 					parsedStr, err := strconv.ParseInt(str, 10, 0)
@@ -1542,7 +1542,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_s",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
 
@@ -1560,7 +1560,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "upcase",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 
 					str := receiver.(*StringObject).value
 
@@ -1571,7 +1571,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_bytes",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					r := receiver.(*StringObject)
 					return t.vm.initGoObject([]byte(r.value))
 				}

--- a/vm/string.go
+++ b/vm/string.go
@@ -84,7 +84,7 @@ func builtinStringClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *callFrame) Object {
-					return t.unsupportedMethodError("#new", receiver)
+					return t.initUnsupportedMethodError("#new", receiver)
 				}
 			},
 		},

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -204,15 +204,15 @@ func TestStringComparison(t *testing.T) {
 
 func TestStringComparisonFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"a" < 1`, "TypeError: Expect argument to be String. got: Integer", 1},
-		{`"a" > 1`, "TypeError: Expect argument to be String. got: Integer", 1},
-		{`"a" <=> 1`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`"a" < 1`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
+		{`"a" > 1`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
+		{`"a" <=> 1`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
 	}
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -237,14 +237,14 @@ func TestStringMatchOperator(t *testing.T) {
 
 func TestStringMatchOperatorFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"abc" =~ *[1, 2]`, "ArgumentError: Expect 1 argument. got=2", 1},
-		{`"abc" =~ 'a'`, "TypeError: Expect argument to be Regexp. got: String", 1},
+		{`"abc" =~ *[1, 2]`, "ArgumentError: Expect 1 argument. got=2", 1, 1},
+		{`"abc" =~ 'a'`, "TypeError: Expect argument to be Regexp. got: String", 1, 1},
 	}
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -297,20 +297,20 @@ func TestStringOperation(t *testing.T) {
 
 func TestStringOperationFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Taipei" + 101`, "TypeError: Expect argument to be String. got: Integer", 1},
-		{`"Taipei" * "101"`, "TypeError: Expect argument to be Integer. got: String", 1},
-		{`"Taipei" * (-101)`, "ArgumentError: Second argument must be greater than or equal to 0. got=-101", 1},
-		{`"Taipei"[1] = 1`, "TypeError: Expect argument to be String. got: Integer", 1},
-		{`"Taipei"[1] = true`, "TypeError: Expect argument to be String. got: Boolean", 1},
-		{`"Taipei"[]`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`"Taipei"[true] = 101`, "TypeError: Expect argument to be Integer. got: Boolean", 1},
+		{`"Taipei" + 101`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
+		{`"Taipei" * "101"`, "TypeError: Expect argument to be Integer. got: String", 1, 1},
+		{`"Taipei" * (-101)`, "ArgumentError: Second argument must be greater than or equal to 0. got=-101", 1, 1},
+		{`"Taipei"[1] = 1`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
+		{`"Taipei"[1] = true`, "TypeError: Expect argument to be String. got: Boolean", 1, 1},
+		{`"Taipei"[]`, "ArgumentError: Expect 1 argument. got=0", 1, 1},
+		{`"Taipei"[true] = 101`, "TypeError: Expect argument to be Integer. got: Boolean", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -378,18 +378,18 @@ func TestStringConcatenateMethod(t *testing.T) {
 
 func TestStringConcatenateMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"a".concat`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`"a".concat("Hello", "World")`, "ArgumentError: Expect 1 argument. got=2", 1},
-		{`"a".concat(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
-		{`"a".concat(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
-		{`"a".concat(nil)`, "TypeError: Expect argument to be String. got: Null", 1},
+		{`"a".concat`, "ArgumentError: Expect 1 argument. got=0", 1, 1},
+		{`"a".concat("Hello", "World")`, "ArgumentError: Expect 1 argument. got=2", 1, 1},
+		{`"a".concat(1)`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
+		{`"a".concat(true)`, "TypeError: Expect argument to be String. got: Boolean", 1, 1},
+		{`"a".concat(nil)`, "TypeError: Expect argument to be String. got: Null", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -434,17 +434,17 @@ func TestStringDeleteMethod(t *testing.T) {
 
 func TestStringDeleteMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Hello hello HeLlo".delete`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`"Hello hello HeLlo".delete(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
-		{`"Hello hello HeLlo".delete(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
-		{`"Hello hello HeLlo".delete(nil)`, "TypeError: Expect argument to be String. got: Null", 1},
+		{`"Hello hello HeLlo".delete`, "ArgumentError: Expect 1 argument. got=0", 1, 1},
+		{`"Hello hello HeLlo".delete(1)`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
+		{`"Hello hello HeLlo".delete(true)`, "TypeError: Expect argument to be String. got: Boolean", 1, 1},
+		{`"Hello hello HeLlo".delete(nil)`, "TypeError: Expect argument to be String. got: Null", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -505,15 +505,15 @@ func TestStringEachByteMethodFail(t *testing.T) {
 		"Taipei".each_byte(101) do |byte|
 		  puts byte
 		end
-		`, "ArgumentError: Expect 0 argument. got=1", 2},
-		{`"Taipei".each_byte`, "InternalError: Can't yield without a block", 1},
+		`, "ArgumentError: Expect 0 argument. got=1", 2, 2},
+		{`"Taipei".each_byte`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -554,15 +554,15 @@ func TestStringEachCharMethodFail(t *testing.T) {
 		"Taipei".each_char(101) do |char|
 		  puts char
 		end
-		`, "ArgumentError: Expect 0 argument. got=1", 2},
-		{`"Taipei".each_char`, "InternalError: Can't yield without a block", 1},
+		`, "ArgumentError: Expect 0 argument. got=1", 2, 2},
+		{`"Taipei".each_char`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -603,15 +603,15 @@ func TestStringEachLineMethodFail(t *testing.T) {
 		"Taipei".each_line(101) do |line|
 		  puts line
 		end
-		`, "ArgumentError: Expect 0 argument. got=1", 2},
-		{`"Taipei".each_line`, "InternalError: Can't yield without a block", 1},
+		`, "ArgumentError: Expect 0 argument. got=1", 2, 2},
+		{`"Taipei".each_line`, "InternalError: Can't yield without a block", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -642,17 +642,17 @@ func TestStringEndWithMethod(t *testing.T) {
 
 func TestStringEndWithMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Taipei".end_with?("1", "0", "1")`, "ArgumentError: Expect 1 argument. got=3", 1},
-		{`"Taipei".end_with?(101)`, "TypeError: Expect argument to be String. got: Integer", 1},
-		{`"Hello".end_with?(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
-		{`"Hello".end_with?(1..5)`, "TypeError: Expect argument to be String. got: Range", 1},
+		{`"Taipei".end_with?("1", "0", "1")`, "ArgumentError: Expect 1 argument. got=3", 1, 1},
+		{`"Taipei".end_with?(101)`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
+		{`"Hello".end_with?(true)`, "TypeError: Expect argument to be String. got: Boolean", 1, 1},
+		{`"Hello".end_with?(1..5)`, "TypeError: Expect argument to be String. got: Range", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -700,15 +700,15 @@ func TestStringEqualMethod(t *testing.T) {
 
 func TestStringEqualMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Hello".eql?`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`"Hello".eql?("Hello", "World")`, "ArgumentError: Expect 1 argument. got=2", 1},
+		{`"Hello".eql?`, "ArgumentError: Expect 1 argument. got=0", 1, 1},
+		{`"Hello".eql?("Hello", "World")`, "ArgumentError: Expect 1 argument. got=2", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -735,17 +735,17 @@ func TestStringGlobalSubstituteMethod(t *testing.T) {
 
 func TestStringGlobalSubstituteMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Ruby".gsub()`, "ArgumentError: Expect 2 arguments. got=0", 1},
-		{`"Ruby".gsub("Ru")`, "ArgumentError: Expect 2 arguments. got=1", 1},
-		{`"Ruby".gsub(123, "Go")`, "TypeError: Expect pattern to be String. got: Integer", 1},
-		{`"Ruby".gsub("Ru", 456)`, "TypeError: Expect replacement to be String. got: Integer", 1},
+		{`"Ruby".gsub()`, "ArgumentError: Expect 2 arguments. got=0", 1, 1},
+		{`"Ruby".gsub("Ru")`, "ArgumentError: Expect 2 arguments. got=1", 1, 1},
+		{`"Ruby".gsub(123, "Go")`, "TypeError: Expect pattern to be String. got: Integer", 1, 1},
+		{`"Ruby".gsub("Ru", 456)`, "TypeError: Expect replacement to be String. got: Integer", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -775,18 +775,18 @@ func TestStringIncludeMethod(t *testing.T) {
 
 func TestStringIncludeMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Goby".include?`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`"Goby".include?("Ruby", "Lang")`, "ArgumentError: Expect 1 argument. got=2", 1},
-		{`"Goby".include?(2)`, "TypeError: Expect argument to be String. got: Integer", 1},
-		{`"Goby".include?(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
-		{`"Goby".include?(nil)`, "TypeError: Expect argument to be String. got: Null", 1},
+		{`"Goby".include?`, "ArgumentError: Expect 1 argument. got=0", 1, 1},
+		{`"Goby".include?("Ruby", "Lang")`, "ArgumentError: Expect 1 argument. got=2", 1, 1},
+		{`"Goby".include?(2)`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
+		{`"Goby".include?(true)`, "TypeError: Expect argument to be String. got: Boolean", 1, 1},
+		{`"Goby".include?(nil)`, "TypeError: Expect argument to be String. got: Null", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -819,19 +819,19 @@ func TestStringInsertMethod(t *testing.T) {
 
 func TestStringInsertMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Goby Lang".insert`, "ArgumentError: Expect 2 arguments. got=0", 1},
-		{`"Taipei".insert(6, " ", "101")`, "ArgumentError: Expect 2 arguments. got=3", 1},
-		{`"Taipei".insert("6", " 101")`, "TypeError: Expect argument to be Integer. got: String", 1},
-		{`"Taipei".insert(6, 101)`, "TypeError: Expect insert string to be String. got: Integer", 1},
-		{`"Taipei".insert(-8, "101")`, "ArgumentError: Index value out of range. got=-8", 1},
-		{`"Taipei".insert(7, "101")`, "ArgumentError: Index value out of range. got=7", 1},
+		{`"Goby Lang".insert`, "ArgumentError: Expect 2 arguments. got=0", 1, 1},
+		{`"Taipei".insert(6, " ", "101")`, "ArgumentError: Expect 2 arguments. got=3", 1, 1},
+		{`"Taipei".insert("6", " 101")`, "TypeError: Expect argument to be Integer. got: String", 1, 1},
+		{`"Taipei".insert(6, 101)`, "TypeError: Expect insert string to be String. got: Integer", 1, 1},
+		{`"Taipei".insert(-8, "101")`, "ArgumentError: Index value out of range. got=-8", 1, 1},
+		{`"Taipei".insert(7, "101")`, "ArgumentError: Index value out of range. got=7", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -858,21 +858,21 @@ func TestStringLeftJustifyMethod(t *testing.T) {
 
 func TestStringLeftJustifyMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Hello".ljust`, "ArgumentError: Expect 1..2 arguments. got=0", 1},
-		{`"Hello".ljust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1..2 arguments. got=5", 1},
-		{`"Hello".ljust(true)`, "TypeError: Expect justify width to be Integer. got: Boolean", 1},
-		{`"Hello".ljust("World")`, "TypeError: Expect justify width to be Integer. got: String", 1},
-		{`"Hello".ljust(2..5)`, "TypeError: Expect justify width to be Integer. got: Range", 1},
-		{`"Hello".ljust(10, 10)`, "TypeError: Expect padding string to be String. got: Integer", 1},
-		{`"Hello".ljust(10, 2..5)`, "TypeError: Expect padding string to be String. got: Range", 1},
-		{`"Hello".ljust(10, true)`, "TypeError: Expect padding string to be String. got: Boolean", 1},
+		{`"Hello".ljust`, "ArgumentError: Expect 1..2 arguments. got=0", 1, 1},
+		{`"Hello".ljust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1..2 arguments. got=5", 1, 1},
+		{`"Hello".ljust(true)`, "TypeError: Expect justify width to be Integer. got: Boolean", 1, 1},
+		{`"Hello".ljust("World")`, "TypeError: Expect justify width to be Integer. got: String", 1, 1},
+		{`"Hello".ljust(2..5)`, "TypeError: Expect justify width to be Integer. got: Range", 1, 1},
+		{`"Hello".ljust(10, 10)`, "TypeError: Expect padding string to be String. got: Integer", 1, 1},
+		{`"Hello".ljust(10, 2..5)`, "TypeError: Expect padding string to be String. got: Range", 1, 1},
+		{`"Hello".ljust(10, true)`, "TypeError: Expect padding string to be String. got: Boolean", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -916,15 +916,15 @@ func TestStringMatch(t *testing.T) {
 
 func TestStringMatchFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`'a'.match(Regexp.new("abc"), 1)`, "ArgumentError: Expect 1 argument. got=2", 1},
-		{`'a'.match(1)`, "TypeError: Expect argument to be Regexp. got: Integer", 1},
+		{`'a'.match(Regexp.new("abc"), 1)`, "ArgumentError: Expect 1 argument. got=2", 1, 1},
+		{`'a'.match(1)`, "TypeError: Expect argument to be Regexp. got: Integer", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -951,16 +951,16 @@ func TestStringReplaceMethod(t *testing.T) {
 
 func TestStringReplaceMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Taipei".replace`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`"Taipei".replace(101)`, "TypeError: Expect argument to be String. got: Integer", 1},
-		{`"Taipei".replace(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
+		{`"Taipei".replace`, "ArgumentError: Expect 1 argument. got=0", 1, 1},
+		{`"Taipei".replace(101)`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
+		{`"Taipei".replace(true)`, "TypeError: Expect argument to be String. got: Boolean", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1008,21 +1008,21 @@ func TestStringRightJustifyMethod(t *testing.T) {
 
 func TestStringRightJustifyFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Hello".rjust`, "ArgumentError: Expect 1..2 arguments. got=0", 1},
-		{`"Hello".rjust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1..2 arguments. got=5", 1},
-		{`"Hello".rjust(true)`, "TypeError: Expect justify width to be Integer. got: Boolean", 1},
-		{`"Hello".rjust("World")`, "TypeError: Expect justify width to be Integer. got: String", 1},
-		{`"Hello".rjust(2..5)`, "TypeError: Expect justify width to be Integer. got: Range", 1},
-		{`"Hello".rjust(10, 10)`, "TypeError: Expect padding string to be String. got: Integer", 1},
-		{`"Hello".rjust(10, 2..5)`, "TypeError: Expect padding string to be String. got: Range", 1},
-		{`"Hello".rjust(10, true)`, "TypeError: Expect padding string to be String. got: Boolean", 1},
+		{`"Hello".rjust`, "ArgumentError: Expect 1..2 arguments. got=0", 1, 1},
+		{`"Hello".rjust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1..2 arguments. got=5", 1, 1},
+		{`"Hello".rjust(true)`, "TypeError: Expect justify width to be Integer. got: Boolean", 1, 1},
+		{`"Hello".rjust("World")`, "TypeError: Expect justify width to be Integer. got: String", 1, 1},
+		{`"Hello".rjust(2..5)`, "TypeError: Expect justify width to be Integer. got: Range", 1, 1},
+		{`"Hello".rjust(10, 10)`, "TypeError: Expect padding string to be String. got: Integer", 1, 1},
+		{`"Hello".rjust(10, 2..5)`, "TypeError: Expect padding string to be String. got: Range", 1, 1},
+		{`"Hello".rjust(10, true)`, "TypeError: Expect padding string to be String. got: Boolean", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1095,16 +1095,16 @@ func TestStringSliceMethod(t *testing.T) {
 
 func TestStringSliceMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Goby Lang".slice`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`"Goby Lang".slice("Hello")`, "TypeError: Expect slice range to be Range or Integer. got: String", 1},
-		{`"Goby Lang".slice(true)`, "TypeError: Expect slice range to be Range or Integer. got: Boolean", 1},
+		{`"Goby Lang".slice`, "ArgumentError: Expect 1 argument. got=0", 1, 1},
+		{`"Goby Lang".slice("Hello")`, "TypeError: Expect slice range to be Range or Integer. got: String", 1, 1},
+		{`"Goby Lang".slice(true)`, "TypeError: Expect slice range to be Range or Integer. got: Boolean", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1191,17 +1191,17 @@ func TestStringSplitMethod(t *testing.T) {
 
 func TestStringSplitMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Hello World".split`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`"Hello World".split(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
-		{`"Hello World".split(123)`, "TypeError: Expect argument to be String. got: Integer", 1},
-		{`"Hello World".split(1..2)`, "TypeError: Expect argument to be String. got: Range", 1},
+		{`"Hello World".split`, "ArgumentError: Expect 1 argument. got=0", 1, 1},
+		{`"Hello World".split(true)`, "TypeError: Expect argument to be String. got: Boolean", 1, 1},
+		{`"Hello World".split(123)`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
+		{`"Hello World".split(1..2)`, "TypeError: Expect argument to be String. got: Range", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1232,17 +1232,17 @@ func TestStringStartWithMethod(t *testing.T) {
 
 func TestStringStartWithMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Taipei".start_with("1", "0", "1")`, "ArgumentError: Expect 1 argument. got=3", 1},
-		{`"Taipei".start_with(101)`, "TypeError: Expect argument to be String. got: Integer", 1},
-		{`"Hello".start_with(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
-		{`"Hello".start_with(1..5)`, "TypeError: Expect argument to be String. got: Range", 1},
+		{`"Taipei".start_with("1", "0", "1")`, "ArgumentError: Expect 1 argument. got=3", 1, 1},
+		{`"Taipei".start_with(101)`, "TypeError: Expect argument to be String. got: Integer", 1, 1},
+		{`"Hello".start_with(true)`, "TypeError: Expect argument to be String. got: Boolean", 1, 1},
+		{`"Hello".start_with(1..5)`, "TypeError: Expect argument to be String. got: Range", 1, 1},
 	}
 
 	for i, tt := range testsFail {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
-		v.checkCFP(t, i, 1)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -170,7 +170,7 @@ func (t *thread) sendMethod(methodName string, argCount int, blockFrame *callFra
 	case *BuiltinMethodObject:
 		t.evalBuiltinMethod(receiver, m, receiverPr, argCount, &bytecode.ArgSet{}, blockFrame)
 	case *Error:
-		t.returnError(errors.InternalError, m.toString())
+		t.pushErrorObject(errors.InternalError, m.toString())
 	}
 }
 
@@ -274,11 +274,11 @@ func (t *thread) evalMethodObject(call *callObject) {
 	t.sp = call.argPtr()
 }
 
-func (t *thread) returnError(errorType, format string, args ...interface{}) {
+func (t *thread) pushErrorObject(errorType, format string, args ...interface{}) {
 	err := t.vm.initErrorObject(errorType, format, args...)
 	t.stack.push(&Pointer{Target: err})
 }
 
-func (t *thread) unsupportedMethodError(methodName string, receiver Object) *Error {
+func (t *thread) initUnsupportedMethodError(methodName string, receiver Object) *Error {
 	return t.vm.initErrorObject(errors.UnsupportedMethodError, "Unsupported Method %s for %+v", methodName, receiver.toString())
 }

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -40,12 +40,55 @@ func (t *thread) startFromTopFrame() {
 	t.evalCallFrame(cf)
 }
 
-func (t *thread) evalCallFrame(cf *normalCallFrame) {
-	for cf.pc < len(cf.instructionSet.instructions) {
-		i := cf.instructionSet.instructions[cf.pc]
-		t.execInstruction(cf, i)
-		if _, yes := t.hasError(); yes {
-			return
+func (t *thread) evalCallFrame(cf callFrame) {
+	switch cf := cf.(type) {
+	case *normalCallFrame:
+		for cf.pc < len(cf.instructionSet.instructions) {
+			i := cf.instructionSet.instructions[cf.pc]
+			t.execInstruction(cf, i)
+			if _, yes := t.hasError(); yes {
+				return
+			}
+		}
+	case *goMethodCallFrame:
+		args := []Object{}
+
+		for _, obj := range cf.locals {
+			if obj != nil {
+				args = append(args, obj.Target)
+			}
+		}
+		result := cf.method(t, args, cf.blockFrame)
+		t.stack.push(&Pointer{Target: result})
+		t.callFrameStack.pop()
+	}
+
+	t.removeUselessBlockFrame(cf)
+}
+
+/*
+	Remove top frame if it's a block frame
+
+	Block execution frame <- This was popped after callframe is executed
+	---------------------
+	Block frame           <- So this frame is useless
+	---------------------
+	Main frame
+*/
+
+func (t *thread) removeUselessBlockFrame(frame callFrame) {
+	switch frame.(type) {
+	case *normalCallFrame:
+		topFrame := t.callFrameStack.top()
+		if topFrame != nil && topFrame.IsBlock() {
+			normalFrame := t.callFrameStack.pop().(*normalCallFrame)
+			normalFrame.pc = len(normalFrame.instructionSet.instructions)
+		}
+	case *goMethodCallFrame:
+		topFrame := t.callFrameStack.top()
+
+		if topFrame != nil && topFrame.IsBlock() {
+			t.callFrameStack.pop()
 		}
 	}
 }
@@ -54,7 +97,9 @@ func (t *thread) hasError() (string, bool) {
 	var hasError bool
 	var msg string
 	if t.stack.top() != nil {
-		if err, ok := t.stack.top().Target.(*Error); ok {
+		top := t.stack.top().Target
+		err, ok := top.(*Error)
+		if ok {
 			hasError = true
 			msg = err.Message
 		}
@@ -174,27 +219,30 @@ func (t *thread) sendMethod(methodName string, argCount int, blockFrame *normalC
 	}
 }
 
-func (t *thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject, receiverPr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame) {
-	methodBody := method.Fn(receiver)
-	args := []Object{}
-	argPr := receiverPr + 1
+func (t *thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame) {
+	cf := newGoMethodCallFrame(method.Fn(receiver), method.Name)
+	cf.blockFrame = blockFrame
+	argPtr := receiverPtr + 1
 
 	for i := 0; i < argCount; i++ {
-		args = append(args, t.stack.Data[argPr+i].Target)
+		cf.locals = append(cf.locals, t.stack.Data[argPtr+i])
 	}
 
-	evaluated := methodBody(t, args, blockFrame)
+	t.callFrameStack.push(cf)
+	t.startFromTopFrame()
+	evaluated := t.stack.top()
 
 	_, ok := receiver.(*RClass)
 	if method.Name == "new" && ok {
-		instance, ok := evaluated.(*RObject)
+		instance, ok := evaluated.Target.(*RObject)
 		if ok && instance.InitializeMethod != nil {
-			callObj := newCallObject(instance, instance.InitializeMethod, receiverPr, argCount, argSet, blockFrame)
+			callObj := newCallObject(instance, instance.InitializeMethod, receiverPtr, argCount, argSet, blockFrame)
 			t.evalMethodObject(callObj)
 		}
 	}
-	t.stack.set(receiverPr, &Pointer{Target: evaluated})
-	t.sp = argPr
+
+	t.stack.set(receiverPtr, evaluated)
+	t.sp = argPtr
 }
 
 func (t *thread) reportArgumentError(idealArgNumber int, methodName string, exactArgNumber int, receiverPtr int) {

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -110,7 +110,7 @@ func (t *thread) hasError() (string, bool) {
 func (t *thread) execInstruction(cf *normalCallFrame, i *instruction) {
 	cf.pc++
 
-	i.action.operation(t, cf, i.Params...)
+	i.action.operation(t, i, cf, i.Params...)
 }
 
 func (t *thread) builtinMethodYield(blockFrame *normalCallFrame, args ...Object) *Pointer {
@@ -156,7 +156,7 @@ func (t *thread) retrieveBlock(cf *normalCallFrame, args []interface{}) (blockFr
 	return
 }
 
-func (t *thread) sendMethod(methodName string, argCount int, blockFrame *normalCallFrame) {
+func (t *thread) sendMethod(methodName string, argCount int, blockFrame *normalCallFrame, instruction *instruction) {
 	var method Object
 
 	if arr, ok := t.stack.top().Target.(*ArrayObject); ok && arr.splat {
@@ -215,15 +215,15 @@ func (t *thread) sendMethod(methodName string, argCount int, blockFrame *normalC
 		callObj := newCallObject(receiver, m, receiverPr, argCount, &bytecode.ArgSet{}, blockFrame, sendCallFrame.SourceLine(), sendCallFrame.FileName())
 		t.evalMethodObject(callObj)
 	case *BuiltinMethodObject:
-		t.evalBuiltinMethod(receiver, m, receiverPr, argCount, &bytecode.ArgSet{}, blockFrame, sendCallFrame.SourceLine(), sendCallFrame.FileName())
+		t.evalBuiltinMethod(receiver, m, receiverPr, argCount, &bytecode.ArgSet{}, blockFrame, instruction, sendCallFrame.FileName())
 	case *Error:
 		t.pushErrorObject(errors.InternalError, m.toString())
 	}
 }
 
-func (t *thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame, sourceLine int, fileName string) {
-	cf := newGoMethodCallFrame(method.Fn(receiver), method.Name, fileName)
-	cf.sourceLine = sourceLine
+func (t *thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame, instruction *instruction, fileName string) {
+	cf := newGoMethodCallFrame(method.Fn(receiver, instruction), method.Name, fileName)
+	cf.sourceLine = instruction.sourceLine
 	cf.blockFrame = blockFrame
 	argPtr := receiverPtr + 1
 
@@ -239,7 +239,7 @@ func (t *thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject,
 	if method.Name == "new" && ok {
 		instance, ok := evaluated.Target.(*RObject)
 		if ok && instance.InitializeMethod != nil {
-			callObj := newCallObject(instance, instance.InitializeMethod, receiverPtr, argCount, argSet, blockFrame, sourceLine, fileName)
+			callObj := newCallObject(instance, instance.InitializeMethod, receiverPtr, argCount, argSet, blockFrame, instruction.sourceLine, fileName)
 			t.evalMethodObject(callObj)
 		}
 	}

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -155,11 +155,9 @@ func (t *thread) builtinMethodYield(blockFrame *normalCallFrame, args ...Object)
 	return t.stack.top()
 }
 
-func (t *thread) retrieveBlock(cf *normalCallFrame, args []interface{}) (blockFrame *normalCallFrame) {
+func (t *thread) retrieveBlock(fileName, blockFlag string) (blockFrame *normalCallFrame) {
 	var blockName string
 	var hasBlock bool
-
-	blockFlag := args[2].(string)
 
 	if len(blockFlag) != 0 {
 		hasBlock = true
@@ -167,15 +165,10 @@ func (t *thread) retrieveBlock(cf *normalCallFrame, args []interface{}) (blockFr
 	}
 
 	if hasBlock {
-		block := t.getBlock(blockName, cf.instructionSet.filename)
+		block := t.getBlock(blockName, fileName)
 
-		c := newNormalCallFrame(block, cf.instructionSet.filename)
+		c := newNormalCallFrame(block, fileName)
 		c.isBlock = true
-		c.ep = cf
-		c.self = cf.self
-
-		t.callFrameStack.push(c)
-
 		blockFrame = c
 	}
 

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -202,7 +202,7 @@ func (t *thread) sendMethod(methodName string, argCount int, blockFrame *normalC
 	method = receiver.findMethod(methodName)
 
 	if method == nil {
-		err := t.vm.initErrorObject(errors.UndefinedMethodError, "Undefined Method '%+v' for %+v", methodName, receiver.toString())
+		err := t.vm.initErrorObject(errors.UndefinedMethodError, instruction, "Undefined Method '%+v' for %+v", methodName, receiver.toString())
 		t.stack.set(receiverPr, &Pointer{Target: err})
 		t.sp = argPr
 		return
@@ -213,11 +213,11 @@ func (t *thread) sendMethod(methodName string, argCount int, blockFrame *normalC
 	switch m := method.(type) {
 	case *MethodObject:
 		callObj := newCallObject(receiver, m, receiverPr, argCount, &bytecode.ArgSet{}, blockFrame, sendCallFrame.SourceLine(), sendCallFrame.FileName())
-		t.evalMethodObject(callObj)
+		t.evalMethodObject(callObj, instruction)
 	case *BuiltinMethodObject:
 		t.evalBuiltinMethod(receiver, m, receiverPr, argCount, &bytecode.ArgSet{}, blockFrame, instruction, sendCallFrame.FileName())
 	case *Error:
-		t.pushErrorObject(errors.InternalError, m.toString())
+		t.pushErrorObject(errors.InternalError, instruction, m.toString())
 	}
 }
 
@@ -240,7 +240,7 @@ func (t *thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject,
 		instance, ok := evaluated.Target.(*RObject)
 		if ok && instance.InitializeMethod != nil {
 			callObj := newCallObject(instance, instance.InitializeMethod, receiverPtr, argCount, argSet, blockFrame, instruction.sourceLine, fileName)
-			t.evalMethodObject(callObj)
+			t.evalMethodObject(callObj, instruction)
 		}
 	}
 
@@ -248,7 +248,7 @@ func (t *thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject,
 	t.sp = argPtr
 }
 
-func (t *thread) reportArgumentError(idealArgNumber int, methodName string, exactArgNumber int, receiverPtr int) {
+func (t *thread) reportArgumentError(instruction *instruction, idealArgNumber int, methodName string, exactArgNumber int, receiverPtr int) {
 	var message string
 
 	if idealArgNumber > exactArgNumber {
@@ -257,24 +257,25 @@ func (t *thread) reportArgumentError(idealArgNumber int, methodName string, exac
 		message = "Expect at most %d args for method '%s'. got: %d"
 	}
 
-	e := t.vm.initErrorObject(errors.ArgumentError, message, idealArgNumber, methodName, exactArgNumber)
+	e := t.vm.initErrorObject(errors.ArgumentError, instruction, message, idealArgNumber, methodName, exactArgNumber)
 	t.stack.set(receiverPtr, &Pointer{Target: e})
 	t.sp = receiverPtr + 1
 }
 
-func (t *thread) evalMethodObject(call *callObject) {
+// TODO: Move instruction into call object
+func (t *thread) evalMethodObject(call *callObject, instruction *instruction) {
 	normalParamsCount := call.normalParamsCount()
 	paramTypes := call.paramTypes()
 	paramsCount := len(call.paramTypes())
 	stack := t.stack.Data
 
 	if call.argCount > paramsCount && !call.method.isSplatArgIncluded() {
-		t.reportArgumentError(paramsCount, call.methodName(), call.argCount, call.receiverPtr)
+		t.reportArgumentError(instruction, paramsCount, call.methodName(), call.argCount, call.receiverPtr)
 		return
 	}
 
 	if normalParamsCount > call.argCount {
-		t.reportArgumentError(normalParamsCount, call.methodName(), call.argCount, call.receiverPtr)
+		t.reportArgumentError(instruction, normalParamsCount, call.methodName(), call.argCount, call.receiverPtr)
 		return
 	}
 
@@ -284,7 +285,7 @@ func (t *thread) evalMethodObject(call *callObject) {
 		case bytecode.RequiredKeywordArg:
 			paramName := call.paramNames()[paramIndex]
 			if _, ok := call.hasKeywordArgument(paramName); !ok {
-				e := t.vm.initErrorObject(errors.ArgumentError, "Method %s requires key argument %s", call.methodName(), paramName)
+				e := t.vm.initErrorObject(errors.ArgumentError, instruction, "Method %s requires key argument %s", call.methodName(), paramName)
 				t.stack.set(call.receiverPtr, &Pointer{Target: e})
 				t.sp = call.argPtr()
 				return
@@ -295,7 +296,7 @@ func (t *thread) evalMethodObject(call *callObject) {
 	err := call.assignKeywordArguments(stack)
 
 	if err != nil {
-		e := t.vm.initErrorObject(errors.ArgumentError, err.Error())
+		e := t.vm.initErrorObject(errors.ArgumentError, instruction, err.Error())
 		t.stack.set(call.receiverPtr, &Pointer{Target: e})
 		t.sp = call.argPtr()
 		return
@@ -325,11 +326,11 @@ func (t *thread) evalMethodObject(call *callObject) {
 	t.sp = call.argPtr()
 }
 
-func (t *thread) pushErrorObject(errorType, format string, args ...interface{}) {
-	err := t.vm.initErrorObject(errorType, format, args...)
+func (t *thread) pushErrorObject(errorType string, instruction *instruction, format string, args ...interface{}) {
+	err := t.vm.initErrorObject(errorType, instruction, format, args...)
 	t.stack.push(&Pointer{Target: err})
 }
 
-func (t *thread) initUnsupportedMethodError(methodName string, receiver Object) *Error {
-	return t.vm.initErrorObject(errors.UnsupportedMethodError, "Unsupported Method %s for %+v", methodName, receiver.toString())
+func (t *thread) initUnsupportedMethodError(instruction *instruction, methodName string, receiver Object) *Error {
+	return t.vm.initErrorObject(errors.UnsupportedMethodError, instruction, "Unsupported Method %s for %+v", methodName, receiver.toString())
 }

--- a/vm/uri.go
+++ b/vm/uri.go
@@ -28,7 +28,7 @@ func builtinURIClassMethods() []*BuiltinMethodObject {
 					u, err := url.Parse(uri)
 
 					if err != nil {
-						return t.vm.initErrorObject(errors.InternalError, err.Error())
+						return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 					}
 
 					uriAttrs := map[string]Object{
@@ -56,7 +56,7 @@ func builtinURIClassMethods() []*BuiltinMethodObject {
 						p, err := strconv.ParseInt(u.Port(), 0, 64)
 
 						if err != nil {
-							return t.vm.initErrorObject(errors.InternalError, err.Error())
+							return t.vm.initErrorObject(errors.InternalError, instruction, err.Error())
 						}
 
 						uriAttrs["@port"] = t.vm.initIntegerObject(int(p))

--- a/vm/uri.go
+++ b/vm/uri.go
@@ -21,7 +21,7 @@ func builtinURIClassMethods() []*BuiltinMethodObject {
 			// u.path # => "/"
 			// ```
 			Name: "parse",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					uri := args[0].(*StringObject).value
 					uriModule := t.vm.topLevelClass("URI")

--- a/vm/uri.go
+++ b/vm/uri.go
@@ -22,7 +22,7 @@ func builtinURIClassMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "parse",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(t *thread, args []Object, blockFrame *callFrame) Object {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
 					uri := args[0].(*StringObject).value
 					uriModule := t.vm.topLevelClass("URI")
 					u, err := url.Parse(uri)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -268,7 +268,8 @@ func (vm *VM) startFromTopFrame() {
 }
 
 func (vm *VM) currentFilePath() string {
-	return string(vm.mainThread.callFrameStack.top().instructionSet.filename)
+	frame := vm.mainThread.callFrameStack.top()
+	return frame.FileName()
 }
 
 func (vm *VM) getBlock(name string, filename filename) *instructionSet {
@@ -328,7 +329,7 @@ func (vm *VM) loadConstant(name string, isModule bool) *RClass {
 	return c
 }
 
-func (vm *VM) lookupConstant(cf *normalCallFrame, constName string) (constant *Pointer) {
+func (vm *VM) lookupConstant(cf callFrame, constName string) (constant *Pointer) {
 	var namespace *RClass
 	var hasNamespace bool
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -366,7 +366,7 @@ func (vm *VM) execGobyLib(libName string) {
 	file, err := ioutil.ReadFile(libPath)
 
 	if err != nil {
-		vm.mainThread.returnError(errors.InternalError, err.Error())
+		vm.mainThread.pushErrorObject(errors.InternalError, err.Error())
 	}
 
 	vm.execRequiredFile(libPath, file)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -141,23 +141,23 @@ func (vm *VM) newThread() *thread {
 
 // ExecInstructions accepts a sequence of bytecodes and use vm to evaluate them.
 func (vm *VM) ExecInstructions(sets []*bytecode.InstructionSet, fn string) {
-	p := newInstructionTranslator(fn)
-	p.vm = vm
-	p.transferInstructionSets(sets)
+	translator := newInstructionTranslator(fn)
+	translator.vm = vm
+	translator.transferInstructionSets(sets)
 
 	// Keep instruction set table updated after parsed new files.
 	// TODO: Find more efficient way to do this.
-	for setType, table := range p.setTable {
+	for setType, table := range translator.setTable {
 		for name, is := range table {
 			vm.isTables[setType][name] = is
 		}
 	}
 
-	vm.blockTables[p.filename] = p.blockTable
-	vm.SetClassISIndexTable(p.filename)
-	vm.SetMethodISIndexTable(p.filename)
+	vm.blockTables[translator.filename] = translator.blockTable
+	vm.SetClassISIndexTable(translator.filename)
+	vm.SetMethodISIndexTable(translator.filename)
 
-	cf := newNormalCallFrame(p.program)
+	cf := newNormalCallFrame(translator.program, translator.filename)
 	cf.self = vm.mainObj
 	vm.mainThread.callFrameStack.push(cf)
 	vm.startFromTopFrame()

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -131,7 +131,7 @@ func New(fileDir string, args []string) (vm *VM, e error) {
 
 func (vm *VM) newThread() *thread {
 	s := &stack{RWMutex: new(sync.RWMutex)}
-	cfs := &callFrameStack{callFrames: []*callFrame{}}
+	cfs := &callFrameStack{callFrames: []callFrame{}}
 	t := &thread{stack: s, callFrameStack: cfs, sp: 0, cfp: 0}
 	s.thread = t
 	cfs.thread = t
@@ -157,7 +157,7 @@ func (vm *VM) ExecInstructions(sets []*bytecode.InstructionSet, fn string) {
 	vm.SetClassISIndexTable(p.filename)
 	vm.SetMethodISIndexTable(p.filename)
 
-	cf := newCallFrame(p.program)
+	cf := newNormalCallFrame(p.program)
 	cf.self = vm.mainObj
 	vm.mainThread.callFrameStack.push(cf)
 	vm.startFromTopFrame()
@@ -179,7 +179,7 @@ func builtinMainObjSingletonMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_s",
 			Fn: func(receiver Object) builtinMethodBody {
-				return func(thread *thread, objects []Object, frame *callFrame) Object {
+				return func(thread *thread, objects []Object, frame *normalCallFrame) Object {
 					return thread.vm.initStringObject("main")
 				}
 			},
@@ -328,7 +328,7 @@ func (vm *VM) loadConstant(name string, isModule bool) *RClass {
 	return c
 }
 
-func (vm *VM) lookupConstant(cf *callFrame, constName string) (constant *Pointer) {
+func (vm *VM) lookupConstant(cf *normalCallFrame, constName string) (constant *Pointer) {
 	var namespace *RClass
 	var hasNamespace bool
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -367,7 +367,7 @@ func (vm *VM) execGobyLib(libName string) {
 	file, err := ioutil.ReadFile(libPath)
 
 	if err != nil {
-		vm.mainThread.pushErrorObject(errors.InternalError, err.Error())
+		vm.mainThread.pushErrorObject(errors.InternalError, nil, err.Error())
 	}
 
 	vm.execRequiredFile(libPath, file)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -178,7 +178,7 @@ func builtinMainObjSingletonMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "to_s",
-			Fn: func(receiver Object) builtinMethodBody {
+			Fn: func(receiver Object, instruction *instruction) builtinMethodBody {
 				return func(thread *thread, objects []Object, frame *normalCallFrame) Object {
 					return thread.vm.initStringObject("main")
 				}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 type errorTestCase struct {
-	input     string
-	expected  string
-	errorLine int
+	input       string
+	expected    string
+	errorLine   int
+	expectedCFP int
 }
 
 func TestVM_REPLExec(t *testing.T) {


### PR DESCRIPTION
Currently `vm/thread.go`'s code is quite ugly, especially the method call part. So this PR is aim at refactoring thread's `evalMethodObject` function.