### PR TITLE
Make the snap classic (https://docs.snapcraft.io/reference/confinement)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,19 +1,19 @@
 name: goby-lang
-version: master
+version: git
 summary: A new language helps you develop microservices
 description: |
   Goby is an object-oriented interpreter language deeply inspired by Ruby as
   well as its core implementation by 100% pure Go. Moreover, it has standard
   libraries to provide several features such as the Plugin system.
 
-grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: devmode
+grade: stable
+confinement: classic
 
 apps:
   goby:
     environment:
       GOBY_ROOT: $SNAP
-    command: goby
+    command: bin/goby
 
 parts:
   goby:


### PR DESCRIPTION
This makes the snap classic so that it can interact with the user's filesystem. It also generates the version string from git.

Classic confinement requires manual approval in the Snap Store, which I have a request up for here:
https://forum.snapcraft.io/t/classic-confinement-for-goby/2665