### PR TITLE
Fix toplevel constant's bug: issue #491

### DIFF
--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -81,7 +81,7 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	// Prohibit calling a capitalized method on toplevel:
 	if p.curTokenIs(token.Constant) && (p.fsm.Is(normal) || p.fsm.Is(parsingAssignment)) {
 		if p.peekTokenIs(token.LParen) {
-			p.peekError(p.curToken.Type)
+			p.callConstantError(p.curToken.Type)
 			return nil
 		}
 	}

--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -78,6 +78,14 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 		return nil
 	}
 
+	// Prohibit calling a capitalized method on toplevel:
+	if p.curTokenIs(token.Constant) && (p.fsm.Is(normal) || p.fsm.Is(parsingAssignment)) {
+		if p.peekTokenIs(token.LParen) {
+			p.peekError(p.curToken.Type)
+			return nil
+		}
+	}
+
 	/*
 		Parse method call without explicit receiver and doesn't have parens around arguments. Here's some examples:
 

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -294,3 +294,8 @@ func newTypeParsingError(tokenLiteral, targetType string, line int) *Error {
 	msg := fmt.Sprintf("could not parse %q as %s. Line: %d", tokenLiteral, targetType, line)
 	return &Error{Message: msg, errType: SyntaxError}
 }
+
+func (p *Parser) callConstantError(t token.Type) {
+	msg := fmt.Sprintf("cannot call %s with %s. Line: %d", t, p.peekToken.Type, p.peekToken.Line)
+	p.error = &Error{Message: msg, errType: UnexpectedTokenError}
+}

--- a/compiler/parser/parser_test.go
+++ b/compiler/parser/parser_test.go
@@ -364,3 +364,22 @@ func testLiteralExpression(
 	t.Errorf("type of exp not handled. got=%T", exp)
 	return false
 }
+
+// Makes sure to prohibit calling a capitalized method on toplevel
+func TestProhibitingCallingCapitalizedMethod(t *testing.T) {
+	input := `
+	Const()
+	`
+
+	l := lexer.New(input)
+	p := New(l)
+	_, err := p.ParseProgram()
+
+	if err == nil {
+		t.Fatal("Calling a capitalized method on toplevel should be prohibited")
+	} else {
+		if err.Message != "cannot call CONSTANT with (. Line: 1" {
+			t.Fatal("Error should be: 'cannot call CONSTANT with (. Line: 1': ", err.Message)
+		}
+	}
+}


### PR DESCRIPTION
Fixing https://github.com/goby-lang/goby/issues/491

Added the following message:

```ruby
» Hi()
cannot call CONSTANT with (. Line: 0
```