### PR TITLE
Refactor: Add type alias for regexp2.Regexp

### DIFF
--- a/vm/regexp.go
+++ b/vm/regexp.go
@@ -34,9 +34,10 @@ import (
 //
 // **To Goby maintainers**: avoid using Go's standard regexp package (slow and not rich). Consider the faster `Trim` or `Split` etc in Go's "strings" package first, or just use the dlclark/regexp2 instead.
 // ToDo: Regexp literals with '/.../'
+type Regexp = regexp2.Regexp
 type RegexpObject struct {
 	*baseObj
-	Regexp *regexp2.Regexp
+	regexp *Regexp
 }
 
 // Class methods --------------------------------------------------------
@@ -132,7 +133,7 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 						return t.vm.initErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
 					}
 
-					re := receiver.(*RegexpObject).Regexp
+					re := receiver.(*RegexpObject).regexp
 					m, _ := re.MatchString(input.value)
 
 					return toBooleanObject(m)
@@ -153,7 +154,7 @@ func (vm *VM) initRegexpObject(regexp string) *RegexpObject {
 	}
 	return &RegexpObject{
 		baseObj: &baseObj{class: vm.topLevelClass(classes.RegexpClass)},
-		Regexp:  r,
+		regexp:  r,
 	}
 }
 
@@ -168,12 +169,12 @@ func (vm *VM) initRegexpClass() *RClass {
 
 // Value returns the object
 func (r *RegexpObject) Value() interface{} {
-	return r.toString()
+	return r.regexp.String()
 }
 
 // toString returns the object's name as the string format
 func (r *RegexpObject) toString() string {
-	return r.Regexp.String()
+	return r.regexp.String()
 }
 
 // toJSON just delegates to toString

--- a/vm/string.go
+++ b/vm/string.go
@@ -261,7 +261,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 
 					arg := args[0]
 
-					regexp, ok := arg.(*RegexpObject)
+					re, ok := arg.(*RegexpObject)
 
 					if !ok {
 						return t.vm.initErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.RegexpClass, arg.Class().Name)
@@ -269,7 +269,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 
 					text := receiver.(*StringObject).value
 
-					match, _ := regexp.Regexp.FindStringMatch(text)
+					match, _ := re.regexp.FindStringMatch(text)
 
 					if match == nil {
 						return NULL
@@ -1035,7 +1035,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// 'pow'.match(Regexp.new("x")) # => nil
 			// ```
 			//
-			// @param string [String]
+			// @param string [Regexp]
 			// @return [MatchData]
 			Name: "match",
 			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
@@ -1051,16 +1051,16 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 						return t.vm.initErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.RegexpClass, arg.Class().Name)
 					}
 
-					regexp := regexpObj.Regexp
+					re := regexpObj.regexp
 					text := receiver.(*StringObject).value
 
-					match, _ := regexp.FindStringMatch(text)
+					match, _ := re.FindStringMatch(text)
 
 					if match == nil {
 						return NULL
 					}
 
-					return t.vm.initMatchDataObject(match, regexp.String(), text)
+					return t.vm.initMatchDataObject(match, re.String(), text)
 				}
 			},
 		},


### PR DESCRIPTION
- Add a type alias `Regexp` for `*regexp2.Regexp`
- Change the attribute `Regexp` to the lowercase `regexp`