### PR TITLE
Fix #508/update MatchData class

### DIFF
--- a/vm/match_data.go
+++ b/vm/match_data.go
@@ -112,9 +112,9 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 						return t.vm.initErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 					}
 
-					matchData, _ := receiver.(*MatchDataObject)
+					m := receiver.(*MatchDataObject).match
 
-					return t.vm.initIntegerObject(len(matchData.captures))
+					return t.vm.initIntegerObject(m.GroupCount())
 				}
 			},
 		},

--- a/vm/match_data_test.go
+++ b/vm/match_data_test.go
@@ -27,9 +27,9 @@ func TestMatchDataCaptures(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{`'a1bca2'.match(Regexp.new('a.')).to_s`, "#<MatchData \"a1\">"},
-		{`'a1bca2'.match(Regexp.new('(a.)')).to_s`, "#<MatchData \"a1\" 1:\"a1\">"},
-		{`'a1bca2'.match(Regexp.new('(a.)(b.)')).to_s`, "#<MatchData \"a1bc\" 1:\"a1\" 2:\"bc\">"},
+		{`'a1bca2'.match(Regexp.new('a.')).to_s`, "#<MatchData 0:\"a1\">"},
+		{`'a1bca2'.match(Regexp.new('(a.)')).to_s`, "#<MatchData 0:\"a1\" 1:\"a1\">"},
+		{`'a1bca2'.match(Regexp.new('(a.)(b.)')).to_s`, "#<MatchData 0:\"a1bc\" 1:\"a1\" 2:\"bc\">"},
 	}
 
 	for i, tt := range tests {

--- a/vm/regexp.go
+++ b/vm/regexp.go
@@ -34,9 +34,10 @@ import (
 //
 // **To Goby maintainers**: avoid using Go's standard regexp package (slow and not rich). Consider the faster `Trim` or `Split` etc in Go's "strings" package first, or just use the dlclark/regexp2 instead.
 // ToDo: Regexp literals with '/.../'
+type Regexp = regexp2.Regexp
 type RegexpObject struct {
 	*baseObj
-	Regexp *regexp2.Regexp
+	regexp *Regexp
 }
 
 // Class methods --------------------------------------------------------
@@ -132,7 +133,7 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 						return t.vm.initErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
 					}
 
-					re := receiver.(*RegexpObject).Regexp
+					re := receiver.(*RegexpObject).regexp
 					m, _ := re.MatchString(input.value)
 
 					return toBooleanObject(m)
@@ -153,7 +154,7 @@ func (vm *VM) initRegexpObject(regexp string) *RegexpObject {
 	}
 	return &RegexpObject{
 		baseObj: &baseObj{class: vm.topLevelClass(classes.RegexpClass)},
-		Regexp:  r,
+		regexp:  r,
 	}
 }
 
@@ -168,12 +169,12 @@ func (vm *VM) initRegexpClass() *RClass {
 
 // Value returns the object
 func (r *RegexpObject) Value() interface{} {
-	return r.toString()
+	return r.regexp.String()
 }
 
 // toString returns the object's name as the string format
 func (r *RegexpObject) toString() string {
-	return r.Regexp.String()
+	return r.regexp.String()
 }
 
 // toJSON just delegates to toString

--- a/vm/string.go
+++ b/vm/string.go
@@ -261,7 +261,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 
 					arg := args[0]
 
-					regexp, ok := arg.(*RegexpObject)
+					re, ok := arg.(*RegexpObject)
 
 					if !ok {
 						return t.vm.initErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.RegexpClass, arg.Class().Name)
@@ -269,7 +269,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 
 					text := receiver.(*StringObject).value
 
-					match, _ := regexp.Regexp.FindStringMatch(text)
+					match, _ := re.regexp.FindStringMatch(text)
 
 					if match == nil {
 						return NULL
@@ -1035,7 +1035,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// 'pow'.match(Regexp.new("x")) # => nil
 			// ```
 			//
-			// @param string [String]
+			// @param string [Regexp]
 			// @return [MatchData]
 			Name: "match",
 			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
@@ -1051,16 +1051,16 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 						return t.vm.initErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.RegexpClass, arg.Class().Name)
 					}
 
-					regexp := regexpObj.Regexp
+					re := regexpObj.regexp
 					text := receiver.(*StringObject).value
 
-					match, _ := regexp.FindStringMatch(text)
+					match, _ := re.FindStringMatch(text)
 
 					if match == nil {
 						return NULL
 					}
 
-					return t.vm.initMatchDataObject(match, regexp.String(), text)
+					return t.vm.initMatchDataObject(match, re.String(), text)
 				}
 			},
 		},

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -901,7 +901,7 @@ func TestStringMatch(t *testing.T) {
 		input    string
 		expected interface{}
 	}{
-		{`"Goby!!".match(Regexp.new("G(o)b(y)")).to_s`, "#<MatchData \"Goby\" 1:\"o\" 2:\"y\">"},
+		{`"Goby!!".match(Regexp.new("G(o)b(y)")).to_s`, "#<MatchData 0:\"Goby\" 1:\"o\" 2:\"y\">"},
 		{`"Ruby".match(Regexp.new("G(o)b(y)"))`, nil},
 	}
 


### PR DESCRIPTION
- To fix https://github.com/goby-lang/goby/issues/508, including update for `MatchData`

@st0012 as notified https://github.com/goby-lang/goby/issues/508#issuecomment-343762322, I'd like to use the "new style" for MatchData object if you're OK.

- Ruby style:`#<MatchData "Goby" 1:"o" 2:"y">`
- New style:     `#<MatchData 0:"Goby" 1:"o" 2:"y">`