### PR TITLE
Add checks the number of args in `require` and `require_relative`

### DIFF
--- a/vm/class.go
+++ b/vm/class.go
@@ -855,15 +855,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// Loads the given Goby library name without extension (mainly for modules), returning `true`
 			// if successful and `false` if the feature is already loaded.
 			//
-			// Currently, only the following embedded Goby libraries are targeted:
-			//
-			// - "file"
-			// - "net/http"
-			// - "net/simple_server"
-			// - "uri"
-			//
 			// ```ruby
-			// require("file")
+			// require("db")
 			// File.extname("foo.rb")
 			// ```
 			//

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -746,14 +746,19 @@ func TestRequireStandardLibSuccess(t *testing.T) {
 }
 
 func TestRequireFail(t *testing.T) {
-	input := `require "bar"`
-	expected := `InternalError: Can't require "bar"`
+	testsFail := []errorTestCase{
+		{`require "bar"`, `InternalError: Can't require "bar"`, 1, 1},
+		{`require "db", "json"`, `ArgumentError: Expect 1 argument. got: 2`, 1, 1},
+		{`require_relative "db", "json"`, `ArgumentError: Expect 1 argument. got: 2`, 1, 1},
+	}
 
-	v := initTestVM()
-	evaluated := v.testEval(t, input, getFilename())
-	checkError(t, 0, evaluated, expected, getFilename(), 1)
-	v.checkCFP(t, 0, 1)
-	v.checkSP(t, 0, 1)
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
 }
 
 func TestGeneralIsNilMethod(t *testing.T) {


### PR DESCRIPTION
- Add a check for the number of arguments in `require` and `require_relative`
- Update the API document

FYI: I happened to find that `require :db` works. Looks like this comes from the fact that symbols are automatically converted into strings. Of course `require :net/http` does not work.