### PR TITLE
[WIP] Time class

### DIFF
--- a/lib/time.gb
+++ b/lib/time.gb
@@ -1,0 +1,9 @@
+# The Time class is just to extend Goby's native Time class (vm/time.go).
+
+class Time
+  # Alias of Time.new. The printed format is like the following:
+  # "2017-11-18 17:30:15.496004 +0900 JST m=+5.870407705"
+  def self.now
+    new
+  end
+end

--- a/vm/classes/classes.go
+++ b/vm/classes/classes.go
@@ -20,4 +20,5 @@ const (
 	MatchDataClass = "MatchData"
 	GoMapClass     = "GoMap"
 	DecimalClass   = "Decimal"
+	TimeClass      = "Time"
 )

--- a/vm/time.go
+++ b/vm/time.go
@@ -66,6 +66,31 @@ func builtinTimeClassMethods() []*BuiltinMethodObject {
 func builtinTimeInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
+			// Parses a string-format time/date/timezone and updates the Time object.
+			Name: "parse",
+			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
+					if len(args) != 1 {
+						return t.vm.initErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+					}
+
+					arg, ok := args[0].(*StringObject)
+					if !ok {
+						return t.vm.initErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
+					}
+
+					ts, err := parseTime(arg.toString())
+					if err != nil {
+						return t.vm.initErrorObject(errors.ArgumentError, sourceLine, "Invalid time format. got=%s", arg.value)
+					}
+
+					m := receiver.(*TimeObject)
+					m.value = ts
+					return m
+				}
+			},
+		},
+		{
 			// Converts a Time object into a fixed-format string.
 			Name: "to_s",
 			Fn: func(receiver Object, sourceLine int) builtinMethodBody {

--- a/vm/time.go
+++ b/vm/time.go
@@ -67,6 +67,12 @@ func builtinTimeInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			// Parses a string-format time/date/timezone and updates the Time object.
+			//
+			// ```Ruby
+			// Time.new.parse('2017-05-30') #=> 2017-05-30 00:00:00 +0000 UTC
+			// ```
+			//
+			// @return [Time]
 			Name: "parse",
 			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
@@ -91,7 +97,17 @@ func builtinTimeInstanceMethods() []*BuiltinMethodObject {
 			},
 		},
 		{
-			// Converts a Time object into a fixed-format string.
+			// Converts a Time object into a string format.
+			//
+			// ```Ruby
+			// Time.new('2017-05-30').to_s
+			// #=> "2017-05-30 00:00:00 +0000 UTC"
+			//
+			// Time.new.to_s
+			// #=> 2017-11-18 18:46:23.721956 +0900 JST m=+108.616754431
+			// ```
+			//
+			// @return [Time]
 			Name: "to_s",
 			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {

--- a/vm/time.go
+++ b/vm/time.go
@@ -1,0 +1,164 @@
+package vm
+
+import (
+	"github.com/goby-lang/goby/vm/classes"
+	"github.com/goby-lang/goby/vm/errors"
+	"strings"
+	"time"
+)
+
+// TimeObject represents an absolute point on a time flow, in year/month/day/hour/minute/second or RFC/ISO representations or like that, considering timezone, geo-location, DST, and calendar system.
+// TBD: Note that TimeObject itself does not contain a concept of "duration".
+// Duration is represented by using DurationObject.
+//
+// The followings are implemented in lib/time.gb (standard lib)
+// - `Time.now`
+//
+// ```ruby
+// Time.now #=> 2017-11-09 23:10:49 +0900
+// Time.new #=> 2017-11-09 23:10:49 +0900
+// Time.new('2017-05-30')               #=> 2017-05-30 00:00:00 +0000 UTC
+// Time.new('2017-05-30 18:00')         #=> 2017-05-30 18:00:00 +0000 UTC
+// Time.new('2017-05-30 18:00:34')      #=> 2017-05-30 18:00:34 +0000 UTC
+// Time.new('2017-05-30 9:00')          #=> 2017-05-30 09:00:00 +0000 UTC
+// Time.new('2017-05-30 9:00:56')       #=> 2017-05-30 09:00:56 +0000 UTC
+// Time.new('2017-05-30 09:00 JST')     #=> 2017-05-30 09:00:00 +0900 JST
+// Time.new('2017-05-30 09:00:59 JST')  #=> 2017-05-30 09:00:59 +0900 JST
+// ```
+//
+// - `Time.new` is supported.
+type Time = time.Time
+type TimeObject struct {
+	*baseObj
+	value Time
+}
+
+// Class methods --------------------------------------------------------
+func builtinTimeClassMethods() []*BuiltinMethodObject {
+	return []*BuiltinMethodObject{
+		{
+			Name: "new",
+			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
+					switch len(args) {
+					case 0:
+						return t.vm.initTimeObject(currentTime())
+					case 1:
+						arg, ok := args[0].(*StringObject)
+						if !ok {
+							return t.vm.initErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
+						}
+						if current, err := parseTime(arg.toString()); err != nil {
+							return t.vm.initErrorObject(errors.ArgumentError, sourceLine, "Invalid time format. got=%s", arg.value)
+						} else {
+							return t.vm.initTimeObject(current)
+						}
+					default:
+						return t.vm.initErrorObject(errors.ArgumentError, sourceLine, "Expect 0 or 1 argument. got=%d", len(args))
+					}
+				}
+			},
+		},
+	}
+}
+
+// Instance methods -----------------------------------------------------
+func builtinTimeInstanceMethods() []*BuiltinMethodObject {
+	return []*BuiltinMethodObject{
+		{
+			// Converts a Time object into a fixed-format string.
+			Name: "to_s",
+			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
+					m := receiver.(*TimeObject)
+					return t.vm.initStringObject(m.toString())
+				}
+			},
+		},
+	}
+}
+
+// Internal functions ===================================================
+
+// Functions for initialization -----------------------------------------
+
+func (vm *VM) initTimeObject(t Time) *TimeObject {
+	return &TimeObject{
+		baseObj: &baseObj{class: vm.topLevelClass(classes.TimeClass)},
+		value:   t,
+	}
+}
+
+func (vm *VM) initTimeClass() *RClass {
+	tc := vm.initializeClass("Time", true)
+	tc.setBuiltinMethods(builtinTimeInstanceMethods(), false)
+	tc.setBuiltinMethods(builtinTimeClassMethods(), true)
+	vm.objectClass.setClassConstant(tc)
+	vm.libFiles = append(vm.libFiles, "time.gb")
+	return tc
+}
+
+// Polymorphic helper functions -----------------------------------------
+
+// Value returns the object
+func (t *TimeObject) Value() interface{} {
+	return t.timeValue()
+}
+
+// Numeric interface
+func (t *TimeObject) timeValue() Time {
+	return t.value
+}
+
+// toString returns the object's value as the string format, in non
+// exponential format (straight number, without exponent `E<exp>`).
+func (t *TimeObject) toString() string {
+	return t.value.String()
+}
+
+// toJSON just delegates to toString
+func (t *TimeObject) toJSON() string {
+	return t.toString()
+}
+
+// equal checks if the Float values between receiver and argument are equal
+func (t *TimeObject) equal(e *TimeObject) bool {
+	return t.value == e.value
+}
+
+// Other helper functions -----------------------------------------------
+
+// Obtains current local time
+func currentTime() Time {
+	return time.Now()
+}
+
+// Parses the date/time strings into Time object
+// Follow https://golang.org/src/time/format.go for formatting
+func parseTime(t string) (Time, error) {
+	const (
+		dateForm            = "2006-01-02"
+		dateTimeForm        = "2006-01-02 15:04"
+		dateTimeSecForm     = "2006-01-02 15:04:05"
+		dateTimezoneForm    = "2006-01-02 15:04 MST"
+		dateTimezoneSecForm = "2006-01-02 15:04:05 MST"
+	)
+	switch strings.Count(t, ":") {
+	case 0:
+		return time.Parse(dateForm, t)
+	case 1:
+		if strings.Count(t, " ") > 1 {
+			return time.Parse(dateTimezoneForm, t)
+		} else {
+			return time.Parse(dateTimeForm, t)
+		}
+	case 2:
+		if strings.Count(t, " ") > 1 {
+			return time.Parse(dateTimezoneSecForm, t)
+		} else {
+			return time.Parse(dateTimeSecForm, t)
+		}
+	default:
+		return time.Parse("", t)
+	}
+}

--- a/vm/time_test.go
+++ b/vm/time_test.go
@@ -73,3 +73,54 @@ func TestTimeNewFail(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+
+func TestTimeParse(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`Time.new.parse('2017-05-30').to_s`,
+			"2017-05-30 00:00:00 +0000 UTC"},
+		{`Time.new.parse('2017-05-30 18:00').to_s`,
+			"2017-05-30 18:00:00 +0000 UTC"},
+		{`Time.new.parse('2017-05-30 9:00').to_s`,
+			"2017-05-30 09:00:00 +0000 UTC"},
+		{`Time.new.parse('2017-05-30 23:00 JST').to_s`,
+			"2017-05-30 23:00:00 +0900 JST"},
+		{`Time.new.parse('2017-05-30 23:59 JST').to_s`,
+			"2017-05-30 23:59:00 +0900 JST"},
+		{`Time.new.parse('2017-05-30 23:59:59 JST').to_s`,
+			"2017-05-30 23:59:59 +0900 JST"},
+		{`Time.new.parse('2017-05-30  23:59:59  JST').to_s`,
+			"2017-05-30 23:59:59 +0900 JST"},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestTimeParseFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`Time.new.parse('2017-5-30').to_s`,
+			"ArgumentError: Invalid time format. got=2017-5-30", 1, 1},
+		{`Time.new.parse('2017-05-30 00:00:00:00 JST')`,
+			"ArgumentError: Invalid time format. got=2017-05-30 00:00:00:00 JST", 1, 1},
+		{`Time.new.parse('2017-Jan-30 00:0 JST')`,
+			"ArgumentError: Invalid time format. got=2017-Jan-30 00:0 JST", 1, 1},
+		{`Time.new.parse('09:00 JST')`,
+			"ArgumentError: Invalid time format. got=09:00 JST", 1, 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/time_test.go
+++ b/vm/time_test.go
@@ -1,0 +1,75 @@
+package vm
+
+import (
+	"testing"
+)
+
+func TestTimeClassSuperclass(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`Time.class.name`, "Class"},
+		{`Time.superclass.name`, "Object"},
+		{`Time.ancestors.to_s`, "[Time, Object]"},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestTimeNew(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`Time.new('2017-05-30').to_s`,
+			"2017-05-30 00:00:00 +0000 UTC"},
+		{`Time.new('2017-05-30 18:00').to_s`,
+			"2017-05-30 18:00:00 +0000 UTC"},
+		{`Time.new('2017-05-30 9:00').to_s`,
+			"2017-05-30 09:00:00 +0000 UTC"},
+		{`Time.new('2017-05-30 23:00 JST').to_s`,
+			"2017-05-30 23:00:00 +0900 JST"},
+		{`Time.new('2017-05-30 23:59 JST').to_s`,
+			"2017-05-30 23:59:00 +0900 JST"},
+		{`Time.new('2017-05-30 23:59:59 JST').to_s`,
+			"2017-05-30 23:59:59 +0900 JST"},
+		{`Time.new('2017-05-30  23:59:59  JST').to_s`,
+			"2017-05-30 23:59:59 +0900 JST"},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestTimeNewFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`Time.new('2017-5-30').to_s`,
+			"ArgumentError: Invalid time format. got=2017-5-30", 1, 1},
+		{`Time.new('2017-05-30 00:00:00:00 JST')`,
+			"ArgumentError: Invalid time format. got=2017-05-30 00:00:00:00 JST", 1, 1},
+		{`Time.new('2017-Jan-30 00:0 JST')`,
+			"ArgumentError: Invalid time format. got=2017-Jan-30 00:0 JST", 1, 1},
+		{`Time.new('09:00 JST')`,
+			"ArgumentError: Invalid time format. got=09:00 JST", 1, 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkError(t, i, evaluated, tt.expected, getFilename(), tt.errorLine)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -223,6 +223,7 @@ func (vm *VM) initConstants() {
 		vm.initMatchDataClass(),
 		vm.initGoMapClass(),
 		vm.initDecimalClass(),
+		vm.initTimeClass(),
 	}
 
 	// Init error classes


### PR DESCRIPTION
Implemented a minimum `Time` class in vm/time.go and lib/time.gb:

```ruby
» Time.new
#» 2017-11-18 18:51:48.749644 +0900 JST m=+2.760456980
» a = Time.new('2017-05-30')
#» 2017-05-30 00:00:00 +0000 UTC
» a = Time.new('2017-05-30 17:30')
#» 2017-05-30 17:30:00 +0000 UTC
» a = Time.new('2017-05-30 17:30 JST')
#» 2017-05-30 17:30:00 +0900 JST
» a.parse("1999-07-01")
#» 1999-07-01 00:00:00 +0000 UTC
» a.parse("1999-07-01").to_s
#» 1999-07-01 00:00:00 +0000 UTC
```

I think we need `Time` class to write loggers or like that.

---------------------------

I'd like to ask @st0012 and other contributors how this `Time` class should be extended because this is a language design matter and this should meet st0012's philosophy.

My rough memorandom:

- Avoid creating `Date` or `DateTime` class: they are pretty confusing in Ruby. I guess aggregating any methods for date/time/timezone into this `Time` class might be good.
- Create a `Duration` class to represent time durations: for example, the difference between two instances of `Time` spawns an instance of `Duration` class. And adding helper methods like `1.month` or `2.days` as ActiveSupport does.
- Make `Time` and `Duration` classes standard libs that can be loaded via `require` to be optional. Especially, `Duration` class would mutate numeric classes. 
- Get the default timezone from `ENV` when performing `Time#new`.

How about this?