### PR TITLE
Fix method call parsing issue

### DIFF
--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -358,6 +358,88 @@ func TestMethodCall(t *testing.T) {
 
 		Foo.new.bar
 		`, nil},
+		/*
+			These two cases is to prevent range value being treated as method argument.
+			See issue #532 for more info
+		*/
+		{`
+		def foo(k)
+		  b = "4".to_i
+		  (1..k).each do |x|
+			b += x
+		  end
+		  b
+		end
+
+		foo(2)
+		`, 7},
+		{`
+		def four
+		  4
+		end
+
+		def foo(k)
+		  b = four
+		  (1..k).each do |x|
+			b += x
+		  end
+		  b
+		end
+
+		foo(2)
+		`, 7},
+		{`
+		def foo(k)
+		  b = "4".to_i
+		  (1..k).each do |x|
+			b += x
+		  end
+		  b
+		end
+
+		foo(2)
+		`, 7},
+		{`
+		def foo(k)
+		  b = "4".to_i
+		  (k..10).each do |x|
+			b += x
+		  end
+		  b
+		end
+
+		foo(2)
+		`, 58},
+		{`
+		def four
+		  4
+		end
+
+		def foo(k)
+		  b = four
+		  (1..k).each do |x|
+			b += x
+		  end
+		  b
+		end
+
+		foo(2)
+		`, 7},
+		{`
+		def four
+		  4
+		end
+
+		def foo(k)
+		  b = four
+		  (k..10).each do |x|
+			b += x
+		  end
+		  b
+		end
+
+		foo(2)
+		`, 58},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
In some cases range type might be parsed as a method call's argument.
For example:

```ruby
bar.foo
(1..5).to_a
```
In this case the range object `(1..5)` would be parsed as method `#foo`'s argument
instead of a range type. This is because parseCallExpressionWithReceiver
function didn't check if the next token is at same line and looking for
arguments directly.

This closes #532 