### PR TITLE
Add zero-division check

### DIFF
--- a/vm/decimal.go
+++ b/vm/decimal.go
@@ -79,7 +79,7 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 						return new(Decimal).Add(leftValue, rightValue)
 					}
 
-					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine)
+					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
 				}
 			},
 		},
@@ -102,7 +102,7 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 						return new(Decimal).Sub(leftValue, rightValue)
 					}
 
-					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine)
+					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
 				}
 			},
 		},
@@ -125,7 +125,7 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 						return new(Decimal).Mul(leftValue, rightValue)
 					}
 
-					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine)
+					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
 				}
 			},
 		},
@@ -154,7 +154,7 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 						return new(Decimal).SetFloat64(math.Pow(l, r))
 					}
 
-					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine)
+					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
 				}
 			},
 		},
@@ -179,7 +179,7 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 						return new(Decimal).Quo(leftValue, rightValue)
 					}
 
-					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], decimalOperation, sourceLine)
+					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], decimalOperation, sourceLine, true)
 				}
 			},
 		},
@@ -621,12 +621,17 @@ func (d *DecimalObject) arithmeticOperation(
 	rightObject Object,
 	decimalOperation func(leftValue *Decimal, rightValue *Decimal) *Decimal,
 	sourceLine int,
+	division bool,
 ) Object {
 	var result Decimal
 
 	rightValue, ok := assertNumeric(rightObject)
 	if ok == false {
 		return t.vm.initErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, "Numeric", rightObject.Class().Name)
+	}
+
+	if division && rightValue.RatString() == "0" {
+		return t.vm.initErrorObject(errors.ZeroDivisionError, sourceLine, errors.DividedByZero)
 	}
 
 	leftValue := d.value

--- a/vm/decimal_test.go
+++ b/vm/decimal_test.go
@@ -356,3 +356,22 @@ func TestDecimalToStringFail(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+
+func TestDecimalZeroDivisionFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`(6.0).to_d / 0`, "ZeroDivisionError: Divided by 0", 1},
+		{`(6.0).to_d / -0`, "ZeroDivisionError: Divided by 0", 1},
+		{`(6.0).to_d / "0".to_d`, "ZeroDivisionError: Divided by 0", 1},
+		{`(6.0).to_d / "-0".to_d`, "ZeroDivisionError: Divided by 0", 1},
+		{`(6.0).to_d / "0".to_f`, "ZeroDivisionError: Divided by 0", 1},
+		{`(6.0).to_d / "-0".to_f`, "ZeroDivisionError: Divided by 0", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/error.go
+++ b/vm/error.go
@@ -14,12 +14,7 @@ import (
 //
 // The type of internal errors:
 //
-// * `InternalError`: default error type
-// * `ArgumentError`: an argument-related error
-// * `NameError`: a constant-related error
-// * `TypeError`: a type-related error
-// * `UndefinedMethodError`: undefined-method error
-// * `UnsupportedMethodError`: intentionally unsupported-method error
+// see vm/errors/error.go.
 //
 type Error struct {
 	*baseObj
@@ -62,7 +57,7 @@ func (vm *VM) initErrorObject(errorType string, sourceLine int, format string, a
 }
 
 func (vm *VM) initErrorClasses() {
-	errTypes := []string{errors.InternalError, errors.ArgumentError, errors.NameError, errors.TypeError, errors.UndefinedMethodError, errors.UnsupportedMethodError, errors.ConstantAlreadyInitializedError, errors.HTTPError}
+	errTypes := []string{errors.InternalError, errors.ArgumentError, errors.NameError, errors.TypeError, errors.UndefinedMethodError, errors.UnsupportedMethodError, errors.ConstantAlreadyInitializedError, errors.HTTPError, errors.ZeroDivisionError}
 
 	for _, errType := range errTypes {
 		c := vm.initializeClass(errType, false)

--- a/vm/errors/error.go
+++ b/vm/errors/error.go
@@ -17,7 +17,7 @@ const (
 	ConstantAlreadyInitializedError = "ConstantAlreadyInitializedError"
 	// HTTPError is returned when when a request fails to return a proper response
 	HTTPError = "HTTPError"
-	// For zero-division by Integer or Decimal value
+	// ZeroDivisionError is for zero-division by Integer/Float/Decimal value
 	ZeroDivisionError = "ZeroDivisionError"
 )
 

--- a/vm/errors/error.go
+++ b/vm/errors/error.go
@@ -17,6 +17,8 @@ const (
 	ConstantAlreadyInitializedError = "ConstantAlreadyInitializedError"
 	// HTTPError is returned when when a request fails to return a proper response
 	HTTPError = "HTTPError"
+	// For zero-division by Integer or Decimal value
+	ZeroDivisionError = "ZeroDivisionError"
 )
 
 /*
@@ -26,4 +28,5 @@ const (
 	WrongNumberOfArgumentFormat = "Expect %d arguments. got: %d"
 	WrongArgumentTypeFormat     = "Expect argument to be %s. got: %s"
 	CantYieldWithoutBlockFormat = "Can't yield without a block"
+	DividedByZero               = "Divided by 0"
 )

--- a/vm/float.go
+++ b/vm/float.go
@@ -53,7 +53,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return leftValue + rightValue
 					}
 
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
 				}
 			},
 		},
@@ -71,7 +71,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return math.Mod(leftValue, rightValue)
 					}
 
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, true)
 				}
 			},
 		},
@@ -89,7 +89,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return leftValue - rightValue
 					}
 
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
 				}
 			},
 		},
@@ -107,7 +107,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return leftValue * rightValue
 					}
 
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
 				}
 			},
 		},
@@ -125,7 +125,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return math.Pow(leftValue, rightValue)
 					}
 
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
 				}
 			},
 		},
@@ -143,7 +143,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 						return leftValue / rightValue
 					}
 
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine)
+					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, true)
 				}
 			},
 		},
@@ -388,7 +388,7 @@ func (f *FloatObject) floatValue() float64 {
 
 // TODO: Remove instruction argument
 // Apply the passed arithmetic operation, while performing type conversion.
-func (f *FloatObject) arithmeticOperation(t *thread, rightObject Object, operation func(leftValue float64, rightValue float64) float64, sourceLine int) Object {
+func (f *FloatObject) arithmeticOperation(t *thread, rightObject Object, operation func(leftValue float64, rightValue float64) float64, sourceLine int, division bool) Object {
 	rightNumeric, ok := rightObject.(Numeric)
 
 	if !ok {
@@ -397,6 +397,10 @@ func (f *FloatObject) arithmeticOperation(t *thread, rightObject Object, operati
 
 	leftValue := f.value
 	rightValue := rightNumeric.floatValue()
+
+	if division && rightValue == 0 {
+		return t.vm.initErrorObject(errors.ZeroDivisionError, sourceLine, errors.DividedByZero)
+	}
 
 	result := operation(leftValue, rightValue)
 

--- a/vm/float_test.go
+++ b/vm/float_test.go
@@ -68,10 +68,10 @@ func TestFloatArithmeticOperationWithInteger(t *testing.T) {
 
 func TestFloatArithmeticOperationFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`1 + "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`1 - "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`1 ** "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},
-		{`1 / "t"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1.1 + "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1.1 - "m"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1.1 ** "p"`, "TypeError: Expect argument to be Numeric. got: String", 1},
+		{`1.1 / "t"`, "TypeError: Expect argument to be Numeric. got: String", 1},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/float_test.go
+++ b/vm/float_test.go
@@ -246,3 +246,24 @@ func TestFloatEdgeCases(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+
+func TestFloatZeroDivisionFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`6.0 / 0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6.0 / -0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6.0 / 0.0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6.0 / -0.0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6.0 % 0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6.0 % -0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6.0 % 0.0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6.0 % -0.0`, "ZeroDivisionError: Divided by 0", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -77,7 +77,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 						return leftValue + rightValue
 					}
 
-					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine)
+					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
 				}
 			},
 		},
@@ -98,7 +98,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 						return math.Mod(leftValue, rightValue)
 					}
 
-					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine)
+					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, true)
 				}
 			},
 		},
@@ -119,7 +119,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 						return leftValue - rightValue
 					}
 
-					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine)
+					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
 				}
 			},
 		},
@@ -140,7 +140,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 						return leftValue * rightValue
 					}
 
-					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine)
+					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
 				}
 			},
 		},
@@ -161,7 +161,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 						return math.Pow(leftValue, rightValue)
 					}
 
-					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine)
+					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
 				}
 			},
 		},
@@ -175,6 +175,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			Name: "/",
 			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
+
 					intOperation := func(leftValue int, rightValue int) int {
 						return leftValue / rightValue
 					}
@@ -182,7 +183,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 						return leftValue / rightValue
 					}
 
-					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine)
+					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, true)
 				}
 			},
 		},
@@ -695,11 +696,15 @@ func (i *IntegerObject) arithmeticOperation(
 	intOperation func(leftValue int, rightValue int) int,
 	floatOperation func(leftValue float64, rightValue float64) float64,
 	sourceLine int,
+	division bool,
 ) Object {
 	switch rightObject.(type) {
 	case *IntegerObject:
 		leftValue := i.value
 		rightValue := rightObject.(*IntegerObject).value
+		if division && rightValue == 0 {
+			return t.vm.initErrorObject(errors.ZeroDivisionError, sourceLine, errors.DividedByZero)
+		}
 
 		result := intOperation(leftValue, rightValue)
 
@@ -707,6 +712,10 @@ func (i *IntegerObject) arithmeticOperation(
 	case *FloatObject:
 		leftValue := float64(i.value)
 		rightValue := rightObject.(*FloatObject).value
+
+		if division && rightValue == 0 {
+			return t.vm.initErrorObject(errors.ZeroDivisionError, sourceLine, errors.DividedByZero)
+		}
 
 		result := floatOperation(leftValue, rightValue)
 

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -346,3 +346,24 @@ func TestIntegerTimesMethodFail(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+
+func TestIntegerZeroDivisionFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`6 / 0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6 / -0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6 / 0.0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6 / -0.0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6 % 0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6 % -0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6 % 0.0`, "ZeroDivisionError: Divided by 0", 1},
+		{`6 % -0.0`, "ZeroDivisionError: Divided by 0", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}


### PR DESCRIPTION
I found that zero division has not been checked in numerical operator `/` and '%`.

Added zero-division check against `Integer`, `Float`, and `Decimal`

```ruby
» 6 / 0
#» ZeroDivisionError: Divided by 0
» 6 / -0
#» ZeroDivisionError: Divided by 0
» 6.0 / 0
#» ZeroDivisionError: Divided by 0
» 6.0 / -0
#» ZeroDivisionError: Divided by 0
» "6.0".to_d / 0
#» ZeroDivisionError: Divided by 0
» "6.0".to_d / -0
#» ZeroDivisionError: Divided by 0
```

Before the fix, `Float`'s zero-division like `6.0 / 0` returned `+Inf` as a `Float` class, but the negative zero-division `6.0 / -0` also returned the positive `+Inf`, which is inappropreate. I wondered a bit but finally treated them as ZeroDivisionError.

---------------

Well, Ruby's zero-division check is like the following: 

```ruby
1/0          #=> ZeroDivisionError: divided by 0
1/-0         #=> ZeroDivisionError: divided by 0
1/0.0        #=> Infinity
1/-0.0       #=> -Infinity
1/0r         #=> ZeroDivisionError: divided by 0
1/-0r        #=> ZeroDivisionError: divided by 0