### PR TITLE
Rename verify functions

### DIFF
--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -16,7 +16,7 @@ func TestArrayClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -36,9 +36,9 @@ func TestArrayEvaluation(t *testing.T) {
 		t.Fatalf("Expect evaluated value to be an array. got=%T", evaluated)
 	}
 
-	checkExpected(t, 0, arr.Elements[0], 1)
-	checkExpected(t, 0, arr.Elements[1], "234")
-	checkExpected(t, 0, arr.Elements[2], true)
+	verifyExpected(t, 0, arr.Elements[0], 1)
+	verifyExpected(t, 0, arr.Elements[1], "234")
+	verifyExpected(t, 0, arr.Elements[2], true)
 }
 
 func TestArrayComparison(t *testing.T) {
@@ -77,7 +77,7 @@ func TestArrayComparison(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -155,7 +155,7 @@ func TestArrayIndex(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -196,7 +196,7 @@ func TestArrayAnyMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -258,7 +258,7 @@ func TestArrayAtMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -299,7 +299,7 @@ func TestArrayClearMethod(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -342,7 +342,7 @@ func TestArrayConcatMethod(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -414,7 +414,7 @@ func TestArrayCountMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -465,7 +465,7 @@ func TestArrayDeleteAtMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -500,7 +500,7 @@ func TestArrayDeleteAtMethod(t *testing.T) {
 	for i, tt := range testsArray {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -545,7 +545,7 @@ func TestArrayDigMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -590,7 +590,7 @@ func TestArrayEachMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -639,7 +639,7 @@ func TestArrayEachIndexMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -691,7 +691,7 @@ func TestArrayEmptyMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -726,7 +726,7 @@ func TestArrayFirstMethod(t *testing.T) {
 	for i, tt := range testsInt {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 	}
 
@@ -753,7 +753,7 @@ func TestArrayFirstMethod(t *testing.T) {
 	for i, tt := range testsArray {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -803,7 +803,7 @@ func TestArrayFlattenMethod(t *testing.T) {
 	for i, tt := range testsArray {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -841,7 +841,7 @@ func TestArrayIncludeMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -869,7 +869,7 @@ func TestArrayJoinMethod(t *testing.T) {
 	for i, tt := range testsInt {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -920,7 +920,7 @@ func TestArrayLastMethod(t *testing.T) {
 	for i, tt := range testsArray {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -975,7 +975,7 @@ func TestArrayLengthMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1027,7 +1027,7 @@ func TestArrayMapMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1057,7 +1057,7 @@ func TestArrayPlusOperator(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -1102,7 +1102,7 @@ func TestArrayPopMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1144,7 +1144,7 @@ func TestArrayPushMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1189,7 +1189,7 @@ func TestArrayReduceMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1234,7 +1234,7 @@ func TestArrayReverseMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1264,7 +1264,7 @@ func TestArrayReverseEachMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1307,7 +1307,7 @@ func TestArrayRotateMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1364,7 +1364,7 @@ func TestArraySelectMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1395,7 +1395,7 @@ func TestArrayShiftMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1446,7 +1446,7 @@ func TestArrayStarMethod(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -1515,7 +1515,7 @@ func TestArrayUnshiftMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1551,7 +1551,7 @@ func TestArrayValuesAtMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/boolean_test.go
+++ b/vm/boolean_test.go
@@ -14,7 +14,7 @@ func TestBooleanClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -34,7 +34,7 @@ func TestEvalBooleanExpression(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -73,7 +73,7 @@ func TestBooleanComparison(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -161,7 +161,7 @@ func TestBooleanLogicalExpression(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -199,7 +199,7 @@ func TestBooleanAssignmentByOperation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/channel_and_thread_test.go
+++ b/vm/channel_and_thread_test.go
@@ -14,7 +14,7 @@ func TestChannelClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -59,7 +59,7 @@ func TestObjectMutationInThread(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -154,7 +154,7 @@ func TestObjectDeliveryBetweenThread(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -14,7 +14,7 @@ func TestClassClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -90,7 +90,7 @@ func TestAttrReaderAndWriter(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -140,7 +140,7 @@ func TestClassInstanceVariable(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -213,7 +213,7 @@ func TestCustomClassConstructor(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, 30)
+	verifyExpected(t, 0, evaluated, 30)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -394,7 +394,7 @@ func TestClassNamespace(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -462,7 +462,7 @@ func TestPrimitiveType(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -502,7 +502,7 @@ func TestClassGeneralComparisonOperation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -531,7 +531,7 @@ func TestGeneralAssignmentByOperation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -584,7 +584,7 @@ func TestMethodsMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -616,7 +616,7 @@ func TestAncestorsMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -635,7 +635,7 @@ func TestBuiltinClassMonkeyPatching(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, "buz")
+	verifyExpected(t, 0, evaluated, "buz")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -680,7 +680,7 @@ func TestClassGreaterThanMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -778,7 +778,7 @@ func TestSendMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -797,7 +797,7 @@ func TestRequireRelativeMethod(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, 160)
+	verifyExpected(t, 0, evaluated, 160)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -811,7 +811,7 @@ func TestRequireMethod(t *testing.T) {
 	`
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, "http")
+	verifyExpected(t, 0, evaluated, "http")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -910,7 +910,7 @@ func TestGeneralIsAMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -969,7 +969,7 @@ func TestGeneralIsNilMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1011,7 +1011,7 @@ func TestClassNameClassMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1060,7 +1060,7 @@ func TestClassSuperclassClassMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1105,7 +1105,7 @@ func TestClassSingletonClassMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1147,7 +1147,7 @@ func TestObjectIdMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/concurrent_array_test.go
+++ b/vm/concurrent_array_test.go
@@ -20,7 +20,7 @@ func TestConcurrentArrayClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -109,7 +109,7 @@ func TestConcurrentArrayIndex(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -203,7 +203,7 @@ func TestConcurrentArrayComparisonOperation(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -249,7 +249,7 @@ func TestConcurrentArrayAnyMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -322,7 +322,7 @@ func TestConcurrentArrayAtMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -373,7 +373,7 @@ func TestConcurrentArrayClearMethod(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -423,7 +423,7 @@ func TestConcurrentArrayConcatMethod(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -507,7 +507,7 @@ func TestConcurrentArrayCountMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -565,7 +565,7 @@ func TestConcurrentArrayDeleteAtMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -604,7 +604,7 @@ func TestConcurrentArrayDeleteAtMethod(t *testing.T) {
 	for i, tt := range testsArray {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -661,7 +661,7 @@ func TestConcurrentArrayEachMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -715,7 +715,7 @@ func TestConcurrentArrayEachIndexMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -770,7 +770,7 @@ func TestConcurrentArrayEmptyMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -810,7 +810,7 @@ func TestConcurrentArrayFirstMethod(t *testing.T) {
 	for i, tt := range testsInt {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 	}
 
@@ -841,7 +841,7 @@ func TestConcurrentArrayFirstMethod(t *testing.T) {
 	for i, tt := range testsArray {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -901,7 +901,7 @@ func TestConcurrentArrayFlattenMethod(t *testing.T) {
 	for i, tt := range testsArray {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -951,7 +951,7 @@ func TestConcurrentArrayJoinMethod(t *testing.T) {
 	for i, tt := range testsInt {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1010,7 +1010,7 @@ func TestConcurrentArrayLastMethod(t *testing.T) {
 	for i, tt := range testsArray {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -1071,7 +1071,7 @@ func TestConcurrentArrayLengthMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1129,7 +1129,7 @@ func TestConcurrentArrayMapMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1161,7 +1161,7 @@ func TestConcurrentArrayPlusMethod(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -1208,7 +1208,7 @@ func TestConcurrentArrayPopMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1250,7 +1250,7 @@ func TestConcurrentArrayPushMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1300,7 +1300,7 @@ func TestConcurrentArrayReduceMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1351,7 +1351,7 @@ func TestConcurrentArrayReverseMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1383,7 +1383,7 @@ func TestConcurrentArrayReverseEachMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1431,7 +1431,7 @@ func TestConcurrentArrayRotateMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1496,7 +1496,7 @@ func TestConcurrentArraySelectMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1527,7 +1527,7 @@ func TestConcurrentArrayShiftMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1583,7 +1583,7 @@ func TestConcurrentArrayStarMethod(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -1654,7 +1654,7 @@ func TestConcurrentArrayUnshiftMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1690,7 +1690,7 @@ func TestConcurrentArrayValuesAtMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testConcurrentArrayObject(t, i, evaluated, tt.expected)
+		verifyConcurrentArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/concurrent_hash_test.go
+++ b/vm/concurrent_hash_test.go
@@ -22,7 +22,7 @@ func TestConcurrentHashClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -46,7 +46,7 @@ func TestConcurrentHashInitialization(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testConcurrentHashObject(t, i, evaluated, tt.expected)
+		verifyConcurrentHashObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -90,11 +90,11 @@ func TestEvalConcurrentHashExpression(t *testing.T) {
 	iterator := func(key, value interface{}) bool {
 		switch key {
 		case "foo":
-			testIntegerObject(t, 0, value.(Object), 123)
+			verifyIntegerObject(t, 0, value.(Object), 123)
 		case "bar":
-			testStringObject(t, 0, value.(Object), "test")
+			verifyStringObject(t, 0, value.(Object), "test")
 		case "Baz":
-			testBooleanObject(t, 0, value.(Object), true)
+			verifyBooleanObject(t, 0, value.(Object), true)
 		}
 
 		return true
@@ -189,7 +189,7 @@ func TestConcurrentHashAccessOperation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -281,7 +281,7 @@ func TestConcurrentHashDeleteMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -332,7 +332,7 @@ func TestConcurrentHashEachMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testConcurrentHashObject(t, i, evaluated, tt.expected)
+		verifyConcurrentHashObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -356,7 +356,7 @@ func TestConcurrentHashEachMethod(t *testing.T) {
 	for i, tt := range tests2 {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testBidimensionalArrayObject(t, i, evaluated, tt.expected)
+		verifyBidimensionalArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -397,7 +397,7 @@ func TestConcurrentHashHasKeyMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -623,7 +623,7 @@ func TestConcurrentHashToStringMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/concurrent_rw_lock_test.go
+++ b/vm/concurrent_rw_lock_test.go
@@ -152,7 +152,7 @@ func TestRWLockAcquireAndReleaseReadLock(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, code, getFilename())
-	testStringObject(t, i, evaluated, expected)
+	verifyStringObject(t, i, evaluated, expected)
 	v.checkCFP(t, i, 0)
 	v.checkSP(t, i, 1)
 }
@@ -173,7 +173,7 @@ func TestRWLockAcquireAndReleaseWriteLock(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, code, getFilename())
-	testStringObject(t, i, evaluated, expected)
+	verifyStringObject(t, i, evaluated, expected)
 	v.checkCFP(t, i, 0)
 	v.checkSP(t, i, 1)
 }
@@ -196,7 +196,7 @@ func TestRWLockWithReadLockMethod(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, code, getFilename())
-	testStringObject(t, i, evaluated, expected)
+	verifyStringObject(t, i, evaluated, expected)
 	v.checkCFP(t, i, 0)
 	v.checkSP(t, i, 1)
 }
@@ -219,7 +219,7 @@ func TestRWLockWithWriteLockMethod(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, code, getFilename())
-	testStringObject(t, i, evaluated, expected)
+	verifyStringObject(t, i, evaluated, expected)
 	v.checkCFP(t, i, 0)
 	v.checkSP(t, i, 1)
 }
@@ -259,7 +259,7 @@ func TestRWLockAcquireAndReleaseLocksReadBlocksWriteNoRaceDetection(t *testing.T
 
 	v := initTestVM()
 	evaluated := v.testEval(t, code, getFilename())
-	testStringObject(t, i, evaluated, expected)
+	verifyStringObject(t, i, evaluated, expected)
 	v.checkCFP(t, i, 0)
 	v.checkSP(t, i, 1)
 }
@@ -297,7 +297,7 @@ func TestRWLockWithReadLockReadBlocksWriteNoRaceDetection(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, code, getFilename())
-	testStringObject(t, i, evaluated, expected)
+	verifyStringObject(t, i, evaluated, expected)
 	v.checkCFP(t, i, 0)
 	v.checkSP(t, i, 1)
 }

--- a/vm/db_test.go
+++ b/vm/db_test.go
@@ -52,7 +52,7 @@ func TestDBPingMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -80,7 +80,7 @@ func TestDBCloseMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -106,7 +106,7 @@ func TestDBRunMethod(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, true)
+	verifyExpected(t, 0, evaluated, true)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -156,7 +156,7 @@ func TestDBExecMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 		cleanTable()

--- a/vm/decimal_test.go
+++ b/vm/decimal_test.go
@@ -16,7 +16,7 @@ func TestDecimalClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -38,7 +38,7 @@ func TestDecimalArithmeticOperationWithDecimal(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -59,7 +59,7 @@ func TestDecimalArithmeticOperationWithInteger(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -85,7 +85,7 @@ func TestDecimalArithmeticOperationWithFloat(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -132,7 +132,7 @@ func TestDecimalComparisonWithFloat(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -163,7 +163,7 @@ func TestDecimalComparisonWithInteger(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -214,7 +214,7 @@ func TestDecimalEquality(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -238,7 +238,7 @@ func TestDecimalToArray(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -257,7 +257,7 @@ func TestDecimalToIntegerStringConversions(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -283,7 +283,7 @@ func TestDecimalToInteger(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -301,7 +301,7 @@ func TestDecimalToNumeric(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -330,7 +330,7 @@ func TestDecimalToStringMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -135,7 +135,7 @@ func TestAssignmentEvaluation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testIntegerObject(t, i, evaluated, tt.expectedValue)
+		verifyIntegerObject(t, i, evaluated, tt.expectedValue)
 		v.checkCFP(t, 0, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -156,7 +156,7 @@ func TestAssignmentByOperationEvaluation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expectedValue)
+		verifyExpected(t, i, evaluated, tt.expectedValue)
 		v.checkCFP(t, 0, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -178,7 +178,7 @@ func TestBangPrefixMethodCall(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -371,7 +371,7 @@ func TestCaseExpressionEvaluation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -393,7 +393,7 @@ func TestClassInheritance(t *testing.T) {
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
 
-	testStringObject(t, 0, evaluated, "Bar")
+	verifyStringObject(t, 0, evaluated, "Bar")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -509,7 +509,7 @@ func TestClassMethodCall(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -538,7 +538,7 @@ func TestComment(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	testIntegerObject(t, 0, evaluated, 123)
+	verifyIntegerObject(t, 0, evaluated, 123)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -581,7 +581,7 @@ func TestComplexEvaluation(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	testIntegerObject(t, 0, evaluated, 310)
+	verifyIntegerObject(t, 0, evaluated, 310)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -641,7 +641,7 @@ func TestConstantNamespace(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -658,7 +658,7 @@ func TestEnvironmentVariable(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, "This is foo. This is bar.")
+	verifyExpected(t, 0, evaluated, "This is foo. This is bar.")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 
@@ -844,7 +844,7 @@ func TestIfExpressionEvaluation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -964,7 +964,7 @@ func TestInstanceVariableEvaluation(t *testing.T) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).message)
 		}
 
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1265,7 +1265,7 @@ func TestMethodCall(t *testing.T) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).message)
 		}
 
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1363,7 +1363,7 @@ func TestMethodCallWithSplatArgument(t *testing.T) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).message)
 		}
 
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1514,7 +1514,7 @@ func TestMethodCallWithBlockArgument(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1620,7 +1620,7 @@ func TestMethodCallWithNestedBlock(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1862,7 +1862,7 @@ func TestMethodCallWithoutParens(t *testing.T) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).message)
 		}
 
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1882,7 +1882,7 @@ func TestMinusPrefixMethodCall(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -2018,7 +2018,7 @@ func TestMultiVarAssignment(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -2057,7 +2057,7 @@ func TestPostfixMethodCall(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -2092,7 +2092,7 @@ func TestRemoveUnusedExpression(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -2159,7 +2159,7 @@ func TestSelfExpressionEvaluation(t *testing.T) {
 			t.Fatalf("got Error: %s", evaluated.(*Error).message)
 		}
 
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/file_test.go
+++ b/vm/file_test.go
@@ -38,7 +38,7 @@ func TestFileObject(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -59,7 +59,7 @@ func TestFileBasenameMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -87,7 +87,7 @@ func TestFileDeleteMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -109,7 +109,7 @@ func TestFileExtnameMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -134,7 +134,7 @@ func TestFileJoinMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -173,7 +173,7 @@ func TestFileWriteMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -186,7 +186,7 @@ func TestFileSizeMethod(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, 22)
+	verifyExpected(t, 0, evaluated, 22)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -204,7 +204,7 @@ func TestFileSplitMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/float_test.go
+++ b/vm/float_test.go
@@ -16,7 +16,7 @@ func TestFloatClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -38,7 +38,7 @@ func TestFloatArithmeticOperationWithFloat(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -60,7 +60,7 @@ func TestFloatArithmeticOperationWithInteger(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -108,7 +108,7 @@ func TestFloatComparisonWithFloat(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -139,7 +139,7 @@ func TestFloatComparisonWithInteger(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -189,7 +189,7 @@ func TestFloatEquality(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -224,7 +224,7 @@ func TestFloatConversions(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -241,7 +241,7 @@ func TestFloatEdgeCases(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/go_map_test.go
+++ b/vm/go_map_test.go
@@ -64,7 +64,7 @@ func TestGoMapGetMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -85,7 +85,7 @@ func TestGoMapSetMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -112,7 +112,7 @@ func TestGoMapToHashMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/go_object_test.go
+++ b/vm/go_object_test.go
@@ -18,7 +18,7 @@ func TestCallingGoObjectFunctionWithReturnValue(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, "xyz!")
+	verifyExpected(t, 0, evaluated, "xyz!")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -37,7 +37,7 @@ func TestCallingGoObjectFunctionWithReturnError(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, nil)
+	verifyExpected(t, 0, evaluated, nil)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -55,7 +55,7 @@ func TestCallingGoObjectFuncWithInt64(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, 110)
+	verifyExpected(t, 0, evaluated, 110)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -73,7 +73,7 @@ func TestCallingGoObjectFuncWithGoObject(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, "xyz")
+	verifyExpected(t, 0, evaluated, "xyz")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -19,7 +19,7 @@ func TestHashClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -41,11 +41,11 @@ func TestEvalHashExpression(t *testing.T) {
 	for key, value := range h.Pairs {
 		switch key {
 		case "foo":
-			testIntegerObject(t, 0, value, 123)
+			verifyIntegerObject(t, 0, value, 123)
 		case "bar":
-			testStringObject(t, 0, value, "test")
+			verifyStringObject(t, 0, value, "test")
 		case "Baz":
-			testBooleanObject(t, 0, value, true)
+			verifyBooleanObject(t, 0, value, true)
 		}
 	}
 
@@ -121,7 +121,7 @@ func TestHashAccessOperation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -148,7 +148,7 @@ func TestHashAccessWithDefaultOperation(t *testing.T) {
 	for i, tt := range valueTests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -173,7 +173,7 @@ func TestHashAccessWithDefaultOperation(t *testing.T) {
 	for i, tt := range hashTests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testHashObject(t, i, evaluated, tt.expected)
+		verifyHashObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -233,7 +233,7 @@ func TestHashComparisonOperation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -276,7 +276,7 @@ func TestHashAnyMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -318,7 +318,7 @@ func TestHashClearMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testHashObject(t, i, evaluated, tt.expected)
+		verifyHashObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -358,7 +358,7 @@ func TestHashDefaultOperation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -426,7 +426,7 @@ func TestHashDeleteMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -482,7 +482,7 @@ func TestHashDeleteIfMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testHashObject(t, i, evaluated, tt.expected)
+		verifyHashObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -522,7 +522,7 @@ func TestHashDigMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -561,7 +561,7 @@ func TestHashEachMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testHashObject(t, i, evaluated, tt.expected)
+		verifyHashObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -584,7 +584,7 @@ func TestHashEachMethod(t *testing.T) {
 	for i, tt := range tests2 {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testBidimensionalArrayObject(t, i, evaluated, tt.expected)
+		verifyBidimensionalArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -645,7 +645,7 @@ func TestHashEachKeyMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -699,7 +699,7 @@ func TestHashEachValueMethod(t *testing.T) {
 	for i, tt := range hashTests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -741,7 +741,7 @@ func TestHashEachValueMethod(t *testing.T) {
 	for i, tt := range normalTests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -777,7 +777,7 @@ func TestHashEmptyMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -820,7 +820,7 @@ func TestHashEqualMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -860,7 +860,7 @@ func TestHashFetchMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -899,7 +899,7 @@ func TestHashFetchValuesMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -933,7 +933,7 @@ func TestHashHasKeyMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -973,7 +973,7 @@ func TestHashHasValueMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1053,7 +1053,7 @@ func TestHashLengthMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1133,7 +1133,7 @@ func TestHashMapValuesMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1175,13 +1175,13 @@ func TestHashMergeMethod(t *testing.T) {
 		for key, value := range h.Pairs {
 			switch key {
 			case "a":
-				testStringObject(t, i, value, "Hello")
+				verifyStringObject(t, i, value, "Hello")
 			case "b":
-				testBooleanObject(t, i, value, true)
+				verifyBooleanObject(t, i, value, true)
 			case "c":
-				testIntegerObject(t, i, value, 123)
+				verifyIntegerObject(t, i, value, 123)
 			case "d":
-				testArrayObject(t, i, value, []interface{}{"World", 456, false})
+				verifyArrayObject(t, i, value, []interface{}{"World", 456, false})
 			}
 		}
 
@@ -1221,7 +1221,7 @@ func TestHashSortedKeysMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1266,7 +1266,7 @@ func TestHashSelectMethod(t *testing.T) {
 	for i, tt := range testsSortedArray {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testHashObject(t, i, evaluated, tt.expected)
+		verifyHashObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1318,7 +1318,7 @@ func TestHashToArrayMethod(t *testing.T) {
 	for i, tt := range testsSortedArray {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1346,13 +1346,13 @@ func TestHashToArrayMethod(t *testing.T) {
 	for k, v := range evaluatedArr {
 		switch k {
 		case "a":
-			testIntegerObject(t, 0, v, 123)
+			verifyIntegerObject(t, 0, v, 123)
 		case "b":
-			testStringObject(t, 0, v, "test")
+			verifyStringObject(t, 0, v, "test")
 		case "c":
-			testBooleanObject(t, 0, v, true)
+			verifyBooleanObject(t, 0, v, true)
 		case "d":
-			testArrayObject(t, 0, v, []interface{}{1, "Goby", false})
+			verifyArrayObject(t, 0, v, []interface{}{1, "Goby", false})
 		}
 	}
 	v.checkCFP(t, 0, 0)
@@ -1552,7 +1552,7 @@ func TestHashToStringMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1632,7 +1632,7 @@ func TestHashTransformValuesMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1674,13 +1674,13 @@ func TestHashValuesMethod(t *testing.T) {
 	for _, v := range arr.Elements {
 		switch value := v.(type) {
 		case *IntegerObject:
-			testIntegerObject(t, 0, value, 123)
+			verifyIntegerObject(t, 0, value, 123)
 		case *StringObject:
-			testStringObject(t, 0, v, "test")
+			verifyStringObject(t, 0, v, "test")
 		case *BooleanObject:
-			testBooleanObject(t, 0, v, true)
+			verifyBooleanObject(t, 0, v, true)
 		case *ArrayObject:
-			testArrayObject(t, 0, v, []interface{}{1, "Goby", false})
+			verifyArrayObject(t, 0, v, []interface{}{1, "Goby", false})
 		}
 	}
 	v.checkCFP(t, 0, 0)
@@ -1721,7 +1721,7 @@ func TestHashValuesAtMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/http_client_test.go
+++ b/vm/http_client_test.go
@@ -72,7 +72,7 @@ func TestHTTPClientObject(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/http_request_test.go
+++ b/vm/http_request_test.go
@@ -33,7 +33,7 @@ func TestHTTPRequestObject(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/http_response_test.go
+++ b/vm/http_response_test.go
@@ -21,7 +21,7 @@ func TestHTTPResponseObject(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, "test")
+	verifyExpected(t, 0, evaluated, "test")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -42,7 +42,7 @@ Net::HTTP.get("%s")
 
 	v := initTestVM()
 	evaluated := v.testEval(t, testScript, getFilename())
-	checkExpected(t, 0, evaluated, expected)
+	verifyExpected(t, 0, evaluated, expected)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -68,7 +68,7 @@ Net::HTTP.get("%s", "path")
 
 	v := initTestVM()
 	evaluated := v.testEval(t, testScript, getFilename())
-	checkExpected(t, 0, evaluated, expected)
+	verifyExpected(t, 0, evaluated, expected)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }

--- a/vm/http_test.go
+++ b/vm/http_test.go
@@ -46,7 +46,7 @@ func TestHTTPRequest(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -16,7 +16,7 @@ func TestIntegerClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -38,7 +38,7 @@ func TestIntegerArithmeticOperationWithInteger(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -60,7 +60,7 @@ func TestIntegerArithmeticOperationWithFloat(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -82,7 +82,7 @@ func TestIntegerArithmeticOperationsPriority(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -130,7 +130,7 @@ func TestIntegerComparisonWithInteger(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -161,7 +161,7 @@ func TestIntegerComparisonWithFloat(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -211,7 +211,7 @@ func TestIntegerEquality(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -230,7 +230,7 @@ func TestIntegerConversion(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -250,7 +250,7 @@ func TestIntegerEvenMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -268,7 +268,7 @@ func TestIntegerNextMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -286,7 +286,7 @@ func TestIntegerOddMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -304,7 +304,7 @@ func TestIntegerPredMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -326,7 +326,7 @@ func TestIntegerTimesMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/json_test.go
+++ b/vm/json_test.go
@@ -28,7 +28,7 @@ func TestJSONValidateMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -73,7 +73,7 @@ func TestJSONObjectParsing(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -122,7 +122,7 @@ func TestJSONObjectArrayParsing(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/main_object_test.go
+++ b/vm/main_object_test.go
@@ -13,7 +13,7 @@ func TestMainToS(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/match_data_test.go
+++ b/vm/match_data_test.go
@@ -16,7 +16,7 @@ func TestMatchDataClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -36,7 +36,7 @@ func TestMatchDataCaptures(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -70,7 +70,7 @@ func TestMatchDataToAMethod(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -103,7 +103,7 @@ func TestMatchDataLengthMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -136,7 +136,7 @@ func TestMatchDataToHMethod(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		testHashObject(t, i, evaluated, tt.expected)
+		verifyHashObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}

--- a/vm/null_test.go
+++ b/vm/null_test.go
@@ -14,7 +14,7 @@ func TestNullClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -25,7 +25,7 @@ func TestEvalNil(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, nil)
+	verifyExpected(t, 0, evaluated, nil)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -46,7 +46,7 @@ func TestNullComparisonOperation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -74,7 +74,7 @@ func TestNullAssignmentByOperation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -92,7 +92,7 @@ func TestNullTypeConversion(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -108,7 +108,7 @@ func TestNullBangPrefixMethod(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, true)
+	verifyExpected(t, 0, evaluated, true)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -131,7 +131,7 @@ func TestNullIsNilMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/object_test.go
+++ b/vm/object_test.go
@@ -14,7 +14,7 @@ func TestObjectClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/plugin_integration_test.go
+++ b/vm/plugin_integration_test.go
@@ -39,7 +39,7 @@ func TestCallingPluginFunctionWithReturnValueNoRaceDetection(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, "Bar")
+	verifyExpected(t, 0, evaluated, "Bar")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -56,7 +56,7 @@ func TestCallingLibFuncFromPluginNoRaceDetection(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, "lib")
+	verifyExpected(t, 0, evaluated, "lib")
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }
@@ -80,7 +80,7 @@ func TestPluginGenerationNoRaceDetection(t *testing.T) {
 
 	v := initTestVM()
 	evaluated := v.testEval(t, input, getFilename())
-	checkExpected(t, 0, evaluated, true)
+	verifyExpected(t, 0, evaluated, true)
 	v.checkCFP(t, 0, 0)
 	v.checkSP(t, 0, 1)
 }

--- a/vm/plugin_test.go
+++ b/vm/plugin_test.go
@@ -47,7 +47,7 @@ func TestPluginInitialization(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/range_test.go
+++ b/vm/range_test.go
@@ -16,7 +16,7 @@ func TestRangeClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -48,7 +48,7 @@ func TestRangeComparisonOperation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -192,7 +192,7 @@ func TestRangeBsearchMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -269,7 +269,7 @@ func TestRangeEachMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -297,7 +297,7 @@ func TestRangeFirstMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -346,7 +346,7 @@ func TestRangeIncludeMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -374,7 +374,7 @@ func TestRangeLastMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -402,7 +402,7 @@ func TestRangeSizeMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -462,7 +462,7 @@ func TestRangeStepMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -490,7 +490,7 @@ func TestRangeToStringMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -524,7 +524,7 @@ func TestRangeToArrayMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -546,7 +546,7 @@ func TestRangeMapMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/regexp_test.go
+++ b/vm/regexp_test.go
@@ -17,7 +17,7 @@ func TestRegexpClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -35,7 +35,7 @@ func TestRegexpClassCreation(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 	}
 }
@@ -62,7 +62,7 @@ func TestRegexpComparison(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 	}
 }
@@ -163,7 +163,7 @@ func TestRegexpMatchMethod(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}

--- a/vm/simple_server_test.go
+++ b/vm/simple_server_test.go
@@ -22,7 +22,7 @@ func TestServerInitialization(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -104,7 +104,7 @@ func TestServerRequestInitialization(t *testing.T) {
 			t.Fatalf("Expect request object to have %s attribute.", tt.varName)
 		}
 
-		checkExpected(t, i, v, tt.expected)
+		verifyExpected(t, i, v, tt.expected)
 	}
 
 }

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -49,7 +49,7 @@ a + 100
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -141,7 +141,7 @@ func TestDefStatement(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -199,7 +199,7 @@ func TestDefStatementWithSplatArgument(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -323,7 +323,7 @@ func TestDefStatementWithKeywordArgument(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -467,7 +467,7 @@ func TestModuleStatement(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -517,7 +517,7 @@ i
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -556,7 +556,7 @@ func TestReturnStatement(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 
@@ -642,7 +642,7 @@ func TestWhileStatement(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -16,7 +16,7 @@ func TestStringClassSuperclass(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -40,7 +40,7 @@ func TestEvalStringExpression(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -149,7 +149,7 @@ func TestStringConversion(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -196,7 +196,7 @@ func TestStringComparison(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -229,7 +229,7 @@ func TestStringMatchOperator(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -289,7 +289,7 @@ func TestStringOperation(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -335,7 +335,7 @@ func TestStringCapitalizeMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -354,7 +354,7 @@ func TestStringChopMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -372,7 +372,7 @@ func TestStringConcatenateMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -410,7 +410,7 @@ func TestStringCountMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -428,7 +428,7 @@ func TestStringDeleteMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -465,7 +465,7 @@ func TestStringDowncaseMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -495,7 +495,7 @@ func TestStringEachByteMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -544,7 +544,7 @@ func TestStringEachCharMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -593,7 +593,7 @@ func TestStringEachLineMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		testArrayObject(t, i, evaluated, tt.expected)
+		verifyArrayObject(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -636,7 +636,7 @@ func TestStringEndWithMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -671,7 +671,7 @@ func TestStringEmptyMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -694,7 +694,7 @@ func TestStringEqualMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -732,7 +732,7 @@ func TestStringIncludeMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -776,7 +776,7 @@ func TestStringInsertMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -815,7 +815,7 @@ func TestStringLeftJustifyMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -855,7 +855,7 @@ func TestStringLengthMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -873,7 +873,7 @@ func TestStringMatch(t *testing.T) {
 	for i, tt := range tests {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}
@@ -907,7 +907,7 @@ func TestStringReplaceMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -944,7 +944,7 @@ func TestStringReplaceOnceMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -983,7 +983,7 @@ func TestStringReverseMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1003,7 +1003,7 @@ func TestStringRightJustifyMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1043,7 +1043,7 @@ func TestStringSizeMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1090,7 +1090,7 @@ func TestStringSliceMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1186,7 +1186,7 @@ func TestStringSplitMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1227,7 +1227,7 @@ func TestStringStartWithMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1263,7 +1263,7 @@ func TestStringStripMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1283,7 +1283,7 @@ func TestStringUpcaseMethod(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1302,7 +1302,7 @@ func TestStringMethodChaining(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
@@ -1321,7 +1321,7 @@ func TestFormattedString(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/uri_test.go
+++ b/vm/uri_test.go
@@ -85,7 +85,7 @@ func TestURIParsing(t *testing.T) {
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
-		checkExpected(t, i, evaluated, tt.expected)
+		verifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -144,7 +144,7 @@ foo
 		}
 
 		evaluated := v.GetExecResult()
-		checkExpected(t, i, evaluated, test.expected)
+		verifyExpected(t, i, evaluated, test.expected)
 		// Because REPL should maintain a base call frame so that the whole program won't exit
 		v.checkCFP(t, i, 1)
 	}
@@ -196,7 +196,7 @@ func (v *VM) checkSP(t *testing.T, index, expectedSp int) {
 
 // Verification helpers
 
-func checkExpected(t *testing.T, i int, evaluated Object, expected interface{}) {
+func verifyExpected(t *testing.T, i int, evaluated Object, expected interface{}) {
 	if isError(evaluated) {
 		t.Errorf("At test case %d: %s", i, evaluated.toString())
 		return
@@ -204,21 +204,21 @@ func checkExpected(t *testing.T, i int, evaluated Object, expected interface{}) 
 
 	switch expected := expected.(type) {
 	case int:
-		testIntegerObject(t, i, evaluated, expected)
+		verifyIntegerObject(t, i, evaluated, expected)
 	case float64:
-		testFloatObject(t, i, evaluated, expected)
+		verifyFloatObject(t, i, evaluated, expected)
 	case string:
-		testStringObject(t, i, evaluated, expected)
+		verifyStringObject(t, i, evaluated, expected)
 	case bool:
-		testBooleanObject(t, i, evaluated, expected)
+		verifyBooleanObject(t, i, evaluated, expected)
 	case nil:
-		testNullObject(t, i, evaluated)
+		verifyNullObject(t, i, evaluated)
 	default:
 		t.Errorf("Unknown type %T at case %d", expected, i)
 	}
 }
 
-func testIntegerObject(t *testing.T, i int, obj Object, expected int) bool {
+func verifyIntegerObject(t *testing.T, i int, obj Object, expected int) bool {
 	switch result := obj.(type) {
 	case *IntegerObject:
 		if result.value != expected {
@@ -236,7 +236,7 @@ func testIntegerObject(t *testing.T, i int, obj Object, expected int) bool {
 	}
 }
 
-func testFloatObject(t *testing.T, i int, obj Object, expected float64) bool {
+func verifyFloatObject(t *testing.T, i int, obj Object, expected float64) bool {
 	switch result := obj.(type) {
 	case *FloatObject:
 		if result.value != expected {
@@ -254,7 +254,7 @@ func testFloatObject(t *testing.T, i int, obj Object, expected float64) bool {
 	}
 }
 
-func testNullObject(t *testing.T, i int, obj Object) bool {
+func verifyNullObject(t *testing.T, i int, obj Object) bool {
 	switch result := obj.(type) {
 	case *NullObject:
 		return true
@@ -267,7 +267,7 @@ func testNullObject(t *testing.T, i int, obj Object) bool {
 	}
 }
 
-func testStringObject(t *testing.T, i int, obj Object, expected string) bool {
+func verifyStringObject(t *testing.T, i int, obj Object, expected string) bool {
 	switch result := obj.(type) {
 	case *StringObject:
 		if result.value != expected {
@@ -285,7 +285,7 @@ func testStringObject(t *testing.T, i int, obj Object, expected string) bool {
 	}
 }
 
-func testBooleanObject(t *testing.T, i int, obj Object, expected bool) bool {
+func verifyBooleanObject(t *testing.T, i int, obj Object, expected bool) bool {
 	switch result := obj.(type) {
 	case *BooleanObject:
 		if result.value != expected {
@@ -303,7 +303,7 @@ func testBooleanObject(t *testing.T, i int, obj Object, expected bool) bool {
 	}
 }
 
-func testArrayObject(t *testing.T, index int, obj Object, expected []interface{}) bool {
+func verifyArrayObject(t *testing.T, index int, obj Object, expected []interface{}) bool {
 	result, ok := obj.(*ArrayObject)
 	if !ok {
 		t.Errorf("At test case %d: object is not Array. got=%s (%+v)", index, obj.Class().Name, obj)
@@ -315,14 +315,14 @@ func testArrayObject(t *testing.T, index int, obj Object, expected []interface{}
 	}
 
 	for i := 0; i < len(result.Elements); i++ {
-		checkExpected(t, index, result.Elements[i], expected[i])
+		verifyExpected(t, index, result.Elements[i], expected[i])
 	}
 
 	return true
 }
 
 // Same as testHashObject(), but expects a ConcurrentArray.
-func testConcurrentArrayObject(t *testing.T, index int, obj Object, expected []interface{}) bool {
+func verifyConcurrentArrayObject(t *testing.T, index int, obj Object, expected []interface{}) bool {
 	result, ok := obj.(*ConcurrentArrayObject)
 	if !ok {
 		t.Errorf("At test case %d: object is not ConcurrentArray. got=%s (%+v)", index, obj.Class().Name, obj)
@@ -334,7 +334,7 @@ func testConcurrentArrayObject(t *testing.T, index int, obj Object, expected []i
 	}
 
 	for i := 0; i < len(result.InternalArray.Elements); i++ {
-		checkExpected(t, i, result.InternalArray.Elements[i], expected[i])
+		verifyExpected(t, i, result.InternalArray.Elements[i], expected[i])
 	}
 
 	return true
@@ -342,7 +342,7 @@ func testConcurrentArrayObject(t *testing.T, index int, obj Object, expected []i
 
 // Same as testHashObject(), but expects a ConcurrentHash.
 //
-func testConcurrentHashObject(t *testing.T, index int, objectResult Object, expected map[string]interface{}) bool {
+func verifyConcurrentHashObject(t *testing.T, index int, objectResult Object, expected map[string]interface{}) bool {
 	result, ok := objectResult.(*ConcurrentHashObject)
 
 	if !ok {
@@ -370,7 +370,7 @@ func testConcurrentHashObject(t *testing.T, index int, objectResult Object, expe
 //
 // The second limitation is currently the only Hash format in Goby, anyway.
 //
-func testHashObject(t *testing.T, index int, objectResult Object, expected map[string]interface{}) bool {
+func verifyHashObject(t *testing.T, index int, objectResult Object, expected map[string]interface{}) bool {
 	result, ok := objectResult.(*HashObject)
 
 	if !ok {
@@ -389,7 +389,7 @@ func testHashObject(t *testing.T, index int, objectResult Object, expected map[s
 //		expected = [][]interface{}{{"a", 1}, {"b", "2"}}
 //		testBidimensionalArrayObject(t, i, evaluated, expected)
 //
-func testBidimensionalArrayObject(t *testing.T, index int, obj Object, expected [][]interface{}) bool {
+func verifyBidimensionalArrayObject(t *testing.T, index int, obj Object, expected [][]interface{}) bool {
 	result, ok := obj.(*ArrayObject)
 	if !ok {
 		t.Errorf("At test case %d: object is not Array. got=%T (%+v)", index, obj, obj)
@@ -404,7 +404,7 @@ func testBidimensionalArrayObject(t *testing.T, index int, obj Object, expected 
 		resultRow := result.Elements[i]
 		expectedRow := expected[i]
 
-		testArrayObject(t, index, resultRow, expectedRow)
+		verifyArrayObject(t, index, resultRow, expectedRow)
 	}
 
 	return true
@@ -428,7 +428,7 @@ func _checkHashPairs(t *testing.T, actual map[string]Object, expected map[string
 	for expectedKey, expectedValue := range expected {
 		resultValue := actual[expectedKey]
 
-		checkExpected(t, i, resultValue, expectedValue)
+		verifyExpected(t, i, resultValue, expectedValue)
 	}
 
 	return true

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -231,7 +231,7 @@ func testIntegerObject(t *testing.T, i int, obj Object, expected int) bool {
 		t.Errorf("At test case %d: %s", i, result.Message())
 		return false
 	default:
-		t.Errorf("At test case %d: object is not Integer. got=%T (%+v).", i, obj, obj)
+		t.Errorf("At test case %d: object is not Integer. got=%s (%+v).", i, obj.Class().Name, obj)
 		return false
 	}
 }
@@ -249,7 +249,7 @@ func testFloatObject(t *testing.T, i int, obj Object, expected float64) bool {
 		t.Errorf("At test case %d: %s", i, result.Message())
 		return false
 	default:
-		t.Errorf("At test case %d: object is not Float. got=%T (%+v).", i, obj, obj)
+		t.Errorf("At test case %d: object is not Float. got=%s (%+v).", i, obj.Class().Name, obj)
 		return false
 	}
 }
@@ -262,7 +262,7 @@ func testNullObject(t *testing.T, i int, obj Object) bool {
 		t.Errorf("At test case %d: %s", i, result.Message())
 		return false
 	default:
-		t.Errorf("At test case %d: object is not NULL. got=%T (%+v)", i, obj, obj)
+		t.Errorf("At test case %d: object is not NULL. got=%s (%+v)", i, obj.Class().Name, obj)
 		return false
 	}
 }
@@ -280,7 +280,7 @@ func testStringObject(t *testing.T, i int, obj Object, expected string) bool {
 		t.Errorf(result.Message())
 		return false
 	default:
-		t.Errorf("At test case %d: object is not String. got=%T (%+v).", i, obj, obj)
+		t.Errorf("At test case %d: object is not String. got=%s (%+v).", i, obj.Class().Name, obj)
 		return false
 	}
 }
@@ -298,7 +298,7 @@ func testBooleanObject(t *testing.T, i int, obj Object, expected bool) bool {
 		t.Errorf(result.Message())
 		return false
 	default:
-		t.Errorf("At test case %d: object is not Boolean. got=%T (%+v).", i, obj, obj)
+		t.Errorf("At test case %d: object is not Boolean. got=%s (%+v).", i, obj.Class().Name, obj)
 		return false
 	}
 }
@@ -306,7 +306,7 @@ func testBooleanObject(t *testing.T, i int, obj Object, expected bool) bool {
 func testArrayObject(t *testing.T, index int, obj Object, expected []interface{}) bool {
 	result, ok := obj.(*ArrayObject)
 	if !ok {
-		t.Errorf("At test case %d: object is not Array. got=%T (%+v)", index, obj, obj)
+		t.Errorf("At test case %d: object is not Array. got=%s (%+v)", index, obj.Class().Name, obj)
 		return false
 	}
 
@@ -315,7 +315,7 @@ func testArrayObject(t *testing.T, index int, obj Object, expected []interface{}
 	}
 
 	for i := 0; i < len(result.Elements); i++ {
-		checkExpected(t, i, result.Elements[i], expected[i])
+		checkExpected(t, index, result.Elements[i], expected[i])
 	}
 
 	return true
@@ -325,7 +325,7 @@ func testArrayObject(t *testing.T, index int, obj Object, expected []interface{}
 func testConcurrentArrayObject(t *testing.T, index int, obj Object, expected []interface{}) bool {
 	result, ok := obj.(*ConcurrentArrayObject)
 	if !ok {
-		t.Errorf("At test case %d: object is not Array. got=%T (%+v)", index, obj, obj)
+		t.Errorf("At test case %d: object is not ConcurrentArray. got=%s (%+v)", index, obj.Class().Name, obj)
 		return false
 	}
 
@@ -346,7 +346,7 @@ func testConcurrentHashObject(t *testing.T, index int, objectResult Object, expe
 	result, ok := objectResult.(*ConcurrentHashObject)
 
 	if !ok {
-		t.Errorf("At test case %d: result is not ConcurrentHash. got=%T", index, objectResult)
+		t.Errorf("At test case %d: result is not ConcurrentHash. got=%s", index, objectResult.Class().Name)
 		return false
 	}
 
@@ -374,7 +374,7 @@ func testHashObject(t *testing.T, index int, objectResult Object, expected map[s
 	result, ok := objectResult.(*HashObject)
 
 	if !ok {
-		t.Errorf("At test case %d: result is not Hash. got=%T", index, objectResult)
+		t.Errorf("At test case %d: result is not Hash. got=%s", index, objectResult.Class().Name)
 		return false
 	}
 


### PR DESCRIPTION
We used to use `testXXX` or `checkXXX` as our verifying function's name, I want to make them have `verify` prefix instead (or `assert`?)