### PR TITLE
Fix-#472: Add a check to parseHashPair

### DIFF
--- a/compiler/parser/data_type_parsing.go
+++ b/compiler/parser/data_type_parsing.go
@@ -104,6 +104,7 @@ func (p *Parser) parseHashPair(pairs map[string]ast.Expression) {
 	case token.Constant, token.Ident:
 		key = p.parseIdentifier().(ast.Variable).ReturnValue()
 	default:
+		p.error = newTypeParsingError(p.curToken.Literal, "hash key", p.curToken.Line)
 		return
 	}
 

--- a/compiler/parser/expression_parsing_test.go
+++ b/compiler/parser/expression_parsing_test.go
@@ -115,6 +115,29 @@ func TestHashExpression(t *testing.T) {
 	}
 }
 
+func TestHashExpressionFail(t *testing.T) {
+	tests := []struct {
+		input string
+		error string
+	}{
+		{`{ 1 }`, `could not parse "1" as hash key. Line: 0`},
+		{`{ "a" }`, `could not parse "a" as hash key. Line: 0`},
+		{`{ nil }`, `could not parse "nil" as hash key. Line: 0`},
+	}
+
+	for _, tt := range tests {
+		l := lexer.New(tt.input)
+		p := New(l)
+		_, err := p.ParseProgram()
+
+		if err.Message != tt.error {
+			t.Fatal("Expected hash literal parsing error")
+			t.Fatal("expect: ", tt.error)
+			t.Fatal("actual: ", err.Message)
+		}
+	}
+}
+
 func TestHashAccessExpression(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
Add tests for  parseHashPair in expression_parsing to fix https://github.com/goby-lang/goby/issues/472