### PR TITLE
#545 Fix Hash#map_values Behaviour

### DIFF
--- a/vm/hash.go
+++ b/vm/hash.go
@@ -825,10 +825,10 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// ```Ruby
 			// h = { a: 1, b: 2, c: 3 }
-			// result = h.transform_values do |v|
+			// result = h.map_values do |v|
 			//   v * 3
 			// end
-			// h      # => { a: 3, b: 6, c: 9 }
+			// h      # => { a: 1, b: 2, c: 3 }
 			// result # => { a: 3, b: 6, c: 9 }
 			// ```
 			//
@@ -845,16 +845,16 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					h := receiver.(*HashObject)
+					result := make(map[string]Object)
 
 					if len(h.Pairs) == 0 {
 						t.callFrameStack.pop()
 					}
 
 					for k, v := range h.Pairs {
-						result := t.builtinMethodYield(blockFrame, v)
-						h.Pairs[k] = result.Target
+						result[k] = t.builtinMethodYield(blockFrame, v).Target
 					}
-					return h
+					return t.vm.initHashObject(result)
 				}
 			},
 		},

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -1085,21 +1085,21 @@ func TestHashMapValuesMethod(t *testing.T) {
 			v * 3
 		end
 		h["a"]
-		`, 3},
+		`, 1},
 		{`
 		h = { a: 1, b: 2, c: 3 }
 		result = h.map_values do |v|
 			v * 3
 		end
 		h["b"]
-		`, 6},
+		`, 2},
 		{`
 		h = { a: 1, b: 2, c: 3 }
 		result = h.map_values do |v|
 			v * 3
 		end
 		h["c"]
-		`, 9},
+		`, 3},
 		{`
 		h = { a: 1, b: 2, c: 3 }
 		result = h.map_values do |v|


### PR DESCRIPTION
@hachi8833 Now, I've changed the method to the correct behaviour which, as you've mentioned, the receiver (the hash) itself shouldn't change the value. Instead, it returns the new one.

However, I create another variable `result` is for not changing the original receiver `h` because it is passed by reference (I think?) so if changing the value in `h` itself, it will also alter the value of the receiver.

This PR should solve issue #545 