### PR TITLE
Allow parsing negative float with method chain.

### DIFF
--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -166,10 +166,8 @@ func (pe *PrefixExpression) TokenLiteral() string {
 func (pe *PrefixExpression) String() string {
 	var out bytes.Buffer
 
-	out.WriteString("(")
 	out.WriteString(pe.Operator)
 	out.WriteString(pe.Right.String())
-	out.WriteString(")")
 
 	return out.String()
 }

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -100,7 +100,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.ResolutionOperator, p.parseInfixExpression)
 	p.registerInfix(token.Assign, p.parseAssignExpression)
 	p.registerInfix(token.Range, p.parseRangeExpression)
-	p.registerInfix(token.Dot, p.parseDotExpression)
+	p.registerInfix(token.Dot, p.parseCallExpressionWithReceiver)
 	p.registerInfix(token.LParen, p.parseCallExpressionWithoutReceiver)
 	p.registerInfix(token.LBracket, p.parseIndexExpression)
 	p.registerInfix(token.Colon, p.parsePairExpression)
@@ -199,7 +199,7 @@ func (p *Parser) peekTokenAtSameLine() bool {
 }
 
 func (p *Parser) peekError(t token.Type) {
-	msg := fmt.Sprintf("expected next token to be %s, got %s instead. Line: %d", t, p.peekToken.Type, p.peekToken.Line)
+	msg := fmt.Sprintf("expected next token to be %s, got %s(%s) instead. Line: %d", t, p.peekToken.Type, p.peekToken.Literal, p.peekToken.Line)
 	p.error = errors.InitError(msg, errors.UnexpectedTokenError)
 }
 

--- a/compiler/parser/parser_test.go
+++ b/compiler/parser/parser_test.go
@@ -49,11 +49,11 @@ func TestOperatorPrecedenceParsing(t *testing.T) {
 	}{
 		{
 			"-a * b",
-			"((-a) * b)",
+			"(-a * b)",
 		},
 		{
 			"!-a",
-			"(!(-a))",
+			"!-a",
 		},
 		{
 			"a + b + c",
@@ -81,7 +81,7 @@ func TestOperatorPrecedenceParsing(t *testing.T) {
 		},
 		{
 			"-5 * -5",
-			"((-5) * (-5))",
+			"(-5 * -5)",
 		},
 		{
 			"5 > 4 == 3 < 4",
@@ -133,11 +133,11 @@ func TestOperatorPrecedenceParsing(t *testing.T) {
 		},
 		{
 			"-(5 + 5)",
-			"(-(5 + 5))",
+			"-(5 + 5)",
 		},
 		{
 			"!(true == true)",
-			"(!(true == true))",
+			"!(true == true)",
 		},
 		{
 			"a + n.add(b * c) + d",

--- a/compiler/parser/precedence/precedence.go
+++ b/compiler/parser/precedence/precedence.go
@@ -14,9 +14,10 @@ const (
 	Compare
 	Sum
 	Product
-	Prefix
+	BangPrefix
 	Index
 	Call
+	MinusPrefix
 )
 
 // LookupTable maps token to its corresponding precedence

--- a/compiler/parser/statement_parsing_test.go
+++ b/compiler/parser/statement_parsing_test.go
@@ -294,7 +294,7 @@ func TestWhileStatementWithoutDoKeywordFail(t *testing.T) {
 	p := New(l)
 	_, err := p.ParseProgram()
 
-	if err.Message != "expected next token to be DO, got IDENT instead. Line: 2" {
+	if err.Message != "expected next token to be DO, got IDENT(puts) instead. Line: 2" {
 		t.Fatal("Condition expression should be followed by a do keyword")
 	}
 

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -173,6 +173,7 @@ func TestBangPrefixMethodCall(t *testing.T) {
 		{"!!true", true},
 		{"!!false", false},
 		{"!!5", true},
+		{`!123.nil?`, true},
 	}
 
 	for i, tt := range tests {

--- a/vm/float_test.go
+++ b/vm/float_test.go
@@ -215,10 +215,9 @@ func TestFloatConversions(t *testing.T) {
 		{`
 		3.14159265358979.to_d.to_s`,
 			"3.14159265358979"},
-		// TODO: Able to parse negative float value and call method without parentheses
-		//{`
-		//-273.150000000.to_d.to_s`,
-		//	"-273.15"},
+		{`
+		-273.150000000.to_d.to_s`,
+			"-273.15"},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Currently we can't parse something like `-123.5.to_s` correctly. It'll be consider as `-((123.5).to_s)` instead of `(-123.5).to_s`.
This closes #526 