### PR TITLE
Allow calling break inside a block.

### DIFF
--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -36,6 +36,7 @@ const (
 	BranchUnless        = "branchunless"
 	BranchIf            = "branchif"
 	Jump                = "jump"
+	Break               = "break"
 	DefMethod           = "def_method"
 	DefSingletonMethod  = "def_singleton_method"
 	DefClass            = "def_class"

--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -100,7 +100,31 @@ func (g *Generator) compileNextStatement(is *InstructionSet, stmt ast.Statement,
 }
 
 func (g *Generator) compileBreakStatement(is *InstructionSet, stmt ast.Statement, scope *scope) {
-	is.define(Jump, stmt.Line(), scope.anchors["break"])
+	if scope.anchors["break"] != nil {
+		/*
+			# We also need to leave current frame if it's inside block like:
+
+			x = [1, 2, 3]
+			y = 0
+
+			while y < 10 do
+			  x.each do |i|
+				y += i
+				if i == 2
+				  break <- need to escape from block so we also need break instruction
+				end
+			  end
+			end
+
+			y # 12
+		*/
+		if is.isType == Block {
+			is.define(Break, stmt.Line())
+		}
+		is.define(Jump, stmt.Line(), scope.anchors["break"])
+	} else {
+		is.define(Break, stmt.Line())
+	}
 }
 
 func (g *Generator) compileClassStmt(is *InstructionSet, stmt *ast.ClassStatement, scope *scope, table *localTable) {

--- a/vm/call_frame.go
+++ b/vm/call_frame.go
@@ -18,7 +18,9 @@ type baseFrame struct {
 	lPr           int
 	isBlock       bool
 	isSourceBlock bool
-	blockFrame    *normalCallFrame
+	// for helping stop the frame execution
+	isRemoved  bool
+	blockFrame *normalCallFrame
 	sync.RWMutex
 	sourceLine int
 	fileName   string
@@ -30,6 +32,7 @@ type callFrame interface {
 	BlockFrame() *normalCallFrame
 	IsBlock() bool
 	IsSourceBlock() bool
+	IsRemoved() bool
 	EP() *normalCallFrame
 	Locals() []*Pointer
 	LocalPtr() int
@@ -52,7 +55,9 @@ type goMethodCallFrame struct {
 	name   string
 }
 
-func (cf *goMethodCallFrame) stopExecution() {}
+func (cf *goMethodCallFrame) stopExecution() {
+	cf.isRemoved = true
+}
 
 type normalCallFrame struct {
 	*baseFrame
@@ -66,6 +71,7 @@ func (n *normalCallFrame) instructionsCount() int {
 }
 
 func (n *normalCallFrame) stopExecution() {
+	n.isRemoved = true
 	n.pc = n.instructionsCount()
 }
 
@@ -79,6 +85,10 @@ func (b *baseFrame) BlockFrame() *normalCallFrame {
 
 func (b *baseFrame) IsBlock() bool {
 	return b.isBlock
+}
+
+func (b *baseFrame) IsRemoved() bool {
+	return b.isRemoved
 }
 
 func (b *baseFrame) IsSourceBlock() bool {

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -200,6 +200,23 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 						objectKey := t.vm.initStringObject(stringKey)
 						result := t.builtinMethodYield(blockFrame, objectKey, value)
 
+						/*
+							TODO: Discuss this behavior
+
+							```ruby
+							{ key: "foo", bar: "baz" }.any? do |k, v|
+							  true
+							  break
+							end
+							```
+
+							The block returns nil because of the break.
+							But in Ruby the final result is nil, which means the block's result is completely ignored
+						 */
+						if blockFrame.IsRemoved() {
+							return NULL
+						}
+
 						if result.Target.isTruthy() {
 							return TRUE
 						}

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -273,6 +273,12 @@ func TestHashAnyMethod(t *testing.T) {
         true
       end
 		`, false},
+		{`
+	  { key: "foo", bar: "baz" }.any? do |k, v|
+	    true
+	    break
+	  end
+		`, nil},
 	}
 
 	for i, tt := range tests {

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -326,6 +326,23 @@ var builtinActions = map[operationType]*action{
 			cf.pc = args[0].(int)
 		},
 	},
+	bytecode.Break: {
+		name: bytecode.Break,
+		operation: func(t *thread, sourceLine int, cf *normalCallFrame, args ...interface{}) {
+			/*
+				Normal frame. IS name: ProgramStart. is block: false. source line: 1
+				Normal frame. IS name: 0. is block: true. ep: 17. source line: 5 <- The block source
+				Go method frame. Method name: each. <- The method call with block
+				Normal frame. IS name: 0. is block: true. ep: 17. source line: 5 <- The block execution
+			*/
+
+			if cf.IsBlock() {
+				t.callFrameStack.pop().stopExecution() // Remove block execution frame
+				t.callFrameStack.pop().stopExecution() // Remove method call frame
+				t.callFrameStack.pop().stopExecution() // Remove block source frame
+			}
+		},
+	},
 	bytecode.PutSelf: {
 		name: bytecode.PutSelf,
 		operation: func(t *thread, sourceLine int, cf *normalCallFrame, args ...interface{}) {

--- a/vm/statement_test.go
+++ b/vm/statement_test.go
@@ -10,40 +10,68 @@ func TestBreakStatement(t *testing.T) {
 		expected interface{}
 	}{
 		{`
-x = 0
-y = 0
+		x = 0
+		y = 0
 
-while x < 10 do
-  x = x + 1
-  if x == 5
-	break
-  end
-  y = y + 1
-end
+		while x < 10 do
+		  x = x + 1
+		  if x == 5
+			break
+		  end
+		  y = y + 1
+		end
 
-x + y
-		`, 9},
+		x + y
+				`, 9},
 		{`
-x = 0
-y = 0
-i = 0
+		x = [1, 2, 3]
+		y = 0
+		
+		x.each do |i|
+		  y += i
+		  if i == 2
+			break
+		  end
+		end
+		
+		y
+		`, 3},
+		{`
+		x = [1, 2, 3]
+		y = 0
+		
+		while y < 10 do
+		  x.each do |i|
+			y += i
+			if i == 2
+			  break
+			end
+		  end
+		end
+		
+		y
+		`, 12},
+		{`
+		x = 0
+		y = 0
+		i = 0
 
-while x < 10 do
-  x = x + 1
-  while y < 5 do
-	y = y + 1
+		while x < 10 do
+		  x = x + 1
+		  while y < 5 do
+			y = y + 1
 
-	if y == 3
-	  break
-	end
+			if y == 3
+			  break
+			end
 
-	i = i + x * y
-  end
-end
+			i = i + x * y
+		  end
+		end
 
-a = i * 10
-a + 100
-		`, 310},
+		a = i * 10
+		a + 100
+				`, 310},
 	}
 
 	for i, tt := range tests {

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -211,7 +211,7 @@ func (t *thread) execInstruction(cf *normalCallFrame, i *instruction) {
 
 func (t *thread) builtinMethodYield(blockFrame *normalCallFrame, args ...Object) *Pointer {
 	if blockFrame.IsRemoved() {
-		return nil
+		return &Pointer{Target:NULL}
 	}
 
 	c := newNormalCallFrame(blockFrame.instructionSet, blockFrame.FileName(), blockFrame.sourceLine)
@@ -227,6 +227,10 @@ func (t *thread) builtinMethodYield(blockFrame *normalCallFrame, args ...Object)
 
 	t.callFrameStack.push(c)
 	t.startFromTopFrame()
+
+	if blockFrame.IsRemoved() {
+		return &Pointer{Target:NULL}
+	}
 
 	return t.stack.top()
 }

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -210,6 +210,10 @@ func (t *thread) execInstruction(cf *normalCallFrame, i *instruction) {
 }
 
 func (t *thread) builtinMethodYield(blockFrame *normalCallFrame, args ...Object) *Pointer {
+	if blockFrame.IsRemoved() {
+		return nil
+	}
+
 	c := newNormalCallFrame(blockFrame.instructionSet, blockFrame.FileName(), blockFrame.sourceLine)
 	c.blockFrame = blockFrame
 	c.ep = blockFrame.ep


### PR DESCRIPTION
Todo this, we need different mechanism than while statement's break.
Cause if we want to break from a block, it means we want to leave
current frame and scope.

So the solution is to pop every callframe related to that block and stop
their execution.