### PR TITLE
Fix #589

### DIFF
--- a/vm/class.go
+++ b/vm/class.go
@@ -1024,6 +1024,13 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			Name: "singleton_class",
 			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
 				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
+					r := receiver
+					if r.SingletonClass() == nil {
+						id := t.vm.initIntegerObject(r.id())
+						singletonClass := t.vm.createRClass(fmt.Sprintf("#<Class:#<%s:%s>>", r.Class().Name, id.toString()))
+						singletonClass.isSingleton = true
+						return singletonClass
+					}
 					return receiver.SingletonClass()
 				}
 			},

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -1100,6 +1100,12 @@ func TestClassSingletonClassMethod(t *testing.T) {
 		class Foo < Bar; end
 		Foo.singleton_class.superclass.name
 		`, "#<Class:Bar>"},
+		// Check if this works on non-class objects
+		{`'a'.singleton_class.to_s.slice(1..16).to_s`, "<Class:#<String:"},
+		{`1.singleton_class.to_s.slice(1..17).to_s`, "<Class:#<Integer:"},
+		{`nil.singleton_class.to_s.slice(1..14).to_s`, "<Class:#<Null:"},
+		{`[1,2].singleton_class.to_s.slice(1..15).to_s`, "<Class:#<Array:"},
+		{`{key: "value"}.singleton_class.to_s.slice(1..14).to_s`, "<Class:#<Hash:"},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
This fixes #589.

Note that the fix works against even Integer objects like `1` (Ruby cannot do that).
I hope this works.