### PR TITLE
Implement Module{#>=, #<, #<=} as Module#>

### DIFF
--- a/vm/class.go
+++ b/vm/class.go
@@ -126,6 +126,47 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			},
 		},
 		{
+			// Returns true if self is an ancestor or same class/module of another.
+			//
+			// ```ruby
+			// Object >= Array #=> true
+			// Array >= Object #=> false
+			// Object >= Object #=> true
+			// ```
+			//
+			// @param module [Class]
+			// @return [Boolean, Null]
+			Name: ">=",
+			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
+					c, ok := receiver.(*RClass)
+
+					if !ok {
+						return t.vm.initErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#<", receiver.toString())
+					}
+
+					module, ok := args[0].(*RClass)
+
+					if !ok {
+						return t.vm.initErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
+					}
+
+					if c == module {
+						return TRUE
+					}
+
+					if module.alreadyInherit(c) {
+						return TRUE
+					}
+
+					if c.alreadyInherit(module) {
+						return FALSE
+					}
+					return NULL
+				}
+			},
+		},
+		{
 			// Creates instance variables and corresponding methods that return the value of
 			// each instance variable and assign an argument to each instance variable.
 			// Only string literal can be used for now.

--- a/vm/class.go
+++ b/vm/class.go
@@ -208,6 +208,47 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			},
 		},
 		{
+			// Returns true if another is an ancestor or same class/module of self.
+			//
+			// ```ruby
+			// Object <= Array #=> false
+			// Array <= Object #=> true
+			// Object <= Object #=> true
+			// ```
+			//
+			// @param module [Class]
+			// @return [Boolean, Null]
+			Name: "<=",
+			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
+					c, ok := receiver.(*RClass)
+
+					if !ok {
+						return t.vm.initErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#<", receiver.toString())
+					}
+
+					module, ok := args[0].(*RClass)
+
+					if !ok {
+						return t.vm.initErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
+					}
+
+					if c == module {
+						return TRUE
+					}
+
+					if module.alreadyInherit(c) {
+						return FALSE
+					}
+
+					if c.alreadyInherit(module) {
+						return TRUE
+					}
+					return NULL
+				}
+			},
+		},
+		{
 			// Creates instance variables and corresponding methods that return the value of
 			// each instance variable and assign an argument to each instance variable.
 			// Only string literal can be used for now.

--- a/vm/class.go
+++ b/vm/class.go
@@ -167,6 +167,47 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			},
 		},
 		{
+			// Returns true if another class/module is an ancestor of self.
+			//
+			// ```ruby
+			// Object < Array #=> false
+			// Array < Object #=> true
+			// Object < Object #=> false
+			// ```
+			//
+			// @param module [Class]
+			// @return [Boolean, Null]
+			Name: "<",
+			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
+					c, ok := receiver.(*RClass)
+
+					if !ok {
+						return t.vm.initErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#<", receiver.toString())
+					}
+
+					module, ok := args[0].(*RClass)
+
+					if !ok {
+						return t.vm.initErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
+					}
+
+					if c == module {
+						return FALSE
+					}
+
+					if module.alreadyInherit(c) {
+						return FALSE
+					}
+
+					if c.alreadyInherit(module) {
+						return TRUE
+					}
+					return NULL
+				}
+			},
+		},
+		{
 			// Creates instance variables and corresponding methods that return the value of
 			// each instance variable and assign an argument to each instance variable.
 			// Only string literal can be used for now.

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -700,6 +700,66 @@ func TestClassGreaterThanMethodFail(t *testing.T) {
 	}
 }
 
+func TestClassGreaterThanOrEqualMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{`
+		Object >= Array
+		`, true},
+		{`
+		Array >= Object
+		`, false},
+		{`
+		Object >= Object
+		`, true},
+		{`
+		(Array >= Hash).nil?
+		`, true},
+		{`
+		module M
+		end
+		class C
+		end
+		class C2 < C
+		  include M
+		end
+		class C3 < C2
+		end
+		M >= C3
+		`, true},
+		{`
+		module M
+		end
+		class C
+		end
+		(M >= C).nil?
+		`, true},
+	}
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		verifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestClassGreaterThanOrEqualMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`Array >= 1`, "TypeError: Expect argument to be a module. got=Integer", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestSendMethod(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -820,6 +820,66 @@ func TestClassLesserThanMethodFail(t *testing.T) {
 	}
 }
 
+func TestClassLesserThanOrEqualMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{`
+		Object <= Array
+		`, false},
+		{`
+		Array <= Object
+		`, true},
+		{`
+		Object <= Object
+		`, true},
+		{`
+		(Array <= Hash).nil?
+		`, true},
+		{`
+		module M
+		end
+		class C
+		end
+		class C2 < C
+		  include M
+		end
+		class C3 < C2
+		end
+		C3 <= M
+		`, true},
+		{`
+		module M
+		end
+		class C
+		end
+		(M <= C).nil?
+		`, true},
+	}
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		verifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestClassLesserThanOrEqualMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`Array <= 1`, "TypeError: Expect argument to be a module. got=Integer", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestSendMethod(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -760,6 +760,66 @@ func TestClassGreaterThanOrEqualMethodFail(t *testing.T) {
 	}
 }
 
+func TestClassLesserThanMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{`
+		Object < Array
+		`, false},
+		{`
+		Array < Object
+		`, true},
+		{`
+		Object < Object
+		`, false},
+		{`
+		(Array < Hash).nil?
+		`, true},
+		{`
+		module M
+		end
+		class C
+		end
+		class C2 < C
+		  include M
+		end
+		class C3 < C2
+		end
+		C3 < M
+		`, true},
+		{`
+		module M
+		end
+		class C
+		end
+		(M < C).nil?
+		`, true},
+	}
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		verifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestClassLesserThanMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`Array < 1`, "TypeError: Expect argument to be a module. got=Integer", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestSendMethod(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
ref: https://github.com/goby-lang/goby/pull/512

I don't have any idea to unify the implementation with `Module#>` 🙇  