### PR TITLE
Fix issues for running sample app

### DIFF
--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -208,8 +208,13 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 			if exp.Operator != "*" {
 				continue
 			}
+
 			ident := exp.Right.(*ast.Identifier)
-			scope.localTable.setLCL(ident.Value, scope.localTable.depth)
+
+			// Set default value to an empty array
+			index, depth := scope.localTable.setLCL(ident.Value, scope.localTable.depth)
+			newIS.define(NewArray, exp.Line(), 0)
+			newIS.define(SetLocal, exp.Line(), depth, index, 1)
 
 			newIS.argTypes.setArg(i, ident.Value, SplatArg)
 		case *ast.ArgumentPairExpression:

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -1404,6 +1404,13 @@ func TestMethodCallWithSplatArgument(t *testing.T) {
 
 		bar(1, 2, 3, 5)
 		`, 11},
+		{`
+		def foo(*a)
+		  a
+		end
+
+		foo
+		`, []interface{}{}},
 	}
 
 	for i, tt := range tests {

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -112,6 +112,20 @@ func (t *thread) execRequiredFile(filepath string, file []byte) (err error) {
 }
 
 func (t *thread) startFromTopFrame() {
+	defer func() {
+		if recover() == nil {
+			return
+		}
+
+		err, ok := recover().(*Error)
+
+		if ok && t.vm.mode == NormalMode {
+			fmt.Println(err.Message())
+		} else {
+			panic(err)
+		}
+	}()
+
 	cf := t.callFrameStack.top()
 	t.evalCallFrame(cf)
 }


### PR DESCRIPTION
Two changes:

- If nothing is passing to a splat argument, the default value will be an empty array instead of `nil`
- Rescue panic in frame execution level to prevent panic slipping in long running program 