### PR TITLE
Implement exit() as kernel method

### DIFF
--- a/igb/repl.go
+++ b/igb/repl.go
@@ -30,7 +30,6 @@ const (
 	echo      = "\033[33m#»\033[0m"
 	interrupt = "^C"
 	semicolon = ";"
-	exit      = "exit"
 	help      = "help"
 	reset     = "reset"
 
@@ -84,7 +83,6 @@ reset:
 		HistoryFile:         filepath.Join(os.TempDir(), "readline_goby.tmp"),
 		AutoComplete:        igb.completer,
 		InterruptPrompt:     interrupt,
-		EOFPrompt:           exit,
 		HistorySearchFold:   true,
 		FuncFilterInputRune: filterInput,
 	})
@@ -148,10 +146,6 @@ reset:
 			println(prompt(igb.indents) + igb.lines)
 			println("Restarting iGb...")
 			goto reset
-		case igb.lines == exit:
-			println(prompt(igb.indents) + igb.lines)
-			println("Bye!")
-			return
 		case igb.lines == "":
 			println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
 			continue
@@ -279,7 +273,6 @@ func newIgb() *iGb {
 		completer: readline.NewPrefixCompleter(
 			readline.PcItem(help),
 			readline.PcItem(reset),
-			readline.PcItem(exit),
 		),
 	}
 }

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -1065,6 +1065,22 @@ func TestRaiseMethodFail(t *testing.T) {
 	}
 }
 
+// With the current framework, only exit() failures can be tested.
+func TestExitMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`exit("abc")`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`exit(1, 2)`, "ArgumentError: Expected at most 1 argument; got: 2", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestGeneralIsAMethod(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
This allows the user to specify the exit code, which is useful in general, but in particular, required by the test framework.

Due to the new implementation, the REPL won't display anymore "Bye!" on exit. This can be restored by implementing and trapping a system exit error.