### PR TITLE
Add exit status to Spec.test invocations

### DIFF
--- a/lib/spec.gb
+++ b/lib/spec.gb
@@ -43,9 +43,16 @@ class Describe
         result_output = "    " + example_node.context_name
         if !example_node.test_result
           result_output += " (FAILED)"
+          Spec.instance.session_successful = false
         end
         puts(result_output)
       end
+    end
+
+    if Spec.instance.session_successful
+      exit
+    else
+      exit(1)
     end
   end
 

--- a/lib/spec.gb
+++ b/lib/spec.gb
@@ -1,6 +1,19 @@
 class Spec
+  attr_accessor :session_successful
+
   def self.describe(context_name)
     Describe.new(context_name, get_block)
+  end
+
+  # Currently, it's not possible to implement a true singleton, as access levels are not yet
+  # implemented.
+  #
+  def self.instance
+    @instance ||= Spec.new
+  end
+
+  def initialize
+    @session_successful = true
   end
 end
 


### PR DESCRIPTION
Spec.test invocations will now exit the interpreter at the end, with the appropriate exit code.

The PR adds a Spec singleton, in order to keep track of the global success status.

Addresses part of #357. Builds on top of #619.