### PR TITLE
Feature/issue 624

### DIFF
--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -231,3 +231,9 @@ func (p *Parser) IsNotDefMethodToken() bool {
 
 	return p.curToken.Type != token.Ident && !(p.peekToken.Type == token.Dot && (p.curToken.Type == token.InstanceVariable || p.curToken.Type == token.Constant || p.curToken.Type == token.Self))
 }
+
+// IsNotParamsToken ensures correct parameters which means it is not InstanceVariable
+func (p *Parser) IsNotParamsToken() bool {
+
+	return p.curToken.Type == token.InstanceVariable
+}

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -232,8 +232,16 @@ func (p *Parser) IsNotDefMethodToken() bool {
 	return p.curToken.Type != token.Ident && !(p.peekToken.Type == token.Dot && (p.curToken.Type == token.InstanceVariable || p.curToken.Type == token.Constant || p.curToken.Type == token.Self))
 }
 
+// Token type InstanceVariable and Constant will trigger IsNotParamsToken()
+var invalidParams = map[token.Type]bool{
+	token.InstanceVariable: true,
+	token.Constant:         true,
+}
+
 // IsNotParamsToken ensures correct parameters which means it is not InstanceVariable
 func (p *Parser) IsNotParamsToken() bool {
 
-	return p.curToken.Type == token.InstanceVariable
+	_, ok := invalidParams[p.curToken.Type]
+	return ok
+
 }

--- a/compiler/parser/statement_parsing_test.go
+++ b/compiler/parser/statement_parsing_test.go
@@ -193,3 +193,47 @@ func TestInvalidMethodNameFail(t *testing.T) {
 		t.Fatal(err.Message)
 	}
 }
+
+func TestInvalidParameter(t *testing.T) {
+	input := `
+	def foo(@a)
+	end`
+
+	l := lexer.New(input)
+	p := New(l)
+	_, err := p.ParseProgram()
+
+	if err.Message != "Invalid parameters: @a. Line: 1" {
+		t.Fatal(err.Message)
+	}
+}
+
+func TestInvalidMultipleParameter(t *testing.T) {
+	input := `
+	def foo(a, @b, c)
+	end`
+
+	l := lexer.New(input)
+	p := New(l)
+	_, err := p.ParseProgram()
+
+	if err.Message != "Invalid parameters: @b. Line: 1" {
+		t.Fatal(err.Message)
+	}
+}
+
+func TestParenthesisInNextLineIsNotParameter(t *testing.T) {
+	input := `
+	def test
+	  (@instance = 1)
+	end`
+
+	l := lexer.New(input)
+	p := New(l)
+	_, err := p.ParseProgram()
+
+	if err != nil {
+		t.Fatal(err.Message)
+	}
+
+}

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -299,6 +299,14 @@ func TestArgumentError(t *testing.T) {
 			// - the receiver of bar, because that call haven't been finished
 			// - the error object
 			6, 3, 3},
+		{`def foo
+          (x=1)
+		end
+		foo(2)
+		`,
+			"ArgumentError: Expect at most 0 args for method 'foo'. got: 1",
+
+			4, 1, 1},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Fix issue-624
Assignment surrounded by parenthesis, inside a method, crashes the interpreter #624

1. Ensure parameter is not instance variable (it will crash interpreter)
2. Identify  weather parenthesis statement is parameter or normal statement
which is make
```ruby=
def foo(a)
end
````
is different form
```ruby=
def foo
  (a)
end
```
The above codes get the same result in current master branch
