### PR TITLE
Feature/issue 524

### DIFF
--- a/compiler/parser/expression_parsing_test.go
+++ b/compiler/parser/expression_parsing_test.go
@@ -690,3 +690,19 @@ func TestArithmeticExpressionFail(t *testing.T) {
 		}
 	}
 }
+
+// If parser doesn't crash then we covered panic successfully
+
+func TestMultipleAssignError(t *testing.T) {
+	input := `
+	a = 4, 5`
+
+	l := lexer.New(input)
+	p := New(l)
+	_, err := p.ParseProgram()
+
+	if err.Message != "unexpected 5 Line: 1" {
+		t.Fatal(err.Message)
+	}
+
+}

--- a/compiler/parser/expression_parsing_test.go
+++ b/compiler/parser/expression_parsing_test.go
@@ -691,8 +691,7 @@ func TestArithmeticExpressionFail(t *testing.T) {
 	}
 }
 
-// If parser doesn't crash then we covered panic successfully
-
+// After covered panic still return error to repl
 func TestMultipleAssignError(t *testing.T) {
 	input := `
 	a = 4, 5`
@@ -702,6 +701,21 @@ func TestMultipleAssignError(t *testing.T) {
 	_, err := p.ParseProgram()
 
 	if err.Message != "unexpected 5 Line: 1" {
+		t.Fatal(err.Message)
+	}
+
+}
+
+// Transfer the unexpected panic into error
+func TestUnexpectedPanicError(t *testing.T) {
+	input := `
+	3()`
+
+	l := lexer.New(input)
+	p := New(l)
+	_, err := p.ParseProgram()
+
+	if err.Message != "Some panic happen token: (. Line: 1" {
 		t.Fatal(err.Message)
 	}
 

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -111,11 +111,15 @@ func New(l *lexer.Lexer) *Parser {
 }
 
 // ParseProgram update program statements and return program
-func (p *Parser) ParseProgram() (*ast.Program, *errors.Error) {
+func (p *Parser) ParseProgram() (program *ast.Program,err *errors.Error) {
 
-	defer func() {
+	defer func(){
 		if recover() != nil {
-			fmt.Println("Parser recovered from panic")
+			err = p.error
+			if err == nil {
+				msg := fmt.Sprintf("Some panic happen token: %s. Line: %d", p.curToken.Literal, p.curToken.Line)
+				err = errors.InitError(msg, errors.MethodDefinitionError)
+			}
 		}
 	}()
 
@@ -123,7 +127,7 @@ func (p *Parser) ParseProgram() (*ast.Program, *errors.Error) {
 	// Read two tokens, so curToken and peekToken are both set.
 	p.nextToken()
 	p.nextToken()
-	program := &ast.Program{}
+	program = &ast.Program{}
 	program.Statements = []ast.Statement{}
 
 	for !p.curTokenIs(token.EOF) {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -111,9 +111,9 @@ func New(l *lexer.Lexer) *Parser {
 }
 
 // ParseProgram update program statements and return program
-func (p *Parser) ParseProgram() (program *ast.Program,err *errors.Error) {
+func (p *Parser) ParseProgram() (program *ast.Program, err *errors.Error) {
 
-	defer func(){
+	defer func() {
 		if recover() != nil {
 			err = p.error
 			if err == nil {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -118,7 +118,7 @@ func (p *Parser) ParseProgram() (program *ast.Program, err *errors.Error) {
 			err = p.error
 			if err == nil {
 				msg := fmt.Sprintf("Some panic happen token: %s. Line: %d", p.curToken.Literal, p.curToken.Line)
-				err = errors.InitError(msg, errors.MethodDefinitionError)
+				err = errors.InitError(msg, errors.SyntaxError)
 			}
 		}
 	}()


### PR DESCRIPTION
- After covered panic still return error to repl
- Transfer the unexpected panic into error

We already have error detection function in current master branch for following code
When the error with panic will still crash parser, so I assign return value in defer function to prevent parser crash.
```
# multiple value assign not array format cause error
a = 2, 3
```

This closes #524 