### PR TITLE
Make lib path customizable on build, using the env variable GOBY_LIBPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GOFMT ?= gofmt -s
 GOFILES := $(shell find . -name "*.go" -type f -not -path "./vendor/*")
-RELEASE_OPTIONS := -ldflags "-s -w -X github.com/goby-lang/goby/vm.DefaultLibPath=${GOBY_LIBPATH}"
+RELEASE_OPTIONS := -ldflags "-s -w -X github.com/goby-lang/goby/vm.DefaultLibPath=${GOBY_LIBPATH}" -tags release
 TEST_OPTIONS := -ldflags "-s -w"
 
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GOFMT ?= gofmt -s
 GOFILES := $(shell find . -name "*.go" -type f -not -path "./vendor/*")
-RELEASE_OPTIONS := -ldflags "-s -w" -tags release
+RELEASE_OPTIONS := -ldflags "-s -w -X github.com/goby-lang/goby/vm.DefaultLibPath=${GOBY_LIBPATH}"
 TEST_OPTIONS := -ldflags "-s -w"
 
 .PHONY: fmt

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -70,7 +70,7 @@ func (t *thread) getClassIS(name string, filename filename) *instructionSet {
 }
 
 func (t *thread) execGobyLib(libName string) (err error) {
-	libPath := filepath.Join(t.vm.projectRoot, "lib", libName)
+	libPath := filepath.Join(t.vm.libPath, libName)
 	err = t.execFile(libPath)
 	return
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -65,6 +65,9 @@ type VM struct {
 	// projectRoot is goby root's absolute path, which is $GOROOT/src/github.com/goby-lang/goby
 	projectRoot string
 
+	// libPath indicates the Goby (.gb) libraries path
+	libPath string
+
 	channelObjectMap *objectMap
 
 	mode int
@@ -111,6 +114,8 @@ func New(fileDir string, args []string) (vm *VM, e error) {
 	} else {
 		vm.projectRoot = gobyRoot
 	}
+
+	vm.libPath = filepath.Join(vm.projectRoot, "lib")
 
 	vm.initConstants()
 	vm.mainObj = vm.initMainObj()

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -20,6 +20,9 @@ const (
 	TestMode
 )
 
+// DefaultLibPath is used for overriding vm.libpath build-time.
+var DefaultLibPath string
+
 type isIndexTable struct {
 	Data map[string]int
 }
@@ -65,7 +68,8 @@ type VM struct {
 	// projectRoot is goby root's absolute path, which is $GOROOT/src/github.com/goby-lang/goby
 	projectRoot string
 
-	// libPath indicates the Goby (.gb) libraries path
+	// libPath indicates the Goby (.gb) libraries path. Defaults to `<projectRoot>/lib`, unless
+	// DefaultLibPath is specified.
 	libPath string
 
 	channelObjectMap *objectMap
@@ -115,7 +119,11 @@ func New(fileDir string, args []string) (vm *VM, e error) {
 		vm.projectRoot = gobyRoot
 	}
 
-	vm.libPath = filepath.Join(vm.projectRoot, "lib")
+	if DefaultLibPath != "" {
+		vm.libPath = DefaultLibPath
+	} else {
+		vm.libPath = filepath.Join(vm.projectRoot, "lib")
+	}
 
 	vm.initConstants()
 	vm.mainObj = vm.initMainObj()


### PR DESCRIPTION
This is a typical pattern for packaged interpreters, so that each binary can have arbitrary library paths, decided by the packager.