### PR TITLE
Add Class#rap?, which is equivalent to Ruby's Object#respond_to?

### DIFF
--- a/vm/class.go
+++ b/vm/class.go
@@ -553,6 +553,38 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			},
 		},
 		{
+			// A predicate class method that returns `true` if the object has an ability to respond to the method, otherwise `false`.
+			// Equivalent to Ruby's `respond_to?` but shorter.
+			// Note that signs like `+` or `-` should be String literal.
+			//
+			// ```ruby
+			// Class.rap? "rap?"            #=> true
+			// Class.rap? :numerator        #=> false
+			// ```
+			//
+			// @param [String]
+			// @return [Boolean]
+			Name: "rap?",
+			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
+					if len(args) != 1 {
+						return t.vm.initErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+					}
+
+					arg, ok := args[0].(*StringObject)
+					if !ok {
+						return t.vm.initErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
+					}
+
+					r := receiver
+					if r.findMethod(arg.value) == nil {
+						return FALSE
+					}
+					return TRUE
+				}
+			},
+		},
+		{
 			// Returns the superclass object of the receiver.
 			//
 			// ```ruby
@@ -1063,6 +1095,39 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					return t.vm.initErrorObject(errors.ArgumentError, sourceLine, "Expect at most 2 arguments. got: %d", len(args))
+				}
+			},
+		},
+		{
+			// A predicate method that returns `true` if the object has an ability to respond to the method, otherwise `false`.
+			// Equivalent to Ruby's `respond_to?` but shorter.
+			// Note that signs like `+` or `-` should be String literal.
+			//
+			// ```ruby
+			// 1.rap? :to_i               #=> true
+			// "string".rap? "+"          #=> true
+			// 1.rap? :numerator          #=> false
+			// ```
+			//
+			// @param [String]
+			// @return [Boolean]
+			Name: "rap?",
+			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
+				return func(t *thread, args []Object, blockFrame *normalCallFrame) Object {
+					if len(args) != 1 {
+						return t.vm.initErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+					}
+
+					arg, ok := args[0].(*StringObject)
+					if !ok {
+						return t.vm.initErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
+					}
+
+					r := receiver
+					if r.findMethod(arg.value) == nil {
+						return FALSE
+					}
+					return TRUE
 				}
 			},
 		},

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -1099,6 +1099,36 @@ func TestRaiseMethodFail(t *testing.T) {
 	}
 }
 
+func TestRapMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{`
+		1.rap? :to_i
+		`, true},
+		{`
+		"string".rap? "+"
+		`, true},
+		{`
+		1.rap? :numerator
+		`, false},
+		{`
+		Class.rap? "rap?"
+		`, true},
+		{`
+		Class.rap? :phantom
+		`, false},
+	}
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		verifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
 // With the current framework, only exit() failures can be tested.
 func TestExitMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{


### PR DESCRIPTION
I think the shorter method name `Class#rap?` is better Ruby's `#respond_to?`.

If most people needs `#responds_to?`, I think just aliasing to it is sufficient.