### PR TITLE
Add Class#inherits_method_missing

### DIFF
--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -914,6 +914,42 @@ func TestClassLesserThanOrEqualMethodFail(t *testing.T) {
 	}
 }
 
+func TestInheritsMethodMissingMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`
+		class Bar
+		end
+		
+		Bar.new.inherits_method_missing?
+
+`, false},
+		{`
+		class Bar
+		  inherits_method_missing
+		end
+		
+		Bar.new.inherits_method_missing?
+
+`, true},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+
+		if isError(evaluated) {
+			t.Fatalf("got Error: %s", evaluated.(*Error).message)
+		}
+
+		VerifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestSendMethod(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -496,7 +496,7 @@ var builtinActions = map[operationType]*action{
 			method = receiver.findMethod(methodName)
 
 			if method == nil {
-				mm := receiver.findMethodMissing()
+				mm := receiver.findMethodMissing(receiver.Class().inheritsMethodMissing)
 
 				if mm == nil {
 					t.setErrorObject(receiverPr, argPr, errors.UndefinedMethodError, sourceLine, "Undefined Method '%+v' for %+v", methodName, receiver.toString())

--- a/vm/object.go
+++ b/vm/object.go
@@ -14,7 +14,7 @@ type Object interface {
 	SingletonClass() *RClass
 	SetSingletonClass(*RClass)
 	findMethod(string) Object
-	findMethodMissing() Object
+	findMethodMissing(bool) Object
 	toString() string
 	toJSON(t *Thread) string
 	id() int
@@ -79,13 +79,19 @@ func (b *baseObj) findMethod(methodName string) (method Object) {
 	return
 }
 
-func (b *baseObj) findMethodMissing() (method Object) {
+func (b *baseObj) findMethodMissing(searchAncestor bool) (method Object) {
+	methodMissing := "method_missing"
+
 	if b.SingletonClass() != nil {
-		method, _ = b.SingletonClass().Methods.get("method_missing")
+		method, _ = b.SingletonClass().Methods.get(methodMissing)
 	}
 
 	if method == nil {
-		method, _ = b.Class().Methods.get("method_missing")
+		method, _ = b.Class().Methods.get(methodMissing)
+	}
+
+	if method == nil && searchAncestor {
+		method = b.findMethod(methodMissing)
 	}
 
 	return


### PR DESCRIPTION
By default, `method_missing`'s behavior is non-inheritable in Goby. So the following code will fail

```ruby
class Foo
  def method_missing(name)
    10
  end
end

class Bar < Foo
end
		
Bar.new.bar #=> NoMethodError
```
  
But after this PR, you just need to call `inherits_method_missing` in the children class (`Bar` in the example) and then it can inherit `method_missing` from its ancestors

```ruby
class Foo
  def method_missing(name)
    10
  end
end

class Bar < Foo
  inherits_method_missing
end
		
Bar.new.bar #=> 10
```