### PR TITLE
Prohibit module initialization

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -1399,7 +1399,7 @@ func (vm *VM) InitArrayObject(elements []Object) *ArrayObject {
 }
 
 func (vm *VM) initArrayClass() *RClass {
-	ac := vm.initializeClass(classes.ArrayClass, false)
+	ac := vm.initializeClass(classes.ArrayClass)
 	ac.setBuiltinMethods(builtinArrayInstanceMethods(), false)
 	ac.setBuiltinMethods(builtinArrayClassMethods(), true)
 	vm.libFiles = append(vm.libFiles, "array.gb")

--- a/vm/block.go
+++ b/vm/block.go
@@ -133,7 +133,7 @@ func builtinBlockInstanceMethods() []*BuiltinMethodObject {
 // Functions for initialization -----------------------------------------
 
 func (vm *VM) initBlockClass() *RClass {
-	class := vm.initializeClass(classes.BlockClass, false)
+	class := vm.initializeClass(classes.BlockClass)
 	class.setBuiltinMethods(builtinBlockClassMethods(), true)
 	class.setBuiltinMethods(builtinBlockInstanceMethods(), false)
 	return class

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -44,7 +44,7 @@ func builtinBooleanClassMethods() []*BuiltinMethodObject {
 // Functions for initialization -----------------------------------------
 
 func (vm *VM) initBoolClass() *RClass {
-	b := vm.initializeClass(classes.BooleanClass, false)
+	b := vm.initializeClass(classes.BooleanClass)
 	b.setBuiltinMethods(builtinBooleanClassMethods(), true)
 
 	TRUE = &BooleanObject{value: true, baseObj: &baseObj{class: b}}

--- a/vm/channel.go
+++ b/vm/channel.go
@@ -248,7 +248,7 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 // Functions for initialization -----------------------------------------
 
 func (vm *VM) initChannelClass() *RClass {
-	class := vm.initializeClass(classes.ChannelClass, false)
+	class := vm.initializeClass(classes.ChannelClass)
 	class.setBuiltinMethods(builtinChannelClassMethods(), true)
 	class.setBuiltinMethods(builtinChannelInstanceMethods(), false)
 	return class

--- a/vm/class.go
+++ b/vm/class.go
@@ -1501,28 +1501,12 @@ func (vm *VM) createRClass(className string) *RClass {
 	}
 }
 
-func initClassClass() *RClass {
-	classClass := &RClass{
-		Name:      classes.ClassClass,
-		Methods:   newEnvironment(),
-		constants: make(map[string]*Pointer),
-		baseObj:   &baseObj{},
-	}
-
+func initModuleClass(classClass *RClass) *RClass {
 	moduleClass := &RClass{
 		Name:      classes.ModuleClass,
 		Methods:   newEnvironment(),
 		constants: make(map[string]*Pointer),
 		baseObj:   &baseObj{},
-	}
-
-	classSingletonClass := &RClass{
-		Name:        "#<Class:Class>",
-		Methods:     newEnvironment(),
-		constants:   make(map[string]*Pointer),
-		isModule:    false,
-		baseObj:     &baseObj{class: classClass, InstanceVariables: newEnvironment()},
-		isSingleton: true,
 	}
 
 	moduleSingletonClass := &RClass{
@@ -1537,12 +1521,33 @@ func initClassClass() *RClass {
 	classClass.superClass = moduleClass
 	classClass.pseudoSuperClass = moduleClass
 
-	classClass.class = classClass
 	moduleClass.class = classClass
-	classClass.singletonClass = classSingletonClass
 	moduleClass.singletonClass = moduleSingletonClass
 
 	moduleClass.setBuiltinMethods(builtinClassCommonClassMethods(), true)
+
+	return moduleClass
+}
+
+func initClassClass() *RClass {
+	classClass := &RClass{
+		Name:      classes.ClassClass,
+		Methods:   newEnvironment(),
+		constants: make(map[string]*Pointer),
+		baseObj:   &baseObj{},
+	}
+
+	classSingletonClass := &RClass{
+		Name:        "#<Class:Class>",
+		Methods:     newEnvironment(),
+		constants:   make(map[string]*Pointer),
+		isModule:    false,
+		baseObj:     &baseObj{class: classClass, InstanceVariables: newEnvironment()},
+		isSingleton: true,
+	}
+
+	classClass.class = classClass
+	classClass.singletonClass = classSingletonClass
 
 	return classClass
 }

--- a/vm/class.go
+++ b/vm/class.go
@@ -58,7 +58,7 @@ func buildMethods(m map[string]MethodBuilder) []*BuiltinMethodObject {
 // ExternalClass helps define external go classes
 func ExternalClass(name, path string, classMethods, instanceMethods map[string]MethodBuilder) ClassLoader {
 	return func(v *VM) error {
-		pg := v.initializeClass(name, false)
+		pg := v.initializeClass(name)
 		pg.setBuiltinMethods(buildMethods(classMethods), true)
 		pg.setBuiltinMethods(buildMethods(instanceMethods), false)
 		v.objectClass.setClassConstant(pg)
@@ -1464,9 +1464,20 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 
 // initializeClass is a common function for vm, which initializes and returns
 // a class instance with given class name.
-func (vm *VM) initializeClass(name string, isModule bool) *RClass {
+func (vm *VM) initializeClass(name string) *RClass {
 	class := vm.createRClass(name)
-	class.isModule = isModule
+	class.isModule = false
+	singletonClass := vm.createRClass(fmt.Sprintf("#<Class:%s>", name))
+	singletonClass.isSingleton = true
+	class.singletonClass = singletonClass
+	class.inherits(vm.objectClass)
+
+	return class
+}
+
+func (vm *VM) initializeModule(name string) *RClass {
+	class := vm.createRClass(name)
+	class.isModule = true
 	singletonClass := vm.createRClass(fmt.Sprintf("#<Class:%s>", name))
 	singletonClass.isSingleton = true
 	class.singletonClass = singletonClass

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -8,7 +8,8 @@ func TestClassClassSuperclass(t *testing.T) {
 		expected string
 	}{
 		{`Class.class.name`, "Class"},
-		{`Class.superclass.name`, "Object"},
+		{`Class.superclass.name`, "Module"},
+		{`Module.superclass.name`, "Object"},
 	}
 
 	for i, tt := range tests {
@@ -1343,7 +1344,7 @@ func TestClassSuperclassClassMethod(t *testing.T) {
 		{`Hash.superclass.name`, "Object"},
 		{`Array.superclass.name`, "Object"},
 		{`Object.superclass.name`, "Object"},
-		{`Class.superclass.name`, "Object"},
+		{`Module.superclass.name`, "Object"},
 		{`
 		module Bar; end
 		class Foo

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -115,6 +115,22 @@ a = Bar.new()
 	v.checkSP(t, 0, 3)
 }
 
+func TestModuleInitializeError(t *testing.T) {
+	input := `
+	module Foo
+	end
+
+	Foo.new
+	`
+	expected := `UndefinedMethodError: Undefined Method 'new' for Foo`
+
+	v := initTestVM()
+	evaluated := v.testEval(t, input, getFilename())
+	checkErrorMsg(t, i, evaluated, expected)
+	v.checkCFP(t, 0, 1)
+	v.checkSP(t, 0, 1)
+}
+
 func TestClassInstanceVariable(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -1345,6 +1361,9 @@ func TestClassSuperclassClassMethod(t *testing.T) {
 		{`Array.superclass.name`, "Object"},
 		{`Object.superclass.name`, "Object"},
 		{`Module.superclass.name`, "Object"},
+		{`Class.superclass.name`, "Module"},
+
+		// This is to make sure superclass won't return included module
 		{`
 		module Bar; end
 		class Foo
@@ -1387,6 +1406,7 @@ func TestClassSingletonClassMethod(t *testing.T) {
 		expected interface{}
 	}{
 		{`Integer.singleton_class.name`, "#<Class:Integer>"},
+		{`Integer.singleton_class.class.name`, "Class"},
 		{`Integer.singleton_class.superclass.name`, "#<Class:Object>"},
 		{`
 		class Bar; end
@@ -1397,12 +1417,28 @@ func TestClassSingletonClassMethod(t *testing.T) {
 		class Foo < Bar; end
 		Foo.singleton_class.superclass.name
 		`, "#<Class:Bar>"},
+		{`
+		module Bar; end
+		
+		Bar.singleton_class.name
+		`, "#<Class:Bar>"},
 		// Check if this works on non-class objects
 		{`'a'.singleton_class.to_s.slice(1..16).to_s`, "<Class:#<String:"},
 		{`1.singleton_class.to_s.slice(1..17).to_s`, "<Class:#<Integer:"},
 		{`nil.singleton_class.to_s.slice(1..14).to_s`, "<Class:#<Null:"},
 		{`[1,2].singleton_class.to_s.slice(1..15).to_s`, "<Class:#<Array:"},
 		{`{key: "value"}.singleton_class.to_s.slice(1..14).to_s`, "<Class:#<Hash:"},
+		// Below is for testing module inheritance chain
+		{`
+		module Bar; end
+		
+		Bar.singleton_class.class.name
+		`, "Class"},
+		{`
+		module Bar; end
+		
+		Bar.singleton_class.superclass.name
+		`, "Module"},
 	}
 
 	for i, tt := range tests {

--- a/vm/classes/classes.go
+++ b/vm/classes/classes.go
@@ -3,6 +3,7 @@ package classes
 const (
 	ObjectClass    = "Object"
 	ClassClass     = "Class"
+	ModuleClass    = "Module"
 	IntegerClass   = "Integer"
 	FloatClass     = "Float"
 	StringClass    = "String"

--- a/vm/concurrent_array.go
+++ b/vm/concurrent_array.go
@@ -104,7 +104,7 @@ func builtinConcurrentArrayInstanceMethods() []*BuiltinMethodObject {
 
 func (vm *VM) initConcurrentArrayObject(elements []Object) *ConcurrentArrayObject {
 	concurrent := vm.loadConstant("Concurrent", true)
-	array := concurrent.getClassConstant("Array")
+	array := concurrent.getClassConstant(classes.ArrayClass)
 
 	return &ConcurrentArrayObject{
 		baseObj:       &baseObj{class: array},
@@ -114,7 +114,7 @@ func (vm *VM) initConcurrentArrayObject(elements []Object) *ConcurrentArrayObjec
 
 func initConcurrentArrayClass(vm *VM) {
 	concurrent := vm.loadConstant("Concurrent", true)
-	array := vm.initializeClass("Array", false)
+	array := vm.initializeClass(classes.ArrayClass)
 
 	array.setBuiltinMethods(builtinConcurrentArrayInstanceMethods(), false)
 	array.setBuiltinMethods(builtinConcurrentArrayClassMethods(), true)

--- a/vm/concurrent_hash.go
+++ b/vm/concurrent_hash.go
@@ -311,7 +311,7 @@ func (vm *VM) initConcurrentHashObject(pairs map[string]Object) *ConcurrentHashO
 	}
 
 	concurrent := vm.loadConstant("Concurrent", true)
-	hash := concurrent.getClassConstant("Hash")
+	hash := concurrent.getClassConstant(classes.HashClass)
 
 	return &ConcurrentHashObject{
 		baseObj:     &baseObj{class: hash},
@@ -321,7 +321,7 @@ func (vm *VM) initConcurrentHashObject(pairs map[string]Object) *ConcurrentHashO
 
 func initConcurrentHashClass(vm *VM) {
 	concurrent := vm.loadConstant("Concurrent", true)
-	hash := vm.initializeClass("Hash", false)
+	hash := vm.initializeClass(classes.HashClass)
 
 	hash.setBuiltinMethods(builtinConcurrentHashInstanceMethods(), false)
 	hash.setBuiltinMethods(builtinConcurrentHashClassMethods(), true)

--- a/vm/concurrent_rw_lock.go
+++ b/vm/concurrent_rw_lock.go
@@ -241,7 +241,7 @@ func (vm *VM) initConcurrentRWLockObject() *ConcurrentRWLockObject {
 
 func initConcurrentRWLockClass(vm *VM) {
 	concurrentModule := vm.loadConstant("Concurrent", true)
-	lockClass := vm.initializeClass("RWLock", false)
+	lockClass := vm.initializeClass("RWLock")
 
 	lockClass.setBuiltinMethods(builtinConcurrentRWLockInstanceMethods(), false)
 	lockClass.setBuiltinMethods(builtinConcurrentRWLockClassMethods(), true)

--- a/vm/decimal.go
+++ b/vm/decimal.go
@@ -587,7 +587,7 @@ func (vm *VM) initDecimalObject(value *Decimal) *DecimalObject {
 }
 
 func (vm *VM) initDecimalClass() *RClass {
-	dc := vm.initializeClass(classes.DecimalClass, false)
+	dc := vm.initializeClass(classes.DecimalClass)
 	dc.setBuiltinMethods(builtinDecimalInstanceMethods(), false)
 	dc.setBuiltinMethods(builtinDecimalClassMethods(), true)
 	return dc

--- a/vm/error.go
+++ b/vm/error.go
@@ -61,7 +61,7 @@ func (vm *VM) initErrorClasses() {
 	errTypes := []string{errors.InternalError, errors.ArgumentError, errors.NameError, errors.StopIteration, errors.TypeError, errors.UndefinedMethodError, errors.UnsupportedMethodError, errors.ConstantAlreadyInitializedError, errors.HTTPError, errors.ZeroDivisionError, errors.ChannelCloseError}
 
 	for _, errType := range errTypes {
-		c := vm.initializeClass(errType, false)
+		c := vm.initializeClass(errType)
 		vm.objectClass.setClassConstant(c)
 	}
 }

--- a/vm/file.go
+++ b/vm/file.go
@@ -350,7 +350,7 @@ func (vm *VM) initFileObject(f *os.File) *FileObject {
 }
 
 func (vm *VM) initFileClass() *RClass {
-	fc := vm.initializeClass(classes.FileClass, false)
+	fc := vm.initializeClass(classes.FileClass)
 	fc.setBuiltinMethods(builtinFileClassMethods(), true)
 	fc.setBuiltinMethods(builtinFileInstanceMethods(), false)
 

--- a/vm/float.go
+++ b/vm/float.go
@@ -369,7 +369,7 @@ func (vm *VM) initFloatObject(value float64) *FloatObject {
 }
 
 func (vm *VM) initFloatClass() *RClass {
-	ic := vm.initializeClass(classes.FloatClass, false)
+	ic := vm.initializeClass(classes.FloatClass)
 	ic.setBuiltinMethods(builtinFloatInstanceMethods(), false)
 	ic.setBuiltinMethods(builtinFloatClassMethods(), true)
 	return ic

--- a/vm/go_map.go
+++ b/vm/go_map.go
@@ -138,7 +138,7 @@ func (vm *VM) initGoMap(d map[string]interface{}) *GoMap {
 }
 
 func (vm *VM) initGoMapClass() *RClass {
-	sc := vm.initializeClass(classes.GoMapClass, false)
+	sc := vm.initializeClass(classes.GoMapClass)
 	sc.setBuiltinMethods(builtinGoMapClassMethods(), true)
 	sc.setBuiltinMethods(builtinGoMapInstanceMethods(), false)
 	vm.objectClass.setClassConstant(sc)

--- a/vm/go_object.go
+++ b/vm/go_object.go
@@ -58,7 +58,7 @@ func (vm *VM) initGoObject(d interface{}) *GoObject {
 }
 
 func (vm *VM) initGoClass() *RClass {
-	sc := vm.initializeClass(classes.GoObjectClass, false)
+	sc := vm.initializeClass(classes.GoObjectClass)
 	sc.setBuiltinMethods(builtinGoObjectClassMethods(), true)
 	sc.setBuiltinMethods(builtinGoObjectInstanceMethods(), false)
 	vm.objectClass.setClassConstant(sc)

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -1218,7 +1218,7 @@ func (vm *VM) InitHashObject(pairs map[string]Object) *HashObject {
 }
 
 func (vm *VM) initHashClass() *RClass {
-	hc := vm.initializeClass(classes.HashClass, false)
+	hc := vm.initializeClass(classes.HashClass)
 	hc.setBuiltinMethods(builtinHashInstanceMethods(), false)
 	hc.setBuiltinMethods(builtinHashClassMethods(), true)
 	return hc

--- a/vm/http.go
+++ b/vm/http.go
@@ -183,7 +183,7 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 
 func initHTTPClass(vm *VM) {
 	net := vm.loadConstant("Net", true)
-	http := vm.initializeClass("HTTP", false)
+	http := vm.initializeClass("HTTP")
 	http.setBuiltinMethods(builtinHTTPClassMethods(), true)
 	initRequestClass(vm, http)
 	initResponseClass(vm, http)
@@ -197,7 +197,7 @@ func initHTTPClass(vm *VM) {
 }
 
 func initRequestClass(vm *VM, hc *RClass) *RClass {
-	requestClass := vm.initializeClass("Request", false)
+	requestClass := vm.initializeClass("Request")
 	hc.setClassConstant(requestClass)
 	builtinHTTPRequestInstanceMethods := []*BuiltinMethodObject{}
 
@@ -208,7 +208,7 @@ func initRequestClass(vm *VM, hc *RClass) *RClass {
 }
 
 func initResponseClass(vm *VM, hc *RClass) *RClass {
-	responseClass := vm.initializeClass("Response", false)
+	responseClass := vm.initializeClass("Response")
 	hc.setClassConstant(responseClass)
 	builtinHTTPResponseInstanceMethods := []*BuiltinMethodObject{}
 

--- a/vm/http_client.go
+++ b/vm/http_client.go
@@ -159,7 +159,7 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 // Functions for initialization -----------------------------------------
 
 func initClientClass(vm *VM, hc *RClass) *RClass {
-	clientClass := vm.initializeClass("Client", false)
+	clientClass := vm.initializeClass("Client")
 	hc.setClassConstant(clientClass)
 
 	clientClass.setBuiltinMethods(builtinHTTPClientInstanceMethods(), false)

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -436,7 +436,13 @@ var builtinActions = map[operationType]*action{
 			classPtr := cf.lookupConstantUnderAllScope(subjectName)
 
 			if classPtr == nil {
-				class := t.vm.initializeClass(subjectName, subjectType == "module")
+				var class *RClass
+				if subjectType == "module" {
+					class = t.vm.initializeModule(subjectName)
+				} else {
+					class = t.vm.initializeClass(subjectName)
+				}
+
 				classPtr = cf.storeConstant(class.Name, class)
 
 				if len(args) >= 2 {

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -688,7 +688,7 @@ func (vm *VM) InitIntegerObject(value int) *IntegerObject {
 }
 
 func (vm *VM) initIntegerClass() *RClass {
-	ic := vm.initializeClass(classes.IntegerClass, false)
+	ic := vm.initializeClass(classes.IntegerClass)
 	ic.setBuiltinMethods(builtinIntegerInstanceMethods(), false)
 	ic.setBuiltinMethods(builtinIntegerClassMethods(), true)
 	return ic

--- a/vm/json.go
+++ b/vm/json.go
@@ -102,7 +102,7 @@ func builtinJSONInstanceMethods() []*BuiltinMethodObject {
 // Functions for initialization -----------------------------------------
 
 func initJSONClass(vm *VM) {
-	class := vm.initializeClass("JSON", false)
+	class := vm.initializeClass("JSON")
 	class.setBuiltinMethods(builtinJSONClassMethods(), true)
 	class.setBuiltinMethods(builtinJSONInstanceMethods(), false)
 	vm.objectClass.setClassConstant(class)

--- a/vm/match_data.go
+++ b/vm/match_data.go
@@ -172,7 +172,7 @@ func (vm *VM) initMatchDataObject(match *Match, pattern, text string) *MatchData
 }
 
 func (vm *VM) initMatchDataClass() *RClass {
-	klass := vm.initializeClass(classes.MatchDataClass, false)
+	klass := vm.initializeClass(classes.MatchDataClass)
 	klass.setBuiltinMethods(builtinMatchDataInstanceMethods(), false)
 	klass.setBuiltinMethods(builtInMatchDataClassMethods(), true)
 	return klass

--- a/vm/method.go
+++ b/vm/method.go
@@ -21,7 +21,7 @@ type MethodObject struct {
 // Functions for initialization -----------------------------------------
 
 func (vm *VM) initMethodClass() *RClass {
-	return vm.initializeClass(classes.MethodClass, false)
+	return vm.initializeClass(classes.MethodClass)
 }
 
 // Polymorphic helper functions -----------------------------------------

--- a/vm/null.go
+++ b/vm/null.go
@@ -136,7 +136,7 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 // Functions for initialization -----------------------------------------
 
 func (vm *VM) initNullClass() *RClass {
-	nc := vm.initializeClass(classes.NullClass, false)
+	nc := vm.initializeClass(classes.NullClass)
 	nc.setBuiltinMethods(builtinNullInstanceMethods(), false)
 	nc.setBuiltinMethods(builtinNullClassMethods(), true)
 	NULL = &NullObject{baseObj: &baseObj{class: nc}}

--- a/vm/plugin.go
+++ b/vm/plugin.go
@@ -171,7 +171,7 @@ func (vm *VM) initPluginObject(fn string, p *plugin.Plugin) *PluginObject {
 }
 
 func initPluginClass(vm *VM) {
-	pc := vm.initializeClass(classes.PluginClass, false)
+	pc := vm.initializeClass(classes.PluginClass)
 	pc.setBuiltinMethods(builtinPluginClassMethods(), true)
 	pc.setBuiltinMethods(builtinPluginInstanceMethods(), false)
 	vm.objectClass.setClassConstant(pc)

--- a/vm/range.go
+++ b/vm/range.go
@@ -537,7 +537,7 @@ func (vm *VM) initRangeObject(start, end int) *RangeObject {
 }
 
 func (vm *VM) initRangeClass() *RClass {
-	rc := vm.initializeClass(classes.RangeClass, false)
+	rc := vm.initializeClass(classes.RangeClass)
 	rc.setBuiltinMethods(builtinRangeInstanceMethods(), false)
 	rc.setBuiltinMethods(builtinRangeClassMethods(), true)
 	vm.libFiles = append(vm.libFiles, "range.gb")

--- a/vm/regexp.go
+++ b/vm/regexp.go
@@ -159,7 +159,7 @@ func (vm *VM) initRegexpObject(regexp string) *RegexpObject {
 }
 
 func (vm *VM) initRegexpClass() *RClass {
-	rc := vm.initializeClass(classes.RegexpClass, false)
+	rc := vm.initializeClass(classes.RegexpClass)
 	rc.setBuiltinMethods(builtinRegexpInstanceMethods(), false)
 	rc.setBuiltinMethods(builtInRegexpClassMethods(), true)
 	return rc

--- a/vm/simple_server.go
+++ b/vm/simple_server.go
@@ -137,7 +137,7 @@ func builtinSimpleServerInstanceMethods() []*BuiltinMethodObject {
 func initSimpleServerClass(vm *VM) {
 	initHTTPClass(vm)
 	net := vm.loadConstant("Net", true)
-	simpleServer := vm.initializeClass("SimpleServer", false)
+	simpleServer := vm.initializeClass("SimpleServer")
 	simpleServer.setBuiltinMethods(builtinSimpleServerInstanceMethods(), false)
 	net.setClassConstant(simpleServer)
 

--- a/vm/string.go
+++ b/vm/string.go
@@ -1681,7 +1681,7 @@ func (vm *VM) initStringObject(value string) *StringObject {
 }
 
 func (vm *VM) initStringClass() *RClass {
-	sc := vm.initializeClass(classes.StringClass, false)
+	sc := vm.initializeClass(classes.StringClass)
 	sc.setBuiltinMethods(builtinStringInstanceMethods(), false)
 	sc.setBuiltinMethods(builtinStringClassMethods(), true)
 	return sc

--- a/vm/uri.go
+++ b/vm/uri.go
@@ -109,9 +109,9 @@ func builtinURIClassMethods() []*BuiltinMethodObject {
 // Functions for initialization -----------------------------------------
 
 func initURIClass(vm *VM) {
-	uri := vm.initializeClass("URI", true)
-	http := vm.initializeClass("HTTP", false)
-	https := vm.initializeClass("HTTPS", false)
+	uri := vm.initializeModule("URI")
+	http := vm.initializeClass("HTTP")
+	https := vm.initializeClass("HTTPS")
 	https.superClass = http
 	https.pseudoSuperClass = http
 	uri.setClassConstant(http)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -214,7 +214,7 @@ func builtinMainObjSingletonMethods() []*BuiltinMethodObject {
 
 func (vm *VM) initMainObj() *RObject {
 	obj := vm.objectClass.initializeInstance()
-	singletonClass := vm.initializeClass(fmt.Sprintf("#<Class:%s>", obj.toString()), false)
+	singletonClass := vm.initializeClass(fmt.Sprintf("#<Class:%s>", obj.toString()))
 	singletonClass.Methods.set("include", vm.topLevelClass(classes.ClassClass).lookupMethod("include"))
 	singletonClass.setBuiltinMethods(builtinMainObjSingletonMethods(), false)
 	obj.singletonClass = singletonClass
@@ -302,7 +302,12 @@ func (vm *VM) loadConstant(name string, isModule bool) *RClass {
 	ptr = vm.objectClass.constants[name]
 
 	if ptr == nil {
-		c = vm.initializeClass(name, isModule)
+		if isModule {
+			c = vm.initializeClass(name)
+		} else {
+			c = vm.initializeModule(name)
+		}
+
 		vm.objectClass.setClassConstant(c)
 	} else {
 		c = ptr.Target.(*RClass)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -227,6 +227,7 @@ func (vm *VM) initConstants() {
 	cClass := initClassClass()
 	vm.objectClass = initObjectClass(cClass)
 	vm.topLevelClass(classes.ObjectClass).setClassConstant(cClass)
+	vm.topLevelClass(classes.ObjectClass).setClassConstant(cClass.superClass)
 
 	// Init builtin classes
 	builtinClasses := []*RClass{

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -225,9 +225,10 @@ func (vm *VM) initMainObj() *RObject {
 func (vm *VM) initConstants() {
 	// Init Class and Object
 	cClass := initClassClass()
+	mClass := initModuleClass(cClass)
 	vm.objectClass = initObjectClass(cClass)
 	vm.topLevelClass(classes.ObjectClass).setClassConstant(cClass)
-	vm.topLevelClass(classes.ObjectClass).setClassConstant(cClass.superClass)
+	vm.topLevelClass(classes.ObjectClass).setClassConstant(mClass)
 
 	// Init builtin classes
 	builtinClasses := []*RClass{


### PR DESCRIPTION
This fixes #679. The solution is more complicated than just forbidden the method. I choose to let it work more like Ruby:

1. `Class < Module` and `Module < Object`
2. Module class doesn't support `#new` (but support `.new`)
3. Class class support `#new`

Before today our inheritance chain for `Class` class is `Class < Object`, so I changed it as described above.

@hachi8833 can you help me compare the Goby's behavior with Ruby again?