### PR TITLE
Reduce method call memory allocation

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -36,3 +36,5 @@ done
 # TODO: Write a test for this specific case
 make install
 goby test specs
+
+./benchmark.rb

--- a/vm/array.go
+++ b/vm/array.go
@@ -23,10 +23,8 @@ func builtinArrayClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
 			},
 		},
 	}
@@ -85,11 +83,9 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param index [Integer], (count [Integer])
 			// @return [Array]
 			Name: "[]",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					arr := receiver.(*ArrayObject)
-					return arr.index(t, args, sourceLine)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				arr := receiver.(*ArrayObject)
+				return arr.index(t, args, sourceLine)
 			},
 		},
 		{
@@ -106,22 +102,21 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param zero or positive integer [Integer]
 			// @return [Array]
 			Name: "*",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 arguments. got=%d", len(args))
-					}
-
-					arr := receiver.(*ArrayObject)
-
-					copiesNumber, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-					}
-
-					return arr.concatenateCopies(t, copiesNumber)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 arguments. got=%d", len(args))
 				}
+
+				arr := receiver.(*ArrayObject)
+
+				copiesNumber, ok := args[0].(*IntegerObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+				}
+
+				return arr.concatenateCopies(t, copiesNumber)
+
 			},
 		},
 		{
@@ -135,27 +130,25 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param array [Array]
 			// @return [Array]
 			Name: "+",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 arguments. got=%d", len(args))
-					}
-
-					otherArrayArg := args[0]
-					otherArray, ok := otherArrayArg.(*ArrayObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.ArrayClass, args[0].Class().Name)
-					}
-
-					selfArray := receiver.(*ArrayObject)
-
-					newArrayelements := append(selfArray.Elements, otherArray.Elements...)
-
-					newArray := t.vm.InitArrayObject(newArrayelements)
-
-					return newArray
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 arguments. got=%d", len(args))
 				}
+
+				otherArrayArg := args[0]
+				otherArray, ok := otherArrayArg.(*ArrayObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.ArrayClass, args[0].Class().Name)
+				}
+
+				selfArray := receiver.(*ArrayObject)
+
+				newArrayelements := append(selfArray.Elements, otherArray.Elements...)
+
+				newArray := t.vm.InitArrayObject(newArrayelements)
+
+				return newArray
 			},
 		},
 		{
@@ -228,113 +221,112 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param index [Integer], count [Integer], object [Object]
 			// @return [Array]
 			Name: "[]=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					// First argument is an index: there exists two cases which will be described in the following code
-					if len(args) != 2 && len(args) != 3 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2..3 arguments. got=%d", len(args))
+				// First argument is an index: there exists two cases which will be described in the following code
+				if len(args) != 2 && len(args) != 3 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2..3 arguments. got=%d", len(args))
+				}
+
+				i := args[0]
+				index, ok := i.(*IntegerObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+				}
+
+				indexValue := index.value
+				arr := receiver.(*ArrayObject)
+
+				// <Three Argument Case>
+				// Second argument: the length of successive array values (zero or positive Integer)
+				// Third argument: the assignment value (object)
+				if len(args) == 3 {
+					// Negative index value too small
+					if indexValue < 0 {
+						if arr.normalizeIndex(index) == -1 {
+							return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Index value %d too small for array. minimum: %d", indexValue, -arr.length())
+						}
+						indexValue = arr.normalizeIndex(index)
 					}
 
-					i := args[0]
-					index, ok := i.(*IntegerObject)
+					c := args[1]
+					count, ok := c.(*IntegerObject)
 
+					// Second argument must be an integer
 					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[1].Class().Name)
 					}
 
-					indexValue := index.value
-					arr := receiver.(*ArrayObject)
+					countValue := count.value
+					// Second argument must be a positive value
+					if countValue < 0 {
+						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect second argument greater than or equal 0. got: %d", countValue)
+					}
 
-					// <Three Argument Case>
-					// Second argument: the length of successive array values (zero or positive Integer)
-					// Third argument: the assignment value (object)
-					if len(args) == 3 {
-						// Negative index value too small
-						if indexValue < 0 {
-							if arr.normalizeIndex(index) == -1 {
-								return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Index value %d too small for array. minimum: %d", indexValue, -arr.length())
-							}
-							indexValue = arr.normalizeIndex(index)
+					a := args[2]
+					assignedValue, isArray := a.(*ArrayObject)
+
+					// Expand the array with nil; the second index is unnecessary in the case
+					if indexValue >= arr.length() {
+
+						for arr.length() < indexValue {
+							arr.Elements = append(arr.Elements, NULL)
 						}
 
-						c := args[1]
-						count, ok := c.(*IntegerObject)
-
-						// Second argument must be an integer
-						if !ok {
-							return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[1].Class().Name)
-						}
-
-						countValue := count.value
-						// Second argument must be a positive value
-						if countValue < 0 {
-							return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect second argument greater than or equal 0. got: %d", countValue)
-						}
-
-						a := args[2]
-						assignedValue, isArray := a.(*ArrayObject)
-
-						// Expand the array with nil; the second index is unnecessary in the case
-						if indexValue >= arr.length() {
-
-							for arr.length() < indexValue {
-								arr.Elements = append(arr.Elements, NULL)
-							}
-
-							if isArray {
-								arr.Elements = append(arr.Elements, assignedValue.Elements...)
-							} else {
-								arr.Elements = append(arr.Elements, a)
-							}
-							return a
-						}
-
-						endValue := indexValue + countValue
-						// the case the addition of index and count is too large
-						if endValue > arr.length() {
-							endValue = arr.length()
-						}
-
-						arr.Elements = append(arr.Elements[:indexValue], arr.Elements[endValue:]...)
-
-						// If assigned value is an array, then splat the array and push each element to the receiver
-						// following the first and second indices
 						if isArray {
-							arr.Elements = append(arr.Elements[:indexValue], append(assignedValue.Elements, arr.Elements[indexValue:]...)...)
+							arr.Elements = append(arr.Elements, assignedValue.Elements...)
 						} else {
-							arr.Elements = append(arr.Elements[:indexValue], append([]Object{a}, arr.Elements[indexValue:]...)...)
+							arr.Elements = append(arr.Elements, a)
 						}
-
 						return a
 					}
 
-					// <Two Argument Case>
-					// Second argument is the assignment value (object)
-
-					// Negative index value condition
-					if indexValue < 0 {
-						if len(arr.Elements) < -indexValue {
-							return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Index value %d too small for array. minimum: %d", indexValue, -arr.length())
-						}
-						arr.Elements[len(arr.Elements)+indexValue] = args[1]
-						return arr.Elements[len(arr.Elements)+indexValue]
+					endValue := indexValue + countValue
+					// the case the addition of index and count is too large
+					if endValue > arr.length() {
+						endValue = arr.length()
 					}
 
-					// Expand the array
-					if len(arr.Elements) < (indexValue + 1) {
-						newArr := make([]Object, indexValue+1)
-						copy(newArr, arr.Elements)
-						for i := len(arr.Elements); i <= indexValue; i++ {
-							newArr[i] = NULL
-						}
-						arr.Elements = newArr
+					arr.Elements = append(arr.Elements[:indexValue], arr.Elements[endValue:]...)
+
+					// If assigned value is an array, then splat the array and push each element to the receiver
+					// following the first and second indices
+					if isArray {
+						arr.Elements = append(arr.Elements[:indexValue], append(assignedValue.Elements, arr.Elements[indexValue:]...)...)
+					} else {
+						arr.Elements = append(arr.Elements[:indexValue], append([]Object{a}, arr.Elements[indexValue:]...)...)
 					}
 
-					arr.Elements[indexValue] = args[1]
-
-					return arr.Elements[indexValue]
+					return a
 				}
+
+				// <Two Argument Case>
+				// Second argument is the assignment value (object)
+
+				// Negative index value condition
+				if indexValue < 0 {
+					if len(arr.Elements) < -indexValue {
+						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Index value %d too small for array. minimum: %d", indexValue, -arr.length())
+					}
+					arr.Elements[len(arr.Elements)+indexValue] = args[1]
+					return arr.Elements[len(arr.Elements)+indexValue]
+				}
+
+				// Expand the array
+				if len(arr.Elements) < (indexValue + 1) {
+					newArr := make([]Object, indexValue+1)
+					copy(newArr, arr.Elements)
+					for i := len(arr.Elements); i <= indexValue; i++ {
+						newArr[i] = NULL
+					}
+					arr.Elements = newArr
+				}
+
+				arr.Elements[indexValue] = args[1]
+
+				return arr.Elements[indexValue]
+
 			},
 		},
 		{
@@ -368,32 +360,31 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param block [Block]
 			// @return [Boolean]
 			Name: "any?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					arr := receiver.(*ArrayObject)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				arr := receiver.(*ArrayObject)
 
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
+				}
 
-					if blockIsEmpty(blockFrame) {
-						return FALSE
-					}
-
-					if len(arr.Elements) == 0 {
-						t.callFrameStack.pop()
-					}
-
-					for _, obj := range arr.Elements {
-						result := t.builtinMethodYield(blockFrame, obj)
-
-						if result.Target.isTruthy() {
-							return TRUE
-						}
-					}
-
+				if blockIsEmpty(blockFrame) {
 					return FALSE
 				}
+
+				if len(arr.Elements) == 0 {
+					t.callFrameStack.pop()
+				}
+
+				for _, obj := range arr.Elements {
+					result := t.builtinMethodYield(blockFrame, obj)
+
+					if result.Target.isTruthy() {
+						return TRUE
+					}
+				}
+
+				return FALSE
+
 			},
 		},
 		{
@@ -411,14 +402,13 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param index [Integer]
 			// @return [Object]
 			Name: "at",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 arguments. got=%d", len(args))
-					}
-					arr := receiver.(*ArrayObject)
-					return arr.index(t, args, sourceLine)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 arguments. got=%d", len(args))
 				}
+				arr := receiver.(*ArrayObject)
+				return arr.index(t, args, sourceLine)
+
 			},
 		},
 		{
@@ -432,17 +422,16 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "clear",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
-
-					arr := receiver.(*ArrayObject)
-					arr.Elements = []Object{}
-
-					return arr
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 				}
+
+				arr := receiver.(*ArrayObject)
+				arr.Elements = []Object{}
+
+				return arr
+
 			},
 		},
 		{
@@ -457,24 +446,23 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param array [Array]
 			// @return [Array]
 			Name: "concat",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					arr := receiver.(*ArrayObject)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				arr := receiver.(*ArrayObject)
 
-					for _, arg := range args {
-						addAr, ok := arg.(*ArrayObject)
+				for _, arg := range args {
+					addAr, ok := arg.(*ArrayObject)
 
-						if !ok {
-							return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.ArrayClass, arg.Class().Name)
-						}
-
-						for _, el := range addAr.Elements {
-							arr.Elements = append(arr.Elements, el)
-						}
+					if !ok {
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.ArrayClass, arg.Class().Name)
 					}
 
-					return arr
+					for _, el := range addAr.Elements {
+						arr.Elements = append(arr.Elements, el)
+					}
 				}
+
+				return arr
+
 			},
 		},
 		{
@@ -495,65 +483,64 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param block [Block]
 			// @return [Integer]
 			Name: "count",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					arr := receiver.(*ArrayObject)
-					var count int
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				arr := receiver.(*ArrayObject)
+				var count int
 
-					if len(args) > 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument, got=%d", len(args))
+				if len(args) > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument, got=%d", len(args))
+				}
+
+				if blockFrame != nil {
+					if blockIsEmpty(blockFrame) {
+						return t.vm.InitIntegerObject(0)
+					}
+					if len(arr.Elements) == 0 {
+						t.callFrameStack.pop()
 					}
 
-					if blockFrame != nil {
-						if blockIsEmpty(blockFrame) {
-							return t.vm.InitIntegerObject(0)
-						}
-						if len(arr.Elements) == 0 {
-							t.callFrameStack.pop()
-						}
-
-						for _, obj := range arr.Elements {
-							result := t.builtinMethodYield(blockFrame, obj)
-							if result.Target.isTruthy() {
-								count++
-							}
-						}
-
-						return t.vm.InitIntegerObject(count)
-					}
-
-					if len(args) == 0 {
-						return t.vm.InitIntegerObject(len(arr.Elements))
-					}
-
-					arg := args[0]
-					findInt, findIsInt := arg.(*IntegerObject)
-					findString, findIsString := arg.(*StringObject)
-					findBoolean, findIsBoolean := arg.(*BooleanObject)
-
-					for i := 0; i < len(arr.Elements); i++ {
-						el := arr.Elements[i]
-						switch el.(type) {
-						case *IntegerObject:
-							elInt := el.(*IntegerObject)
-							if findIsInt && findInt.equal(elInt) {
-								count++
-							}
-						case *StringObject:
-							elString := el.(*StringObject)
-							if findIsString && findString.equal(elString) {
-								count++
-							}
-						case *BooleanObject:
-							elBoolean := el.(*BooleanObject)
-							if findIsBoolean && findBoolean.equal(elBoolean) {
-								count++
-							}
+					for _, obj := range arr.Elements {
+						result := t.builtinMethodYield(blockFrame, obj)
+						if result.Target.isTruthy() {
+							count++
 						}
 					}
 
 					return t.vm.InitIntegerObject(count)
 				}
+
+				if len(args) == 0 {
+					return t.vm.InitIntegerObject(len(arr.Elements))
+				}
+
+				arg := args[0]
+				findInt, findIsInt := arg.(*IntegerObject)
+				findString, findIsString := arg.(*StringObject)
+				findBoolean, findIsBoolean := arg.(*BooleanObject)
+
+				for i := 0; i < len(arr.Elements); i++ {
+					el := arr.Elements[i]
+					switch el.(type) {
+					case *IntegerObject:
+						elInt := el.(*IntegerObject)
+						if findIsInt && findInt.equal(elInt) {
+							count++
+						}
+					case *StringObject:
+						elString := el.(*StringObject)
+						if findIsString && findString.equal(elString) {
+							count++
+						}
+					case *BooleanObject:
+						elBoolean := el.(*BooleanObject)
+						if findIsBoolean && findBoolean.equal(elBoolean) {
+							count++
+						}
+					}
+				}
+
+				return t.vm.InitIntegerObject(count)
+
 			},
 		},
 		{
@@ -572,34 +559,33 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param index [Integer]
 			// @return [Object]
 			Name: "delete_at",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
-					}
-
-					i := args[0]
-					index, ok := i.(*IntegerObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-					}
-
-					arr := receiver.(*ArrayObject)
-					normalizedIndex := arr.normalizeIndex(index)
-
-					if normalizedIndex == -1 {
-						return NULL
-					}
-
-					// delete and slice
-
-					deletedValue := arr.Elements[normalizedIndex]
-
-					arr.Elements = append(arr.Elements[:normalizedIndex], arr.Elements[normalizedIndex+1:]...)
-
-					return deletedValue
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
 				}
+
+				i := args[0]
+				index, ok := i.(*IntegerObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+				}
+
+				arr := receiver.(*ArrayObject)
+				normalizedIndex := arr.normalizeIndex(index)
+
+				if normalizedIndex == -1 {
+					return NULL
+				}
+
+				// delete and slice
+
+				deletedValue := arr.Elements[normalizedIndex]
+
+				arr.Elements = append(arr.Elements[:normalizedIndex], arr.Elements[normalizedIndex+1:]...)
+
+				return deletedValue
+
 			},
 		},
 		{
@@ -617,17 +603,16 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param index [Integer]...
 			// @return [Object]
 			Name: "dig",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) == 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 1+ arguments, got 0")
-					}
-
-					array := receiver.(*ArrayObject)
-					value := array.dig(t, args, sourceLine)
-
-					return value
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) == 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 1+ arguments, got 0")
 				}
+
+				array := receiver.(*ArrayObject)
+				value := array.dig(t, args, sourceLine)
+
+				return value
+
 			},
 		},
 		{
@@ -651,31 +636,30 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param block literal
 			// @return [Array]
 			Name: "each",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
+				}
 
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
+				}
 
-					arr := receiver.(*ArrayObject)
-					if blockIsEmpty(blockFrame) {
-						return arr
-					}
-
-					// If it's an empty array, pop the block's call frame
-					if len(arr.Elements) == 0 {
-						t.callFrameStack.pop()
-					}
-
-					for _, obj := range arr.Elements {
-						t.builtinMethodYield(blockFrame, obj)
-					}
+				arr := receiver.(*ArrayObject)
+				if blockIsEmpty(blockFrame) {
 					return arr
 				}
+
+				// If it's an empty array, pop the block's call frame
+				if len(arr.Elements) == 0 {
+					t.callFrameStack.pop()
+				}
+
+				for _, obj := range arr.Elements {
+					t.builtinMethodYield(blockFrame, obj)
+				}
+				return arr
+
 			},
 		},
 		// Works like #each, but passes the index of the element instead of the element itself.
@@ -700,31 +684,30 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 		// @return [Array]
 		{
 			Name: "each_index",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
+				}
 
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
+				}
 
-					arr := receiver.(*ArrayObject)
-					if blockIsEmpty(blockFrame) {
-						return arr
-					}
-
-					// If it's an empty array, pop the block's call frame
-					if len(arr.Elements) == 0 {
-						t.callFrameStack.pop()
-					}
-
-					for i := range arr.Elements {
-						t.builtinMethodYield(blockFrame, t.vm.InitIntegerObject(i))
-					}
+				arr := receiver.(*ArrayObject)
+				if blockIsEmpty(blockFrame) {
 					return arr
 				}
+
+				// If it's an empty array, pop the block's call frame
+				if len(arr.Elements) == 0 {
+					t.callFrameStack.pop()
+				}
+
+				for i := range arr.Elements {
+					t.builtinMethodYield(blockFrame, t.vm.InitIntegerObject(i))
+				}
+				return arr
+
 			},
 		},
 		{
@@ -739,21 +722,20 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "empty?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
-
-					arr := receiver.(*ArrayObject)
-
-					if arr.length() == 0 {
-						return TRUE
-					}
-
-					return FALSE
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 				}
+
+				arr := receiver.(*ArrayObject)
+
+				if arr.length() == 0 {
+					return TRUE
+				}
+
+				return FALSE
+
 			},
 		},
 		{
@@ -769,38 +751,37 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param count [Integer]
 			// @return [Object]
 			Name: "first",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) > 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0..1 argument. got=%d", len(args))
-					}
-
-					arr := receiver.(*ArrayObject)
-					arrLength := len(arr.Elements)
-
-					if arrLength == 0 {
-						return NULL
-					}
-
-					if len(args) == 0 {
-						return arr.Elements[0]
-					}
-
-					arg, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-					}
-
-					if arg.value < 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument to be positive value. got=%d", arg.value)
-					}
-
-					if arrLength > arg.value {
-						return t.vm.InitArrayObject(arr.Elements[:arg.value])
-					}
-					return arr
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0..1 argument. got=%d", len(args))
 				}
+
+				arr := receiver.(*ArrayObject)
+				arrLength := len(arr.Elements)
+
+				if arrLength == 0 {
+					return NULL
+				}
+
+				if len(args) == 0 {
+					return arr.Elements[0]
+				}
+
+				arg, ok := args[0].(*IntegerObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+				}
+
+				if arg.value < 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument to be positive value. got=%d", arg.value)
+				}
+
+				if arrLength > arg.value {
+					return t.vm.InitArrayObject(arr.Elements[:arg.value])
+				}
+				return arr
+
 			},
 		},
 		{
@@ -818,18 +799,17 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "flatten",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					arr := receiver.(*ArrayObject)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				arr := receiver.(*ArrayObject)
 
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
-
-					newElements := arr.flatten()
-
-					return t.vm.InitArrayObject(newElements)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 				}
+
+				newElements := arr.flatten()
+
+				return t.vm.InitArrayObject(newElements)
+
 			},
 		},
 		{
@@ -847,32 +827,31 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param separator [String]
 			// @return [String]
 			Name: "join",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					arr := receiver.(*ArrayObject)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				arr := receiver.(*ArrayObject)
 
-					var sep string
-					if len(args) == 0 {
-						sep = ""
-					} else if len(args) == 1 {
-						arg, ok := args[0].(*StringObject)
+				var sep string
+				if len(args) == 0 {
+					sep = ""
+				} else if len(args) == 1 {
+					arg, ok := args[0].(*StringObject)
 
-						if !ok {
-							return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
-						}
-
-						sep = arg.value
-					} else {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 or 1 argument. got=%d", len(args))
+					if !ok {
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
 
-					elements := []string{}
-					for _, e := range arr.flatten() {
-						elements = append(elements, e.toString())
-					}
-
-					return t.vm.InitStringObject(strings.Join(elements, sep))
+					sep = arg.value
+				} else {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 or 1 argument. got=%d", len(args))
 				}
+
+				elements := []string{}
+				for _, e := range arr.flatten() {
+					elements = append(elements, e.toString())
+				}
+
+				return t.vm.InitStringObject(strings.Join(elements, sep))
+
 			},
 		},
 		{
@@ -888,34 +867,33 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param count [Integer]
 			// @return [Object]
 			Name: "last",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) > 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0..1 argument. got=%d", len(args))
-					}
-
-					arr := receiver.(*ArrayObject)
-					arrLength := len(arr.Elements)
-
-					if len(args) == 0 {
-						return arr.Elements[arrLength-1]
-					}
-
-					arg, ok := args[0].(*IntegerObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-					}
-
-					if arg.value < 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument to be positive value. got=%d", arg.value)
-					}
-
-					if arrLength > arg.value {
-						return t.vm.InitArrayObject(arr.Elements[arrLength-arg.value : arrLength])
-					}
-					return arr
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0..1 argument. got=%d", len(args))
 				}
+
+				arr := receiver.(*ArrayObject)
+				arrLength := len(arr.Elements)
+
+				if len(args) == 0 {
+					return arr.Elements[arrLength-1]
+				}
+
+				arg, ok := args[0].(*IntegerObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+				}
+
+				if arg.value < 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument to be positive value. got=%d", arg.value)
+				}
+
+				if arrLength > arg.value {
+					return t.vm.InitArrayObject(arr.Elements[arrLength-arg.value : arrLength])
+				}
+				return arr
+
 			},
 		},
 		{
@@ -928,16 +906,15 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "length",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
-
-					arr := receiver.(*ArrayObject)
-					return t.vm.InitIntegerObject(arr.length())
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 				}
+
+				arr := receiver.(*ArrayObject)
+				return t.vm.InitIntegerObject(arr.length())
+
 			},
 		},
 		{
@@ -964,33 +941,32 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param block literal
 			// @return [Array]
 			Name: "map",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					arr := receiver.(*ArrayObject)
-					var elements = make([]Object, len(arr.Elements))
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				arr := receiver.(*ArrayObject)
+				var elements = make([]Object, len(arr.Elements))
 
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
-
-					// If it's an empty array, pop the block's call frame
-					if len(arr.Elements) == 0 {
-						t.callFrameStack.pop()
-					}
-
-					if blockIsEmpty(blockFrame) {
-						for i := 0; i < len(arr.Elements); i++ {
-							elements[i] = NULL
-						}
-					} else {
-						for i, obj := range arr.Elements {
-							result := t.builtinMethodYield(blockFrame, obj)
-							elements[i] = result.Target
-						}
-					}
-
-					return t.vm.InitArrayObject(elements)
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
+
+				// If it's an empty array, pop the block's call frame
+				if len(arr.Elements) == 0 {
+					t.callFrameStack.pop()
+				}
+
+				if blockIsEmpty(blockFrame) {
+					for i := 0; i < len(arr.Elements); i++ {
+						elements[i] = NULL
+					}
+				} else {
+					for i, obj := range arr.Elements {
+						result := t.builtinMethodYield(blockFrame, obj)
+						elements[i] = result.Target
+					}
+				}
+
+				return t.vm.InitArrayObject(elements)
+
 			},
 		},
 		{
@@ -1005,16 +981,15 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Object]
 			Name: "pop",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
-
-					arr := receiver.(*ArrayObject)
-					return arr.pop()
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 				}
+
+				arr := receiver.(*ArrayObject)
+				return arr.pop()
+
 			},
 		},
 		{
@@ -1037,12 +1012,11 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param object [Object]...
 			// @return [Array]
 			Name: "push",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					arr := receiver.(*ArrayObject)
-					return arr.push(args)
-				}
+				arr := receiver.(*ArrayObject)
+				return arr.push(args)
+
 			},
 		},
 		{
@@ -1077,41 +1051,40 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param initial value [Object], block literal with two block parameters
 			// @return [Object]
 			Name: "reduce",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					arr := receiver.(*ArrayObject)
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
-
-					// If it's an empty array, pop the block's call frame
-					if len(arr.Elements) == 0 {
-						t.callFrameStack.pop()
-					}
-
-					if blockIsEmpty(blockFrame) {
-						return NULL
-					}
-
-					var prev Object
-					var start int
-					if len(args) == 0 {
-						prev = arr.Elements[0]
-						start = 1
-					} else if len(args) == 1 {
-						prev = args[0]
-						start = 0
-					} else {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 or 1 argument. got=%d", len(args))
-					}
-
-					for i := start; i < len(arr.Elements); i++ {
-						result := t.builtinMethodYield(blockFrame, prev, arr.Elements[i])
-						prev = result.Target
-					}
-
-					return prev
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				arr := receiver.(*ArrayObject)
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
+
+				// If it's an empty array, pop the block's call frame
+				if len(arr.Elements) == 0 {
+					t.callFrameStack.pop()
+				}
+
+				if blockIsEmpty(blockFrame) {
+					return NULL
+				}
+
+				var prev Object
+				var start int
+				if len(args) == 0 {
+					prev = arr.Elements[0]
+					start = 1
+				} else if len(args) == 1 {
+					prev = args[0]
+					start = 0
+				} else {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 or 1 argument. got=%d", len(args))
+				}
+
+				for i := start; i < len(arr.Elements); i++ {
+					result := t.builtinMethodYield(blockFrame, prev, arr.Elements[i])
+					prev = result.Target
+				}
+
+				return prev
+
 			},
 		},
 		{
@@ -1125,16 +1098,15 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "reverse",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
-
-					arr := receiver.(*ArrayObject)
-
-					return arr.reverse()
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 				}
+
+				arr := receiver.(*ArrayObject)
+
+				return arr.reverse()
+
 			},
 		},
 		{
@@ -1156,34 +1128,33 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param block literal
 			// @return [Array]
 			Name: "reverse_each",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
-
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
-
-					arr := receiver.(*ArrayObject)
-					if blockIsEmpty(blockFrame) {
-						return arr
-					}
-
-					// If it's an empty array, pop the block's call frame
-					if len(arr.Elements) == 0 {
-						t.callFrameStack.pop()
-					}
-
-					reversedArr := arr.reverse()
-
-					for _, obj := range reversedArr.Elements {
-						t.builtinMethodYield(blockFrame, obj)
-					}
-
-					return reversedArr
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 				}
+
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
+				}
+
+				arr := receiver.(*ArrayObject)
+				if blockIsEmpty(blockFrame) {
+					return arr
+				}
+
+				// If it's an empty array, pop the block's call frame
+				if len(arr.Elements) == 0 {
+					t.callFrameStack.pop()
+				}
+
+				reversedArr := arr.reverse()
+
+				for _, obj := range reversedArr.Elements {
+					t.builtinMethodYield(blockFrame, obj)
+				}
+
+				return reversedArr
+
 			},
 		},
 		{
@@ -1211,39 +1182,38 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param index [Integer]
 			// @return [Array]
 			Name: "rotate",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) > 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0..1 argument. got=%d", len(args))
-					}
-					var rotate int
-					arr := receiver.(*ArrayObject)
-					rotArr := t.vm.InitArrayObject(arr.Elements)
-
-					if len(args) == 0 {
-						rotate = 1
-					} else {
-						arg, ok := args[0].(*IntegerObject)
-						if !ok {
-							return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						}
-						rotate = arg.value
-					}
-
-					if rotate < 0 {
-						for i := 0; i > rotate; i-- {
-							el := rotArr.pop()
-							rotArr.unshift([]Object{el})
-						}
-					} else {
-						for i := 0; i < rotate; i++ {
-							el := rotArr.shift()
-							rotArr.push([]Object{el})
-						}
-					}
-
-					return rotArr
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0..1 argument. got=%d", len(args))
 				}
+				var rotate int
+				arr := receiver.(*ArrayObject)
+				rotArr := t.vm.InitArrayObject(arr.Elements)
+
+				if len(args) == 0 {
+					rotate = 1
+				} else {
+					arg, ok := args[0].(*IntegerObject)
+					if !ok {
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
+					}
+					rotate = arg.value
+				}
+
+				if rotate < 0 {
+					for i := 0; i > rotate; i-- {
+						el := rotArr.pop()
+						rotArr.unshift([]Object{el})
+					}
+				} else {
+					for i := 0; i < rotate; i++ {
+						el := rotArr.shift()
+						rotArr.push([]Object{el})
+					}
+				}
+
+				return rotArr
+
 			},
 		},
 		{
@@ -1263,37 +1233,36 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param conditional block literal
 			// @return [Array]
 			Name: "select",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) > 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) > 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
+				}
 
-					arr := receiver.(*ArrayObject)
-					var elements []Object
+				arr := receiver.(*ArrayObject)
+				var elements []Object
 
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
+				}
 
-					if blockIsEmpty(blockFrame) {
-						return t.vm.InitArrayObject(elements)
-					}
-
-					// If it's an empty array, pop the block's call frame
-					if len(arr.Elements) == 0 {
-						t.callFrameStack.pop()
-					}
-
-					for _, obj := range arr.Elements {
-						result := t.builtinMethodYield(blockFrame, obj)
-						if result.Target.isTruthy() {
-							elements = append(elements, obj)
-						}
-					}
-
+				if blockIsEmpty(blockFrame) {
 					return t.vm.InitArrayObject(elements)
 				}
+
+				// If it's an empty array, pop the block's call frame
+				if len(arr.Elements) == 0 {
+					t.callFrameStack.pop()
+				}
+
+				for _, obj := range arr.Elements {
+					result := t.builtinMethodYield(blockFrame, obj)
+					if result.Target.isTruthy() {
+						elements = append(elements, obj)
+					}
+				}
+
+				return t.vm.InitArrayObject(elements)
+
 			},
 		},
 		{
@@ -1308,15 +1277,14 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Object]
 			Name: "shift",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
-
-					arr := receiver.(*ArrayObject)
-					return arr.shift()
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 				}
+
+				arr := receiver.(*ArrayObject)
+				return arr.shift()
+
 			},
 		},
 		{
@@ -1334,11 +1302,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param element [Object]
 			// @return [Array]
 			Name: "unshift",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					arr := receiver.(*ArrayObject)
-					return arr.unshift(args)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				arr := receiver.(*ArrayObject)
+				return arr.unshift(args)
+
 			},
 		},
 		{
@@ -1356,31 +1323,30 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @param index [Integer]...
 			// @return [Array]
 			Name: "values_at",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					arr := receiver.(*ArrayObject)
-					var elements = make([]Object, len(args))
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				arr := receiver.(*ArrayObject)
+				var elements = make([]Object, len(args))
 
-					for i, arg := range args {
-						index, ok := arg.(*IntegerObject)
+				for i, arg := range args {
+					index, ok := arg.(*IntegerObject)
 
-						if !ok {
-							return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, arg.Class().Name)
-						}
-
-						if index.value >= len(arr.Elements) {
-							elements[i] = NULL
-						} else if index.value < 0 && -index.value > len(arr.Elements) {
-							elements[i] = NULL
-						} else if index.value < 0 {
-							elements[i] = arr.Elements[len(arr.Elements)+index.value]
-						} else {
-							elements[i] = arr.Elements[index.value]
-						}
+					if !ok {
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, arg.Class().Name)
 					}
 
-					return t.vm.InitArrayObject(elements)
+					if index.value >= len(arr.Elements) {
+						elements[i] = NULL
+					} else if index.value < 0 && -index.value > len(arr.Elements) {
+						elements[i] = NULL
+					} else if index.value < 0 {
+						elements[i] = arr.Elements[len(arr.Elements)+index.value]
+					} else {
+						elements[i] = arr.Elements[index.value]
+					}
 				}
+
+				return t.vm.InitArrayObject(elements)
+
 			},
 		},
 	}

--- a/vm/block.go
+++ b/vm/block.go
@@ -59,14 +59,12 @@ func builtinBlockClassMethods() []*BuiltinMethodObject {
 			// @param block literal
 			// @return [Block]
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Can't initialize block object without block argument")
-					}
-
-					return t.vm.initBlockObject(blockFrame.instructionSet, blockFrame.ep, blockFrame.self)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Can't initialize block object without block argument")
 				}
+
+				return t.vm.initBlockObject(blockFrame.instructionSet, blockFrame.ep, blockFrame.self)
 			},
 		},
 	}
@@ -113,16 +111,14 @@ func builtinBlockInstanceMethods() []*BuiltinMethodObject {
 			// @param object [Object]...
 			// @return [Object]
 			Name: "call",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					block := receiver.(*BlockObject)
-					c := newNormalCallFrame(block.instructionSet, block.instructionSet.filename, sourceLine)
-					c.ep = block.ep
-					c.self = block.self
-					c.isBlock = true
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				block := receiver.(*BlockObject)
+				c := newNormalCallFrame(block.instructionSet, block.instructionSet.filename, sourceLine)
+				c.ep = block.ep
+				c.self = block.self
+				c.isBlock = true
 
-					return t.builtinMethodYield(c, args...).Target
-				}
+				return t.builtinMethodYield(c, args...).Target
 			},
 		},
 	}

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -30,10 +30,8 @@ func builtinBooleanClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
 			},
 		},
 	}

--- a/vm/call_frame.go
+++ b/vm/call_frame.go
@@ -144,8 +144,11 @@ func (b *baseFrame) insertLCL(index, depth int, value Object) {
 
 	b.Lock()
 
-	b.locals = append(b.locals, nil)
-	copy(b.locals[index:], b.locals[index:])
+	if index >= len(b.locals) {
+		b.locals = append(b.locals, nil)
+		copy(b.locals[index:], b.locals[index:])
+	}
+
 	b.locals[index] = &Pointer{Target: value}
 
 	if index >= b.lPr {

--- a/vm/call_frame.go
+++ b/vm/call_frame.go
@@ -261,9 +261,9 @@ func (cfs *callFrameStack) top() callFrame {
 }
 
 func newNormalCallFrame(is *instructionSet, filename string, sourceLine int) *normalCallFrame {
-	return &normalCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 15), lPr: 0, fileName: filename, sourceLine: sourceLine}, instructionSet: is, pc: 0}
+	return &normalCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 5), lPr: 0, fileName: filename, sourceLine: sourceLine}, instructionSet: is, pc: 0}
 }
 
 func newGoMethodCallFrame(m builtinMethodBody, receiver Object, n, filename string, sourceLine int) *goMethodCallFrame {
-	return &goMethodCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 15), lPr: 0, fileName: filename, sourceLine: sourceLine}, method: m, name: n, receiver: receiver}
+	return &goMethodCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 5), lPr: 0, fileName: filename, sourceLine: sourceLine}, method: m, name: n, receiver: receiver}
 }

--- a/vm/call_frame.go
+++ b/vm/call_frame.go
@@ -52,8 +52,9 @@ type callFrame interface {
 
 type goMethodCallFrame struct {
 	*baseFrame
-	method builtinMethodBody
-	name   string
+	method   builtinMethodBody
+	receiver Object
+	name     string
 }
 
 func (cf *goMethodCallFrame) stopExecution() {}
@@ -263,6 +264,6 @@ func newNormalCallFrame(is *instructionSet, filename string, sourceLine int) *no
 	return &normalCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 15), lPr: 0, fileName: filename, sourceLine: sourceLine}, instructionSet: is, pc: 0}
 }
 
-func newGoMethodCallFrame(m builtinMethodBody, n, filename string, sourceLine int) *goMethodCallFrame {
-	return &goMethodCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 15), lPr: 0, fileName: filename, sourceLine: sourceLine}, method: m, name: n}
+func newGoMethodCallFrame(m builtinMethodBody, receiver Object, n, filename string, sourceLine int) *goMethodCallFrame {
+	return &goMethodCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 15), lPr: 0, fileName: filename, sourceLine: sourceLine}, method: m, name: n, receiver: receiver}
 }

--- a/vm/call_frame.go
+++ b/vm/call_frame.go
@@ -269,6 +269,19 @@ func newNormalCallFrame(is *instructionSet, filename string, sourceLine int) *no
 	return &normalCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 5), lPr: 0, fileName: filename, sourceLine: sourceLine}, instructionSet: is, pc: 0}
 }
 
-func newGoMethodCallFrame(m builtinMethodBody, receiver Object, n, filename string, sourceLine int) *goMethodCallFrame {
-	return &goMethodCallFrame{baseFrame: &baseFrame{locals: make([]*Pointer, 5), lPr: 0, fileName: filename, sourceLine: sourceLine}, method: m, name: n, receiver: receiver}
+func newGoMethodCallFrame(m builtinMethodBody, receiver Object, argCount, argPtr int, n, filename string, sourceLine int, blockFrame *normalCallFrame) *goMethodCallFrame {
+	return &goMethodCallFrame{
+		baseFrame: &baseFrame{
+			locals:     make([]*Pointer, 5),
+			lPr:        0,
+			fileName:   filename,
+			sourceLine: sourceLine,
+			blockFrame: blockFrame,
+		},
+		method:   m,
+		name:     n,
+		receiver: receiver,
+		argCount: argCount,
+		argPtr: argPtr,
+	}
 }

--- a/vm/call_frame.go
+++ b/vm/call_frame.go
@@ -53,6 +53,8 @@ type callFrame interface {
 type goMethodCallFrame struct {
 	*baseFrame
 	method   builtinMethodBody
+	argPtr   int
+	argCount int
 	receiver Object
 	name     string
 }

--- a/vm/call_object.go
+++ b/vm/call_object.go
@@ -13,6 +13,7 @@ type callObject struct {
 	argIndex     int
 	lastArgIndex int
 	callFrame    *normalCallFrame
+	sourceLine   int
 }
 
 func newCallObject(receiver Object, method *MethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame, sourceLine int) *callObject {
@@ -28,6 +29,7 @@ func newCallObject(receiver Object, method *MethodObject, receiverPtr, argCount 
 		// This is only for normal/optioned arguments
 		lastArgIndex: -1,
 		callFrame:    cf,
+		sourceLine:   sourceLine,
 	}
 }
 

--- a/vm/class.go
+++ b/vm/class.go
@@ -46,7 +46,7 @@ func RegisterExternalClass(path string, c ...ClassLoader) {
 // ClassLoader can be registerd with a vm so that it can load this library at vm creation
 type ClassLoader = func(*VM) error
 
-func buildMethods(m map[string]MethodBuilder) []*BuiltinMethodObject {
+func buildMethods(m map[string]Method) []*BuiltinMethodObject {
 	out := make([]*BuiltinMethodObject, len(m))
 	var i int
 	for k, v := range m {
@@ -57,7 +57,7 @@ func buildMethods(m map[string]MethodBuilder) []*BuiltinMethodObject {
 }
 
 // ExternalClass helps define external go classes
-func ExternalClass(name, path string, classMethods, instanceMethods map[string]MethodBuilder) ClassLoader {
+func ExternalClass(name, path string, classMethods, instanceMethods map[string]Method) ClassLoader {
 	return func(v *VM) error {
 		pg := v.initializeClass(name)
 		pg.setBuiltinMethods(buildMethods(classMethods), true)

--- a/vm/class.go
+++ b/vm/class.go
@@ -90,23 +90,21 @@ func builtinClassCommonClassMethods() []*BuiltinMethodObject {
 			// @param class [Class] Receiver
 			// @return [Object] Created object
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					class, ok := receiver.(*RClass)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				class, ok := receiver.(*RClass)
 
-					if !ok {
-						return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
-					}
-
-					instance := class.initializeInstance()
-					initMethod := class.lookupMethod("initialize")
-
-					if initMethod != nil {
-						instance.InitializeMethod = initMethod.(*MethodObject)
-					}
-
-					return instance
+				if !ok {
+					return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
 				}
+
+				instance := class.initializeInstance()
+				initMethod := class.lookupMethod("initialize")
+
+				if initMethod != nil {
+					instance.InitializeMethod = initMethod.(*MethodObject)
+				}
+
+				return instance
 			},
 		},
 	}
@@ -149,21 +147,19 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @param class [Class] Receiver
 			// @return [Array]
 			Name: "ancestors",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					c, ok := receiver.(*RClass)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				c, ok := receiver.(*RClass)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#ancestors", receiver.toString())
-					}
-
-					a := c.ancestors()
-					ancestors := make([]Object, len(a))
-					for i := range a {
-						ancestors[i] = a[i]
-					}
-					return t.vm.InitArrayObject(ancestors)
+				if !ok {
+					return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#ancestors", receiver.toString())
 				}
+
+				a := c.ancestors()
+				ancestors := make([]Object, len(a))
+				for i := range a {
+					ancestors[i] = a[i]
+				}
+				return t.vm.InitArrayObject(ancestors)
 			},
 		},
 		{
@@ -178,33 +174,31 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @param module [Class]
 			// @return [Boolean, Null]
 			Name: ">",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					c, ok := receiver.(*RClass)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				c, ok := receiver.(*RClass)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#<", receiver.toString())
-					}
-
-					module, ok := args[0].(*RClass)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
-					}
-
-					if c == module {
-						return FALSE
-					}
-
-					if module.alreadyInherit(c) {
-						return TRUE
-					}
-
-					if c.alreadyInherit(module) {
-						return FALSE
-					}
-					return NULL
+				if !ok {
+					return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#<", receiver.toString())
 				}
+
+				module, ok := args[0].(*RClass)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
+				}
+
+				if c == module {
+					return FALSE
+				}
+
+				if module.alreadyInherit(c) {
+					return TRUE
+				}
+
+				if c.alreadyInherit(module) {
+					return FALSE
+				}
+				return NULL
 			},
 		},
 		{
@@ -219,33 +213,31 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @param module [Class]
 			// @return [Boolean, Null]
 			Name: ">=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					c, ok := receiver.(*RClass)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				c, ok := receiver.(*RClass)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#<", receiver.toString())
-					}
-
-					module, ok := args[0].(*RClass)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
-					}
-
-					if c == module {
-						return TRUE
-					}
-
-					if module.alreadyInherit(c) {
-						return TRUE
-					}
-
-					if c.alreadyInherit(module) {
-						return FALSE
-					}
-					return NULL
+				if !ok {
+					return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#<", receiver.toString())
 				}
+
+				module, ok := args[0].(*RClass)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
+				}
+
+				if c == module {
+					return TRUE
+				}
+
+				if module.alreadyInherit(c) {
+					return TRUE
+				}
+
+				if c.alreadyInherit(module) {
+					return FALSE
+				}
+				return NULL
 			},
 		},
 		{
@@ -260,33 +252,31 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @param module [Class]
 			// @return [Boolean, Null]
 			Name: "<",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					c, ok := receiver.(*RClass)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				c, ok := receiver.(*RClass)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#<", receiver.toString())
-					}
-
-					module, ok := args[0].(*RClass)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
-					}
-
-					if c == module {
-						return FALSE
-					}
-
-					if module.alreadyInherit(c) {
-						return FALSE
-					}
-
-					if c.alreadyInherit(module) {
-						return TRUE
-					}
-					return NULL
+				if !ok {
+					return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#<", receiver.toString())
 				}
+
+				module, ok := args[0].(*RClass)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
+				}
+
+				if c == module {
+					return FALSE
+				}
+
+				if module.alreadyInherit(c) {
+					return FALSE
+				}
+
+				if c.alreadyInherit(module) {
+					return TRUE
+				}
+				return NULL
 			},
 		},
 		{
@@ -301,33 +291,31 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @param module [Class]
 			// @return [Boolean, Null]
 			Name: "<=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					c, ok := receiver.(*RClass)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				c, ok := receiver.(*RClass)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#<", receiver.toString())
-					}
-
-					module, ok := args[0].(*RClass)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
-					}
-
-					if c == module {
-						return TRUE
-					}
-
-					if module.alreadyInherit(c) {
-						return FALSE
-					}
-
-					if c.alreadyInherit(module) {
-						return TRUE
-					}
-					return NULL
+				if !ok {
+					return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#<", receiver.toString())
 				}
+
+				module, ok := args[0].(*RClass)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
+				}
+
+				if c == module {
+					return TRUE
+				}
+
+				if module.alreadyInherit(c) {
+					return FALSE
+				}
+
+				if c.alreadyInherit(module) {
+					return TRUE
+				}
+				return NULL
 			},
 		},
 		{
@@ -362,13 +350,11 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @param *args [String] One or more quoted method names for 'getter/setter'
 			// @return [Null]
 			Name: "attr_accessor",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*RClass)
-					r.setAttrAccessor(args)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*RClass)
+				r.setAttrAccessor(args)
 
-					return r
-				}
+				return r
 			},
 		},
 		{
@@ -398,13 +384,11 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @param *args [String] One or more quoted method names for 'getter'
 			// @return [Null]
 			Name: "attr_reader",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*RClass)
-					r.setAttrReader(args)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*RClass)
+				r.setAttrReader(args)
 
-					return r
-				}
+				return r
 			},
 		},
 		{
@@ -434,34 +418,31 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @param *args [String] One or more quoted method names for 'setter'
 			// @return [Null]
 			Name: "attr_writer",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*RClass)
-					r.setAttrWriter(args)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*RClass)
+				r.setAttrWriter(args)
 
-					return r
-				}
+				return r
 			},
 		},
 		{
 			Name: "constants",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					var constantNames []string
-					var objs []Object
-					r := receiver.(*RClass)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				var constantNames []string
+				var objs []Object
+				r := receiver.(*RClass)
 
-					for n := range r.constants {
-						constantNames = append(constantNames, n)
-					}
-					sort.Strings(constantNames)
-
-					for _, cn := range constantNames {
-						objs = append(objs, t.vm.InitStringObject(cn))
-					}
-
-					return t.vm.InitArrayObject(objs)
+				for n := range r.constants {
+					constantNames = append(constantNames, n)
 				}
+				sort.Strings(constantNames)
+
+				for _, cn := range constantNames {
+					objs = append(objs, t.vm.InitStringObject(cn))
+				}
+
+				return t.vm.InitArrayObject(objs)
+
 			},
 		},
 		// Inserts a module as a singleton class to make the module's methods class methods.
@@ -493,26 +474,24 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 		// @return [Null]
 		{
 			Name: "extend",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					var class *RClass
-					module, ok := args[0].(*RClass)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				var class *RClass
+				module, ok := args[0].(*RClass)
 
-					if !ok || !module.isModule {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
-					}
+				if !ok || !module.isModule {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
+				}
 
-					class = receiver.SingletonClass()
+				class = receiver.SingletonClass()
 
-					if class.alreadyInherit(module) {
-						return class
-					}
-
-					module.superClass = class.superClass
-					class.superClass = module
-
+				if class.alreadyInherit(module) {
 					return class
 				}
+
+				module.superClass = class.superClass
+				class.superClass = module
+
+				return class
 			},
 		},
 		{
@@ -561,54 +540,50 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @param module [Class] Module name to include
 			// @return [Null]
 			Name: "include",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					var class *RClass
-					module, ok := args[0].(*RClass)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				var class *RClass
+				module, ok := args[0].(*RClass)
 
-					if !ok || !module.isModule {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
-					}
+				if !ok || !module.isModule {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect argument to be a module. got=%v", args[0].Class().Name)
+				}
 
-					switch r := receiver.(type) {
-					case *RClass:
-						class = r
-					default:
-						class = r.SingletonClass()
-					}
+				switch r := receiver.(type) {
+				case *RClass:
+					class = r
+				default:
+					class = r.SingletonClass()
+				}
 
-					if class.alreadyInherit(module) {
-						return class
-					}
-
-					module.superClass = class.superClass
-					class.superClass = module
-
+				if class.alreadyInherit(module) {
 					return class
 				}
+
+				module.superClass = class.superClass
+				class.superClass = module
+
+				return class
 			},
 		},
 		{
 			Name: "inherits_method_missing",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					var class *RClass
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				var class *RClass
 
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
-					}
-
-					switch r := receiver.(type) {
-					case *RClass:
-						class = r
-					default:
-						class = r.SingletonClass()
-					}
-
-					class.inheritsMethodMissing = true
-
-					return class
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
 				}
+
+				switch r := receiver.(type) {
+				case *RClass:
+					class = r
+				default:
+					class = r.SingletonClass()
+				}
+
+				class.inheritsMethodMissing = true
+
+				return class
 			},
 		},
 		{
@@ -622,22 +597,20 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @param class [Class] Receiver
 			// @return [String] Converted receiver name
 			Name: "name",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
-					}
-
-					n, ok := receiver.(*RClass)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#name", receiver.toString())
-					}
-
-					name := n.ReturnName()
-					nameString := t.vm.InitStringObject(name)
-					return nameString
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
 				}
+
+				n, ok := receiver.(*RClass)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#name", receiver.toString())
+				}
+
+				name := n.ReturnName()
+				nameString := t.vm.InitStringObject(name)
+				return nameString
 			},
 		},
 		{
@@ -652,23 +625,21 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @param [String]
 			// @return [Boolean]
 			Name: "respond_to?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
-					}
-
-					arg, ok := args[0].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
-					}
-
-					r := receiver
-					if r.findMethod(arg.value) == nil {
-						return FALSE
-					}
-					return TRUE
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
 				}
+
+				arg, ok := args[0].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
+				}
+
+				r := receiver
+				if r.findMethod(arg.value) == nil {
+					return FALSE
+				}
+				return TRUE
 			},
 		},
 		{
@@ -701,26 +672,24 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @param class [Class] Receiver
 			// @return [Object] Superclass object of the receiver
 			Name: "superclass",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
-					}
-
-					c, ok := receiver.(*RClass)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#superclass", receiver.toString())
-					}
-
-					superClass := c.returnSuperClass()
-
-					if superClass == nil {
-						return NULL
-					}
-
-					return superClass
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
 				}
+
+				c, ok := receiver.(*RClass)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.UndefinedMethodError, sourceLine, "Undefined Method '%s' for %s", "#superclass", receiver.toString())
+				}
+
+				superClass := c.returnSuperClass()
+
+				if superClass == nil {
+					return NULL
+				}
+
+				return superClass
 			},
 		},
 	}
@@ -751,16 +720,14 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [@boolean]
 			Name: "==",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					className := receiver.Class().Name
-					compareClassName := args[0].Class().Name
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				className := receiver.Class().Name
+				compareClassName := args[0].Class().Name
 
-					if className == compareClassName && reflect.DeepEqual(receiver, args[0]) {
-						return TRUE
-					}
-					return FALSE
+				if className == compareClassName && reflect.DeepEqual(receiver, args[0]) {
+					return TRUE
 				}
+				return FALSE
 			},
 		},
 		{
@@ -776,19 +743,18 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param object [Object] object that return boolean value to invert
 			// @return [Object] Inverted boolean value
 			Name: "!",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					rightValue, ok := receiver.(*BooleanObject)
-					if !ok {
-						return FALSE
-					}
-
-					if rightValue.value {
-						return FALSE
-					}
-					return TRUE
+				rightValue, ok := receiver.(*BooleanObject)
+				if !ok {
+					return FALSE
 				}
+
+				if rightValue.value {
+					return FALSE
+				}
+				return TRUE
+
 			},
 		},
 		{
@@ -813,16 +779,14 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "!=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					className := receiver.Class().Name
-					compareClassName := args[0].Class().Name
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				className := receiver.Class().Name
+				compareClassName := args[0].Class().Name
 
-					if className == compareClassName && reflect.DeepEqual(receiver, args[0]) {
-						return FALSE
-					}
-					return TRUE
+				if className == compareClassName && reflect.DeepEqual(receiver, args[0]) {
+					return FALSE
 				}
+				return TRUE
 			},
 		},
 		{
@@ -847,16 +811,15 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param n/a []
 			// @return [Boolean] true/false
 			Name: "block_given?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					cf := t.callFrameStack.callFrames[t.callFrameStack.pointer-2]
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				cf := t.callFrameStack.callFrames[t.callFrameStack.pointer-2]
 
-					if cf.BlockFrame() == nil {
-						return FALSE
-					}
-
-					return TRUE
+				if cf.BlockFrame() == nil {
+					return FALSE
 				}
+
+				return TRUE
+
 			},
 		},
 		{
@@ -874,10 +837,9 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param object [Object] Receiver (required)
 			// @return [Class] The class of the receiver
 			Name: "class",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return receiver.Class()
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return receiver.Class()
+
 			},
 		},
 		// Exits from the interpreter, returning the specified exit code (if any).
@@ -893,25 +855,24 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		// @return nil
 		{
 			Name: "exit",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					switch len(args) {
-					case 0:
-						os.Exit(0)
-					case 1:
-						exitCode, ok := args[0].(*IntegerObject)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				switch len(args) {
+				case 0:
+					os.Exit(0)
+				case 1:
+					exitCode, ok := args[0].(*IntegerObject)
 
-						if !ok {
-							return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
-						}
-
-						os.Exit(exitCode.value)
-					default:
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected at most 1 argument; got: %d", len(args))
+					if !ok {
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
 					}
 
-					return NULL
+					os.Exit(exitCode.value)
+				default:
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected at most 1 argument; got: %d", len(args))
 				}
+
+				return NULL
+
 			},
 		},
 		{
@@ -931,85 +892,81 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param n/a []
 			// @return [Boolean]
 			Name: "is_a?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
-					}
-
-					c := args[0]
-					gobyClass, ok := c.(*RClass)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.ClassClass, c.Class().Name)
-					}
-
-					receiverClass := receiver.Class()
-
-					for {
-						if receiverClass.Name == gobyClass.Name {
-							return TRUE
-						}
-
-						if receiverClass.Name == classes.ObjectClass {
-							break
-						}
-
-						receiverClass = receiverClass.superClass
-					}
-					return FALSE
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
 				}
+
+				c := args[0]
+				gobyClass, ok := c.(*RClass)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.ClassClass, c.Class().Name)
+				}
+
+				receiverClass := receiver.Class()
+
+				for {
+					if receiverClass.Name == gobyClass.Name {
+						return TRUE
+					}
+
+					if receiverClass.Name == classes.ObjectClass {
+						break
+					}
+
+					receiverClass = receiverClass.superClass
+				}
+				return FALSE
 			},
 		},
 		{
 			Name: "inherits_method_missing?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
-					}
-
-					if receiver.Class().inheritsMethodMissing {
-						return TRUE
-					}
-
-					return FALSE
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
 				}
+
+				if receiver.Class().inheritsMethodMissing {
+					return TRUE
+				}
+
+				return FALSE
+
 			},
 		},
 		{
 			Name: "instance_eval",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					switch len(args) {
-					case 0:
-					case 1:
-						if args[0].Class().Name == classes.BlockClass {
-							blockObj := args[0].(*BlockObject)
-							blockFrame = newNormalCallFrame(blockObj.instructionSet, blockObj.instructionSet.filename, sourceLine)
-							blockFrame.ep = blockObj.ep
-							blockFrame.self = receiver
-							blockFrame.isBlock = true
-						} else {
-							return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.BlockClass, args[0].Class().Name)
-						}
-					default:
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect at most 1 arguments. got: %d", len(args))
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				switch len(args) {
+				case 0:
+				case 1:
+					if args[0].Class().Name == classes.BlockClass {
+						blockObj := args[0].(*BlockObject)
+						blockFrame = newNormalCallFrame(blockObj.instructionSet, blockObj.instructionSet.filename, sourceLine)
+						blockFrame.ep = blockObj.ep
+						blockFrame.self = receiver
+						blockFrame.isBlock = true
+					} else {
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.BlockClass, args[0].Class().Name)
 					}
-
-					if blockFrame == nil {
-						return receiver
-					}
-
-					if blockIsEmpty(blockFrame) {
-						return receiver
-					}
-
-					blockFrame.self = receiver
-					result := t.builtinMethodYield(blockFrame)
-
-					return result.Target
+				default:
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect at most 1 arguments. got: %d", len(args))
 				}
+
+				if blockFrame == nil {
+					return receiver
+				}
+
+				if blockIsEmpty(blockFrame) {
+					return receiver
+				}
+
+				blockFrame.self = receiver
+				result := t.builtinMethodYield(blockFrame)
+
+				return result.Target
+
 			},
 		},
 		// Returns the value of the instance variable.
@@ -1030,25 +987,23 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		// @return [Object], value
 		{
 			Name: "instance_variable_get",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 arguments. got: %d", len(args))
-					}
-					arg, isStr := args[0].(*StringObject)
-
-					if !isStr {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
-					}
-
-					obj, ok := receiver.InstanceVariableGet(arg.value)
-
-					if !ok {
-						return NULL
-					}
-
-					return obj
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 arguments. got: %d", len(args))
 				}
+				arg, isStr := args[0].(*StringObject)
+
+				if !isStr {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+				}
+
+				obj, ok := receiver.InstanceVariableGet(arg.value)
+
+				if !ok {
+					return NULL
+				}
+
+				return obj
 			},
 		},
 		{
@@ -1069,23 +1024,22 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param string [String], value [Object]
 			// @return [Object] value
 			Name: "instance_variable_set",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 2 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got: %d", len(args))
-					}
-
-					argName, isStr := args[0].(*StringObject)
-					obj := args[1]
-
-					if !isStr {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
-					}
-
-					receiver.InstanceVariableSet(argName.value, obj)
-
-					return obj
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got: %d", len(args))
 				}
+
+				argName, isStr := args[0].(*StringObject)
+				obj := args[1]
+
+				if !isStr {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+				}
+
+				receiver.InstanceVariableSet(argName.value, obj)
+
+				return obj
+
 			},
 		},
 		// Returns an array that contains the method names of the receiver.
@@ -1099,24 +1053,23 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		// @return [Array]
 		{
 			Name: "methods",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					methods := []Object{}
-					set := map[string]interface{}{}
-					klasses := receiver.Class().ancestors()
-					if receiver.SingletonClass() != nil {
-						klasses = append([]*RClass{receiver.SingletonClass()}, klasses...)
-					}
-					for _, klass := range klasses {
-						for _, name := range klass.Methods.names() {
-							if set[name] == nil {
-								set[name] = true
-								methods = append(methods, t.vm.InitStringObject(name))
-							}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				methods := []Object{}
+				set := map[string]interface{}{}
+				klasses := receiver.Class().ancestors()
+				if receiver.SingletonClass() != nil {
+					klasses = append([]*RClass{receiver.SingletonClass()}, klasses...)
+				}
+				for _, klass := range klasses {
+					for _, name := range klass.Methods.names() {
+						if set[name] == nil {
+							set[name] = true
+							methods = append(methods, t.vm.InitStringObject(name))
 						}
 					}
-					return t.vm.InitArrayObject(methods)
 				}
+				return t.vm.InitArrayObject(methods)
+
 			},
 		},
 		{
@@ -1133,13 +1086,12 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param n/a []
 			// @return [Boolean]
 			Name: "nil?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
-					}
-					return FALSE
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
 				}
+				return FALSE
+
 			},
 		},
 		{
@@ -1147,10 +1099,9 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param n/a []
 			// @return [Integer] Object's address
 			Name: "object_id",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.InitIntegerObject(receiver.id())
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.InitIntegerObject(receiver.id())
+
 			},
 		},
 		{
@@ -1172,37 +1123,35 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param *args [Class] String literals, or other objects that can be converted into String.
 			// @return [Null]
 			Name: "puts",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					for _, arg := range args {
-						fmt.Println(arg.toString())
-					}
-
-					return NULL
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				for _, arg := range args {
+					fmt.Println(arg.toString())
 				}
+
+				return NULL
+
 			},
 		},
 		{
 			Name: "raise",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					switch len(args) {
-					case 0:
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, "")
-					case 1:
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, "'%s'", args[0].toString())
-					case 2:
-						errorClass, ok := args[0].(*RClass)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				switch len(args) {
+				case 0:
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, "")
+				case 1:
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, "'%s'", args[0].toString())
+				case 2:
+					errorClass, ok := args[0].(*RClass)
 
-						if !ok {
-							return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect error class, got: %s", args[0].Class().Name)
-						}
-
-						return t.vm.InitErrorObject(errorClass.Name, sourceLine, "'%s'", args[1].toString())
+					if !ok {
+						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect error class, got: %s", args[0].Class().Name)
 					}
 
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect at most 2 arguments. got: %d", len(args))
+					return t.vm.InitErrorObject(errorClass.Name, sourceLine, "'%s'", args[1].toString())
 				}
+
+				return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect at most 2 arguments. got: %d", len(args))
+
 			},
 		},
 		{
@@ -1218,23 +1167,22 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param [String]
 			// @return [Boolean]
 			Name: "respond_to?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
-					}
-
-					arg, ok := args[0].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
-					}
-
-					r := receiver
-					if r.findMethod(arg.value) == nil {
-						return FALSE
-					}
-					return TRUE
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
 				}
+
+				arg, ok := args[0].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
+				}
+
+				r := receiver
+				if r.findMethod(arg.value) == nil {
+					return FALSE
+				}
+				return TRUE
+
 			},
 		},
 		{
@@ -1251,40 +1199,39 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param filename [String] Quoted file name of the library, without extension
 			// @return [Boolean] Result of loading module
 			Name: "require",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
-					}
-					switch args[0].(type) {
-					case *StringObject:
-						libName := args[0].(*StringObject).value
-						initFunc, ok := standardLibraries[libName]
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				}
+				switch args[0].(type) {
+				case *StringObject:
+					libName := args[0].(*StringObject).value
+					initFunc, ok := standardLibraries[libName]
 
+					if !ok {
+						externalClassLock.Lock()
+						loaders, ok := externalClasses[libName]
+						externalClassLock.Unlock()
 						if !ok {
-							externalClassLock.Lock()
-							loaders, ok := externalClasses[libName]
-							externalClassLock.Unlock()
-							if !ok {
-								err := t.execGobyLib(libName + ".gb")
-								if err != nil {
-									return t.vm.InitErrorObject(errors.InternalError, sourceLine, "Can't require \"%s\"", libName)
-								}
-							}
-							initFunc = func(v *VM) {
-								for _, l := range loaders {
-									l(v)
-								}
+							err := t.execGobyLib(libName + ".gb")
+							if err != nil {
+								return t.vm.InitErrorObject(errors.InternalError, sourceLine, "Can't require \"%s\"", libName)
 							}
 						}
-
-						initFunc(t.vm)
-
-						return TRUE
-					default:
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, "Can't require \"%s\". Pass a string instead", args[0].(Object).Class().Name)
+						initFunc = func(v *VM) {
+							for _, l := range loaders {
+								l(v)
+							}
+						}
 					}
+
+					initFunc(t.vm)
+
+					return TRUE
+				default:
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, "Can't require \"%s\". Pass a string instead", args[0].(Object).Class().Name)
 				}
+
 			},
 		},
 		{
@@ -1300,25 +1247,24 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param path/name [String] Quoted file path to library plus name, without extension
 			// @return [Boolean] Result of loading module
 			Name: "require_relative",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
-					}
-					switch args[0].(type) {
-					case *StringObject:
-						callerDir := path.Dir(t.vm.currentFilePath())
-						filepath := args[0].(*StringObject).value
-						filepath = path.Join(callerDir, filepath)
-						filepath = filepath + ".gb"
-
-						t.execFile(filepath)
-
-						return TRUE
-					default:
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, "Can't require \"%s\". Pass a string instead", args[0].(Object).Class().Name)
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
 				}
+				switch args[0].(type) {
+				case *StringObject:
+					callerDir := path.Dir(t.vm.currentFilePath())
+					filepath := args[0].(*StringObject).value
+					filepath = path.Join(callerDir, filepath)
+					filepath = filepath + ".gb"
+
+					t.execFile(filepath)
+
+					return TRUE
+				default:
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, "Can't require \"%s\". Pass a string instead", args[0].(Object).Class().Name)
+				}
+
 			},
 		},
 		// Invoke the specified instance method or class method.
@@ -1358,22 +1304,21 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		// @return [Object]
 		{
 			Name: "send",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) < 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "no method name given")
-					}
-
-					name, ok := args[0].(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
-					}
-
-					t.sendMethod(name.value, len(args)-1, blockFrame, sourceLine)
-
-					return t.Stack.top().Target
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) < 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "no method name given")
 				}
+
+				name, ok := args[0].(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+				}
+
+				t.sendMethod(name.value, len(args)-1, blockFrame, sourceLine)
+
+				return t.Stack.top().Target
+
 			},
 		},
 		{
@@ -1392,17 +1337,16 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param class [Class] receiver
 			// @return [Object] singleton class
 			Name: "singleton_class",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver
-					if r.SingletonClass() == nil {
-						id := t.vm.InitIntegerObject(r.id())
-						singletonClass := t.vm.createRClass(fmt.Sprintf("#<Class:#<%s:%s>>", r.Class().Name, id.toString()))
-						singletonClass.isSingleton = true
-						return singletonClass
-					}
-					return receiver.SingletonClass()
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver
+				if r.SingletonClass() == nil {
+					id := t.vm.InitIntegerObject(r.id())
+					singletonClass := t.vm.createRClass(fmt.Sprintf("#<Class:#<%s:%s>>", r.Class().Name, id.toString()))
+					singletonClass.isSingleton = true
+					return singletonClass
 				}
+				return receiver.SingletonClass()
+
 			},
 		},
 		{
@@ -1418,52 +1362,50 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param sec [Integer] time to wait in sec
 			// @return [Integer] actual time slept in sec
 			Name: "sleep",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
-					}
-
-					int, ok := args[0].(*IntegerObject)
-
-					if ok {
-						seconds := int.value
-						time.Sleep(time.Duration(seconds) * time.Second)
-						return int
-					}
-
-					float, ok := args[0].(*FloatObject)
-
-					if ok {
-						nanoseconds := int64(float.value * float64(time.Second/time.Nanosecond))
-						time.Sleep(time.Duration(nanoseconds) * time.Nanosecond)
-						return float
-					}
-
-					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
 				}
+
+				int, ok := args[0].(*IntegerObject)
+
+				if ok {
+					seconds := int.value
+					time.Sleep(time.Duration(seconds) * time.Second)
+					return int
+				}
+
+				float, ok := args[0].(*FloatObject)
+
+				if ok {
+					nanoseconds := int64(float.value * float64(time.Second/time.Nanosecond))
+					time.Sleep(time.Duration(nanoseconds) * time.Nanosecond)
+					return float
+				}
+
+				return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
+
 			},
 		},
 		{
 			Name: "thread",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
-
-					newT := t.vm.newThread()
-
-					go func() {
-						newT.builtinMethodYield(blockFrame, args...)
-					}()
-
-					// We need to pop this frame from main thread manually,
-					// because the block's 'leave' instruction is running on other process
-					t.callFrameStack.pop()
-
-					return NULL
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
+
+				newT := t.vm.newThread()
+
+				go func() {
+					newT.builtinMethodYield(blockFrame, args...)
+				}()
+
+				// We need to pop this frame from main thread manually,
+				// because the block's 'leave' instruction is running on other process
+				t.callFrameStack.pop()
+
+				return NULL
+
 			},
 		},
 		{
@@ -1471,10 +1413,9 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @param n/a []
 			// @return [String] Object's string representation.
 			Name: "to_s",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.InitStringObject(receiver.toString())
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.InitStringObject(receiver.toString())
+
 			},
 		},
 	}
@@ -1804,11 +1745,9 @@ func (c *RClass) ancestors() []*RClass {
 func generateAttrWriteMethod(attrName string) *BuiltinMethodObject {
 	return &BuiltinMethodObject{
 		Name: attrName + "=",
-		Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-			return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				v := receiver.InstanceVariableSet("@"+attrName, args[0])
-				return v
-			}
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			v := receiver.InstanceVariableSet("@"+attrName, args[0])
+			return v
 		},
 	}
 }
@@ -1816,16 +1755,14 @@ func generateAttrWriteMethod(attrName string) *BuiltinMethodObject {
 func generateAttrReadMethod(attrName string) *BuiltinMethodObject {
 	return &BuiltinMethodObject{
 		Name: attrName,
-		Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-			return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				v, ok := receiver.InstanceVariableGet("@" + attrName)
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			v, ok := receiver.InstanceVariableGet("@" + attrName)
 
-				if ok {
-					return v
-				}
-
-				return NULL
+			if ok {
+				return v
 			}
+
+			return NULL
 		},
 	}
 }

--- a/vm/concurrent_array.go
+++ b/vm/concurrent_array.go
@@ -69,16 +69,16 @@ func builtinConcurrentArrayClassMethods() []*BuiltinMethodObject {
 
 				if len(args) == 0 {
 					return t.vm.initConcurrentArrayObject([]Object{})
-				} else {
-					arg := args[0]
-					arrayArg, ok := arg.(*ArrayObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.ArrayClass, arg.Class().Name)
-					}
-
-					return t.vm.initConcurrentArrayObject(arrayArg.Elements)
 				}
+
+				arg := args[0]
+				arrayArg, ok := arg.(*ArrayObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.ArrayClass, arg.Class().Name)
+				}
+
+				return t.vm.initConcurrentArrayObject(arrayArg.Elements)
 			},
 		},
 	}

--- a/vm/concurrent_array.go
+++ b/vm/concurrent_array.go
@@ -62,24 +62,22 @@ func builtinConcurrentArrayClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) > 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 or 1 arguments, got %d", len(args))
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 or 1 arguments, got %d", len(args))
+				}
+
+				if len(args) == 0 {
+					return t.vm.initConcurrentArrayObject([]Object{})
+				} else {
+					arg := args[0]
+					arrayArg, ok := arg.(*ArrayObject)
+
+					if !ok {
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.ArrayClass, arg.Class().Name)
 					}
 
-					if len(args) == 0 {
-						return t.vm.initConcurrentArrayObject([]Object{})
-					} else {
-						arg := args[0]
-						arrayArg, ok := arg.(*ArrayObject)
-
-						if !ok {
-							return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.ArrayClass, arg.Class().Name)
-						}
-
-						return t.vm.initConcurrentArrayObject(arrayArg.Elements)
-					}
+					return t.vm.initConcurrentArrayObject(arrayArg.Elements)
 				}
 			},
 		},
@@ -144,31 +142,29 @@ func (cac *ConcurrentArrayObject) Value() interface{} {
 func DefineForwardedConcurrentArrayMethod(methodName string, requireWriteLock bool) *BuiltinMethodObject {
 	return &BuiltinMethodObject{
 		Name: methodName,
-		Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-			return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				concurrentArray := receiver.(*ConcurrentArrayObject)
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			concurrentArray := receiver.(*ConcurrentArrayObject)
 
-				if requireWriteLock {
-					concurrentArray.Lock()
-				} else {
-					concurrentArray.RLock()
-				}
+			if requireWriteLock {
+				concurrentArray.Lock()
+			} else {
+				concurrentArray.RLock()
+			}
 
-				arrayMethodObject := concurrentArray.InternalArray.findMethod(methodName).(*BuiltinMethodObject)
-				result := arrayMethodObject.Fn(concurrentArray.InternalArray, sourceLine)(t, args, blockFrame)
+			arrayMethodObject := concurrentArray.InternalArray.findMethod(methodName).(*BuiltinMethodObject)
+			result := arrayMethodObject.Fn(concurrentArray.InternalArray, sourceLine, t, args, blockFrame)
 
-				if requireWriteLock {
-					concurrentArray.Unlock()
-				} else {
-					concurrentArray.RUnlock()
-				}
+			if requireWriteLock {
+				concurrentArray.Unlock()
+			} else {
+				concurrentArray.RUnlock()
+			}
 
-				switch result.(type) {
-				case *ArrayObject:
-					return t.vm.initConcurrentArrayObject(result.(*ArrayObject).Elements)
-				default:
-					return result
-				}
+			switch result.(type) {
+			case *ArrayObject:
+				return t.vm.initConcurrentArrayObject(result.(*ArrayObject).Elements)
+			default:
+				return result
 			}
 		},
 	}

--- a/vm/concurrent_hash.go
+++ b/vm/concurrent_hash.go
@@ -37,25 +37,24 @@ func builtinConcurrentHashClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) > 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 or 1 arguments, got %d", len(args))
-					}
-
-					if len(args) == 0 {
-						return t.vm.initConcurrentHashObject(make(map[string]Object))
-					}
-
-					arg := args[0]
-					hashArg, ok := arg.(*HashObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.HashClass, arg.Class().Name)
-					}
-
-					return t.vm.initConcurrentHashObject(hashArg.Pairs)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 or 1 arguments, got %d", len(args))
 				}
+
+				if len(args) == 0 {
+					return t.vm.initConcurrentHashObject(make(map[string]Object))
+				}
+
+				arg := args[0]
+				hashArg, ok := arg.(*HashObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.HashClass, arg.Class().Name)
+				}
+
+				return t.vm.initConcurrentHashObject(hashArg.Pairs)
+
 			},
 		},
 	}
@@ -77,30 +76,29 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Object]
 			Name: "[]",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
-					}
-
-					i := args[0]
-					key, ok := i.(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
-					}
-
-					h := receiver.(*ConcurrentHashObject)
-
-					value, ok := h.internalMap.Load(key.value)
-
-					if !ok {
-						return NULL
-					}
-
-					return value.(Object)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
 				}
+
+				i := args[0]
+				key, ok := i.(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
+				}
+
+				h := receiver.(*ConcurrentHashObject)
+
+				value, ok := h.internalMap.Load(key.value)
+
+				if !ok {
+					return NULL
+				}
+
+				return value.(Object)
+
 			},
 		},
 		{
@@ -115,27 +113,26 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Object] The value
 			Name: "[]=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					// First arg is index
-					// Second arg is assigned value
-					if len(args) != 2 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got: %d", len(args))
-					}
-
-					k := args[0]
-					key, ok := k.(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, k.Class().Name)
-					}
-
-					h := receiver.(*ConcurrentHashObject)
-					h.internalMap.Store(key.value, args[1])
-
-					return args[1]
+				// First arg is index
+				// Second arg is assigned value
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got: %d", len(args))
 				}
+
+				k := args[0]
+				key, ok := k.(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, k.Class().Name)
+				}
+
+				h := receiver.(*ConcurrentHashObject)
+				h.internalMap.Store(key.value, args[1])
+
+				return args[1]
+
 			},
 		},
 		{
@@ -149,24 +146,23 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [NULL]
 			Name: "delete",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
-					}
-
-					h := receiver.(*ConcurrentHashObject)
-					d := args[0]
-					deleteKeyObject, ok := d.(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, d.Class().Name)
-					}
-
-					h.internalMap.Delete(deleteKeyObject.value)
-
-					return NULL
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
 				}
+
+				h := receiver.(*ConcurrentHashObject)
+				d := args[0]
+				deleteKeyObject, ok := d.(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, d.Class().Name)
+				}
+
+				h.internalMap.Delete(deleteKeyObject.value)
+
+				return NULL
+
 			},
 		},
 		{
@@ -186,37 +182,36 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Hash] self
 			Name: "each",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
-
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 arguments. got: %d", len(args))
-					}
-
-					hash := receiver.(*ConcurrentHashObject)
-					framePopped := false
-
-					iterator := func(key, value interface{}) bool {
-						keyObject := t.vm.InitStringObject(key.(string))
-
-						t.builtinMethodYield(blockFrame, keyObject, value.(Object))
-
-						framePopped = true
-
-						return true
-					}
-
-					hash.internalMap.Range(iterator)
-
-					if !framePopped {
-						t.callFrameStack.pop()
-					}
-
-					return hash
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
+
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 arguments. got: %d", len(args))
+				}
+
+				hash := receiver.(*ConcurrentHashObject)
+				framePopped := false
+
+				iterator := func(key, value interface{}) bool {
+					keyObject := t.vm.InitStringObject(key.(string))
+
+					t.builtinMethodYield(blockFrame, keyObject, value.(Object))
+
+					framePopped = true
+
+					return true
+				}
+
+				hash.internalMap.Range(iterator)
+
+				if !framePopped {
+					t.callFrameStack.pop()
+				}
+
+				return hash
+
 			},
 		},
 		{
@@ -230,26 +225,25 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "has_key?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
-					}
-
-					h := receiver.(*ConcurrentHashObject)
-					i := args[0]
-					input, ok := i.(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
-					}
-
-					if _, ok := h.internalMap.Load(input.value); ok {
-						return TRUE
-					}
-
-					return FALSE
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
 				}
+
+				h := receiver.(*ConcurrentHashObject)
+				i := args[0]
+				input, ok := i.(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
+				}
+
+				if _, ok := h.internalMap.Load(input.value); ok {
+					return TRUE
+				}
+
+				return FALSE
+
 			},
 		},
 		{
@@ -263,15 +257,14 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "to_json",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
-					}
-
-					r := receiver.(*ConcurrentHashObject)
-					return t.vm.InitStringObject(r.toJSON(t))
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
 				}
+
+				r := receiver.(*ConcurrentHashObject)
+				return t.vm.InitStringObject(r.toJSON(t))
+
 			},
 		},
 		{
@@ -285,15 +278,14 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "to_s",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
-					}
-
-					h := receiver.(*ConcurrentHashObject)
-					return t.vm.InitStringObject(h.toString())
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
 				}
+
+				h := receiver.(*ConcurrentHashObject)
+				return t.vm.InitStringObject(h.toString())
+
 			},
 		},
 	}

--- a/vm/concurrent_rw_lock.go
+++ b/vm/concurrent_rw_lock.go
@@ -32,14 +32,13 @@ func builtinConcurrentRWLockClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
-					}
-
-					return t.vm.initConcurrentRWLockObject()
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
 				}
+
+				return t.vm.initConcurrentRWLockObject()
+
 			},
 		},
 	}
@@ -60,18 +59,17 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// @return [nil]
 			// ```
 			Name: "acquire_read_lock",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
-					}
-
-					lockObject := receiver.(*ConcurrentRWLockObject)
-
-					lockObject.mutex.RLock()
-
-					return NULL
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
 				}
+
+				lockObject := receiver.(*ConcurrentRWLockObject)
+
+				lockObject.mutex.RLock()
+
+				return NULL
+
 			},
 		},
 		{
@@ -86,18 +84,17 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// @return [nil]
 			// ```
 			Name: "acquire_write_lock",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
-					}
-
-					lockObject := receiver.(*ConcurrentRWLockObject)
-
-					lockObject.mutex.Lock()
-
-					return NULL
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
 				}
+
+				lockObject := receiver.(*ConcurrentRWLockObject)
+
+				lockObject.mutex.Lock()
+
+				return NULL
+
 			},
 		},
 		{
@@ -112,18 +109,17 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// @return [nil]
 			// ```
 			Name: "release_read_lock",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
-					}
-
-					lockObject := receiver.(*ConcurrentRWLockObject)
-
-					lockObject.mutex.RUnlock()
-
-					return NULL
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
 				}
+
+				lockObject := receiver.(*ConcurrentRWLockObject)
+
+				lockObject.mutex.RUnlock()
+
+				return NULL
+
 			},
 		},
 		{
@@ -138,18 +134,17 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// @return [nil]
 			// ```
 			Name: "release_write_lock",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
-					}
-
-					lockObject := receiver.(*ConcurrentRWLockObject)
-
-					lockObject.mutex.Unlock()
-
-					return NULL
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
 				}
+
+				lockObject := receiver.(*ConcurrentRWLockObject)
+
+				lockObject.mutex.Unlock()
+
+				return NULL
+
 			},
 		},
 		{
@@ -165,26 +160,25 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object] the yielded value of the block.
 			// ```
 			Name: "with_read_lock",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
-
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
-					}
-
-					lockObject := receiver.(*ConcurrentRWLockObject)
-
-					lockObject.mutex.RLock()
-
-					blockReturnValue := t.builtinMethodYield(blockFrame).Target
-
-					lockObject.mutex.RUnlock()
-
-					return blockReturnValue
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
+
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
+				}
+
+				lockObject := receiver.(*ConcurrentRWLockObject)
+
+				lockObject.mutex.RLock()
+
+				blockReturnValue := t.builtinMethodYield(blockFrame).Target
+
+				lockObject.mutex.RUnlock()
+
+				return blockReturnValue
+
 			},
 		},
 		{
@@ -200,26 +194,25 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object] the yielded value of the block.
 			// ```
 			Name: "with_write_lock",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
-
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
-					}
-
-					lockObject := receiver.(*ConcurrentRWLockObject)
-
-					lockObject.mutex.Lock()
-
-					blockReturnValue := t.builtinMethodYield(blockFrame).Target
-
-					lockObject.mutex.Unlock()
-
-					return blockReturnValue
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
+
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
+				}
+
+				lockObject := receiver.(*ConcurrentRWLockObject)
+
+				lockObject.mutex.Lock()
+
+				blockReturnValue := t.builtinMethodYield(blockFrame).Target
+
+				lockObject.mutex.Unlock()
+
+				return blockReturnValue
+
 			},
 		},
 	}

--- a/vm/decimal.go
+++ b/vm/decimal.go
@@ -49,10 +49,9 @@ func builtinDecimalClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
+
 			},
 		},
 	}
@@ -74,14 +73,13 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Decimal]
 			Name: "+",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue *Decimal, rightValue *Decimal) *Decimal {
-						return new(Decimal).Add(leftValue, rightValue)
-					}
-
-					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue *Decimal, rightValue *Decimal) *Decimal {
+					return new(Decimal).Add(leftValue, rightValue)
 				}
+
+				return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+
 			},
 		},
 		{
@@ -97,14 +95,13 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Decimal]
 			Name: "-",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue *Decimal, rightValue *Decimal) *Decimal {
-						return new(Decimal).Sub(leftValue, rightValue)
-					}
-
-					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue *Decimal, rightValue *Decimal) *Decimal {
+					return new(Decimal).Sub(leftValue, rightValue)
 				}
+
+				return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+
 			},
 		},
 		{
@@ -120,14 +117,13 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Decimal]
 			Name: "*",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue *Decimal, rightValue *Decimal) *Decimal {
-						return new(Decimal).Mul(leftValue, rightValue)
-					}
-
-					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue *Decimal, rightValue *Decimal) *Decimal {
+					return new(Decimal).Mul(leftValue, rightValue)
 				}
+
+				return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+
 			},
 		},
 		{
@@ -147,16 +143,15 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Decimal]
 			Name: "**",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue *Decimal, rightValue *Decimal) *Decimal {
-						l, _ := leftValue.Float64()
-						r, _ := rightValue.Float64()
-						return new(Decimal).SetFloat64(math.Pow(l, r))
-					}
-
-					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue *Decimal, rightValue *Decimal) *Decimal {
+					l, _ := leftValue.Float64()
+					r, _ := rightValue.Float64()
+					return new(Decimal).SetFloat64(math.Pow(l, r))
 				}
+
+				return receiver.(*DecimalObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+
 			},
 		},
 		{
@@ -174,14 +169,13 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Decimal]
 			Name: "/",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					decimalOperation := func(leftValue *Decimal, rightValue *Decimal) *Decimal {
-						return new(Decimal).Quo(leftValue, rightValue)
-					}
-
-					return receiver.(*DecimalObject).arithmeticOperation(t, args[0], decimalOperation, sourceLine, true)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				decimalOperation := func(leftValue *Decimal, rightValue *Decimal) *Decimal {
+					return new(Decimal).Quo(leftValue, rightValue)
 				}
+
+				return receiver.(*DecimalObject).arithmeticOperation(t, args[0], decimalOperation, sourceLine, true)
+
 			},
 		},
 		{
@@ -201,18 +195,17 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: ">",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
-						if leftValue.Cmp(rightValue) == 1 {
-							return true
-						} else {
-							return false
-						}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
+					if leftValue.Cmp(rightValue) == 1 {
+						return true
+					} else {
+						return false
 					}
-
-					return receiver.(*DecimalObject).numericComparison(t, args[0], decimalOperation, sourceLine)
 				}
+
+				return receiver.(*DecimalObject).numericComparison(t, args[0], decimalOperation, sourceLine)
+
 			},
 		},
 		{
@@ -234,19 +227,18 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: ">=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
-						switch leftValue.Cmp(rightValue) {
-						case 1, 0:
-							return true
-						default:
-							return false
-						}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
+					switch leftValue.Cmp(rightValue) {
+					case 1, 0:
+						return true
+					default:
+						return false
 					}
-
-					return receiver.(*DecimalObject).numericComparison(t, args[0], decimalOperation, sourceLine)
 				}
+
+				return receiver.(*DecimalObject).numericComparison(t, args[0], decimalOperation, sourceLine)
+
 			},
 		},
 		{
@@ -266,18 +258,17 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "<",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
-						if leftValue.Cmp(rightValue) == -1 {
-							return true
-						} else {
-							return false
-						}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
+					if leftValue.Cmp(rightValue) == -1 {
+						return true
+					} else {
+						return false
 					}
-
-					return receiver.(*DecimalObject).numericComparison(t, args[0], decimalOperation, sourceLine)
 				}
+
+				return receiver.(*DecimalObject).numericComparison(t, args[0], decimalOperation, sourceLine)
+
 			},
 		},
 		{
@@ -299,19 +290,17 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "<=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
-						switch leftValue.Cmp(rightValue) {
-						case -1, 0:
-							return true
-						default:
-							return false
-						}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
+					switch leftValue.Cmp(rightValue) {
+					case -1, 0:
+						return true
+					default:
+						return false
 					}
-
-					return receiver.(*DecimalObject).numericComparison(t, args[0], decimalOperation, sourceLine)
 				}
+
+				return receiver.(*DecimalObject).numericComparison(t, args[0], decimalOperation, sourceLine)
 			},
 		},
 		{
@@ -329,14 +318,13 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "<=>",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					decimalOperation := func(leftValue *Decimal, rightValue *Decimal) int {
-						return leftValue.Cmp(rightValue)
-					}
-
-					return receiver.(*DecimalObject).rocketComparison(t, args[0], decimalOperation, sourceLine)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				decimalOperation := func(leftValue *Decimal, rightValue *Decimal) int {
+					return leftValue.Cmp(rightValue)
 				}
+
+				return receiver.(*DecimalObject).rocketComparison(t, args[0], decimalOperation, sourceLine)
+
 			},
 		},
 		{
@@ -356,18 +344,17 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "==",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
-						if leftValue.Cmp(rightValue) == 0 {
-							return true
-						} else {
-							return false
-						}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
+					if leftValue.Cmp(rightValue) == 0 {
+						return true
+					} else {
+						return false
 					}
-
-					return receiver.(*DecimalObject).equalityTest(t, args[0], decimalOperation, true, sourceLine)
 				}
+
+				return receiver.(*DecimalObject).equalityTest(t, args[0], decimalOperation, true, sourceLine)
+
 			},
 		},
 		{
@@ -387,18 +374,17 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "!=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
-						if leftValue.Cmp(rightValue) != 0 {
-							return true
-						} else {
-							return false
-						}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
+					if leftValue.Cmp(rightValue) != 0 {
+						return true
+					} else {
+						return false
 					}
-
-					return receiver.(*DecimalObject).equalityTest(t, args[0], decimalOperation, false, sourceLine)
 				}
+
+				return receiver.(*DecimalObject).equalityTest(t, args[0], decimalOperation, false, sourceLine)
+
 			},
 		},
 		{
@@ -416,10 +402,9 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "reduction",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.InitStringObject(receiver.(*DecimalObject).value.RatString())
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.InitStringObject(receiver.(*DecimalObject).value.RatString())
+
 			},
 		},
 		{
@@ -434,10 +419,9 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Decimal]
 			Name: "denominator",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.initDecimalObject(new(Decimal).SetInt(receiver.(*DecimalObject).value.Denom()))
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.initDecimalObject(new(Decimal).SetInt(receiver.(*DecimalObject).value.Denom()))
+
 			},
 		},
 		{
@@ -454,10 +438,9 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "fraction",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.InitStringObject(receiver.(*DecimalObject).value.String())
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.InitStringObject(receiver.(*DecimalObject).value.String())
+
 			},
 		},
 		{
@@ -471,11 +454,10 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Decimal]
 			Name: "inverse",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					d := receiver.(*DecimalObject).value
-					return t.vm.initDecimalObject(d.Inv(d))
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				d := receiver.(*DecimalObject).value
+				return t.vm.initDecimalObject(d.Inv(d))
+
 			},
 		},
 		{
@@ -490,10 +472,9 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Decimal]
 			Name: "numerator",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.initDecimalObject(new(Decimal).SetInt(receiver.(*DecimalObject).value.Num()))
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.initDecimalObject(new(Decimal).SetInt(receiver.(*DecimalObject).value.Num()))
+
 			},
 		},
 		{
@@ -506,18 +487,17 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "to_a",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					n := receiver.(*DecimalObject).value.Num()
-					d := receiver.(*DecimalObject).value.Denom()
-					elems := []Object{}
+				n := receiver.(*DecimalObject).value.Num()
+				d := receiver.(*DecimalObject).value.Denom()
+				elems := []Object{}
 
-					elems = append(elems, t.vm.initDecimalObject(new(Decimal).SetInt(n)))
-					elems = append(elems, t.vm.initDecimalObject(new(Decimal).SetInt(d)))
+				elems = append(elems, t.vm.initDecimalObject(new(Decimal).SetInt(n)))
+				elems = append(elems, t.vm.initDecimalObject(new(Decimal).SetInt(d)))
 
-					return t.vm.InitArrayObject(elems)
-				}
+				return t.vm.InitArrayObject(elems)
+
 			},
 		},
 		{
@@ -532,10 +512,9 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Float]
 			Name: "to_f",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.initFloatObject(receiver.(*DecimalObject).FloatValue())
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.initFloatObject(receiver.(*DecimalObject).FloatValue())
+
 			},
 		},
 		{
@@ -548,10 +527,9 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "to_i",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.InitIntegerObject(receiver.(*DecimalObject).IntegerValue())
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.InitIntegerObject(receiver.(*DecimalObject).IntegerValue())
+
 			},
 		},
 		{
@@ -566,10 +544,9 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "to_s",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.InitStringObject(receiver.(*DecimalObject).toString())
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.InitStringObject(receiver.(*DecimalObject).toString())
+
 			},
 		},
 	}

--- a/vm/decimal.go
+++ b/vm/decimal.go
@@ -199,9 +199,9 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 				decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
 					if leftValue.Cmp(rightValue) == 1 {
 						return true
-					} else {
-						return false
 					}
+
+					return false
 				}
 
 				return receiver.(*DecimalObject).numericComparison(t, args[0], decimalOperation, sourceLine)
@@ -262,9 +262,9 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 				decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
 					if leftValue.Cmp(rightValue) == -1 {
 						return true
-					} else {
-						return false
 					}
+
+					return false
 				}
 
 				return receiver.(*DecimalObject).numericComparison(t, args[0], decimalOperation, sourceLine)
@@ -348,9 +348,9 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 				decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
 					if leftValue.Cmp(rightValue) == 0 {
 						return true
-					} else {
-						return false
 					}
+
+					return false
 				}
 
 				return receiver.(*DecimalObject).equalityTest(t, args[0], decimalOperation, true, sourceLine)
@@ -378,9 +378,9 @@ func builtinDecimalInstanceMethods() []*BuiltinMethodObject {
 				decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
 					if leftValue.Cmp(rightValue) != 0 {
 						return true
-					} else {
-						return false
 					}
+
+					return false
 				}
 
 				return receiver.(*DecimalObject).equalityTest(t, args[0], decimalOperation, false, sourceLine)

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -125,6 +125,24 @@ func TestStackTraces(t *testing.T) {
 			2,
 			2,
 		},
+		{`def foo
+		  10
+		end
+
+		[1, 2].each do
+			[1, 2, 3].each(1) do |i|
+			  foo(i)
+			end
+		end
+		`,
+			"ArgumentError: Expect 0 argument. got=1",
+			[]string{
+				fmt.Sprintf("from %s:6", getFilename()),
+				fmt.Sprintf("from %s:5", getFilename()),
+			},
+			4,
+			2,
+		},
 	}
 
 	for i, tt := range tests {

--- a/vm/float.go
+++ b/vm/float.go
@@ -28,10 +28,9 @@ func builtinFloatClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
+
 			},
 		},
 	}
@@ -48,14 +47,13 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "+",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue float64, rightValue float64) float64 {
-						return leftValue + rightValue
-					}
-
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue float64, rightValue float64) float64 {
+					return leftValue + rightValue
 				}
+
+				return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+
 			},
 		},
 		{
@@ -66,14 +64,13 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "%",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue float64, rightValue float64) float64 {
-						return math.Mod(leftValue, rightValue)
-					}
-
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, true)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue float64, rightValue float64) float64 {
+					return math.Mod(leftValue, rightValue)
 				}
+
+				return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, true)
+
 			},
 		},
 		{
@@ -84,14 +81,13 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "-",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue float64, rightValue float64) float64 {
-						return leftValue - rightValue
-					}
-
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue float64, rightValue float64) float64 {
+					return leftValue - rightValue
 				}
+
+				return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+
 			},
 		},
 		{
@@ -102,14 +98,13 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "*",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue float64, rightValue float64) float64 {
-						return leftValue * rightValue
-					}
-
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue float64, rightValue float64) float64 {
+					return leftValue * rightValue
 				}
+
+				return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+
 			},
 		},
 		{
@@ -120,14 +115,13 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "**",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue float64, rightValue float64) float64 {
-						return math.Pow(leftValue, rightValue)
-					}
-
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue float64, rightValue float64) float64 {
+					return math.Pow(leftValue, rightValue)
 				}
+
+				return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
+
 			},
 		},
 		{
@@ -138,14 +132,13 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "/",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue float64, rightValue float64) float64 {
-						return leftValue / rightValue
-					}
-
-					return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, true)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue float64, rightValue float64) float64 {
+					return leftValue / rightValue
 				}
+
+				return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, true)
+
 			},
 		},
 		{
@@ -157,14 +150,13 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: ">",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue float64, rightValue float64) bool {
-						return leftValue > rightValue
-					}
-
-					return receiver.(*FloatObject).numericComparison(t, args[0], operation, sourceLine)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue float64, rightValue float64) bool {
+					return leftValue > rightValue
 				}
+
+				return receiver.(*FloatObject).numericComparison(t, args[0], operation, sourceLine)
+
 			},
 		},
 		{
@@ -176,14 +168,13 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: ">=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue float64, rightValue float64) bool {
-						return leftValue >= rightValue
-					}
-
-					return receiver.(*FloatObject).numericComparison(t, args[0], operation, sourceLine)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue float64, rightValue float64) bool {
+					return leftValue >= rightValue
 				}
+
+				return receiver.(*FloatObject).numericComparison(t, args[0], operation, sourceLine)
+
 			},
 		},
 		{
@@ -195,14 +186,13 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "<",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue float64, rightValue float64) bool {
-						return leftValue < rightValue
-					}
-
-					return receiver.(*FloatObject).numericComparison(t, args[0], operation, sourceLine)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue float64, rightValue float64) bool {
+					return leftValue < rightValue
 				}
+
+				return receiver.(*FloatObject).numericComparison(t, args[0], operation, sourceLine)
+
 			},
 		},
 		{
@@ -214,14 +204,13 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "<=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					operation := func(leftValue float64, rightValue float64) bool {
-						return leftValue <= rightValue
-					}
-
-					return receiver.(*FloatObject).numericComparison(t, args[0], operation, sourceLine)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				operation := func(leftValue float64, rightValue float64) bool {
+					return leftValue <= rightValue
 				}
+
+				return receiver.(*FloatObject).numericComparison(t, args[0], operation, sourceLine)
+
 			},
 		},
 		{
@@ -234,26 +223,25 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Float]
 			Name: "<=>",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					rightNumeric, ok := args[0].(Numeric)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				rightNumeric, ok := args[0].(Numeric)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
-					}
-
-					leftValue := receiver.(*FloatObject).value
-					rightValue := rightNumeric.floatValue()
-
-					if leftValue < rightValue {
-						return t.vm.InitIntegerObject(-1)
-					}
-					if leftValue > rightValue {
-						return t.vm.InitIntegerObject(1)
-					}
-
-					return t.vm.InitIntegerObject(0)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, "Numeric", args[0].Class().Name)
 				}
+
+				leftValue := receiver.(*FloatObject).value
+				rightValue := rightNumeric.floatValue()
+
+				if leftValue < rightValue {
+					return t.vm.InitIntegerObject(-1)
+				}
+				if leftValue > rightValue {
+					return t.vm.InitIntegerObject(1)
+				}
+
+				return t.vm.InitIntegerObject(0)
+
 			},
 		},
 		{
@@ -268,12 +256,11 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "==",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					result := receiver.(*FloatObject).equalityTest(args[0])
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				result := receiver.(*FloatObject).equalityTest(args[0])
 
-					return toBooleanObject(result)
-				}
+				return toBooleanObject(result)
+
 			},
 		},
 		{
@@ -288,12 +275,11 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "!=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					result := !receiver.(*FloatObject).equalityTest(args[0])
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				result := !receiver.(*FloatObject).equalityTest(args[0])
 
-					return toBooleanObject(result)
-				}
+				return toBooleanObject(result)
+
 			},
 		},
 		{
@@ -310,22 +296,21 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Decimal]
 			Name: "to_d",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%v", strconv.Itoa(len(args)))
-					}
-
-					fl := receiver.(*FloatObject).value
-					fs := strconv.FormatFloat(fl, 'f', -1, 64)
-					de, err := new(Decimal).SetString(fs)
-					if err == false {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Invalid numeric string. got=%v", fs)
-					}
-
-					return t.vm.initDecimalObject(de)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%v", strconv.Itoa(len(args)))
 				}
+
+				fl := receiver.(*FloatObject).value
+				fs := strconv.FormatFloat(fl, 'f', -1, 64)
+				de, err := new(Decimal).SetString(fs)
+				if err == false {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Invalid numeric string. got=%v", fs)
+				}
+
+				return t.vm.initDecimalObject(de)
+
 			},
 		},
 		{
@@ -336,22 +321,20 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "to_i",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*FloatObject)
-					newInt := t.vm.InitIntegerObject(int(r.value))
-					newInt.flag = i
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*FloatObject)
+				newInt := t.vm.InitIntegerObject(int(r.value))
+				newInt.flag = i
+				return newInt
+
 			},
 		},
 		{
 			Name: "ptr",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*FloatObject)
-					return t.vm.initGoObject(&r.value)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*FloatObject)
+				return t.vm.initGoObject(&r.value)
+
 			},
 		},
 	}

--- a/vm/go_map.go
+++ b/vm/go_map.go
@@ -23,26 +23,25 @@ func builtinGoMapClassMethods() []*BuiltinMethodObject {
 			//
 			// @return [GoMap]
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					m := make(map[string]interface{})
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				m := make(map[string]interface{})
 
-					if len(args) == 0 {
-						return t.vm.initGoMap(m)
-					}
-
-					hash, ok := args[0].(*HashObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.HashClass, args[0].Class().Name)
-					}
-
-					for k, v := range hash.Pairs {
-						m[k] = v.Value()
-					}
-
+				if len(args) == 0 {
 					return t.vm.initGoMap(m)
 				}
+
+				hash, ok := args[0].(*HashObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.HashClass, args[0].Class().Name)
+				}
+
+				for k, v := range hash.Pairs {
+					m[k] = v.Value()
+				}
+
+				return t.vm.initGoMap(m)
+
 			},
 		},
 	}
@@ -53,77 +52,74 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "to_hash",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
-					}
-
-					m := receiver.(*GoMap)
-
-					pairs := map[string]Object{}
-
-					for k, obj := range m.data {
-						pairs[k] = t.vm.InitObjectFromGoType(obj)
-
-					}
-
-					return t.vm.InitHashObject(pairs)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
 				}
+
+				m := receiver.(*GoMap)
+
+				pairs := map[string]Object{}
+
+				for k, obj := range m.data {
+					pairs[k] = t.vm.InitObjectFromGoType(obj)
+
+				}
+
+				return t.vm.InitHashObject(pairs)
+
 			},
 		},
 		{
 			Name: "get",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
-					}
-
-					key, ok := args[0].(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
-					}
-
-					m := receiver.(*GoMap).data
-
-					result, ok := m[key.value]
-
-					if !ok {
-						return NULL
-					}
-
-					obj, ok := result.(Object)
-
-					if !ok {
-						obj = t.vm.InitObjectFromGoType(result)
-					}
-
-					return obj
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
 				}
+
+				key, ok := args[0].(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+				}
+
+				m := receiver.(*GoMap).data
+
+				result, ok := m[key.value]
+
+				if !ok {
+					return NULL
+				}
+
+				obj, ok := result.(Object)
+
+				if !ok {
+					obj = t.vm.InitObjectFromGoType(result)
+				}
+
+				return obj
+
 			},
 		},
 		{
 			Name: "set",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 2 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 argument. got: %d", len(args))
-					}
-
-					key, ok := args[0].(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
-					}
-
-					m := receiver.(*GoMap).data
-
-					m[key.value] = args[1]
-
-					return args[1]
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 argument. got: %d", len(args))
 				}
+
+				key, ok := args[0].(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+				}
+
+				m := receiver.(*GoMap).data
+
+				m[key.value] = args[1]
+
+				return args[1]
+
 			},
 		},
 	}

--- a/vm/go_object.go
+++ b/vm/go_object.go
@@ -24,26 +24,25 @@ func builtinGoObjectInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "go_func",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					s, ok := args[0].(*StringObject)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				s, ok := args[0].(*StringObject)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
-					}
-
-					funcName := s.value
-					r := receiver.(*GoObject)
-
-					funcArgs, err := convertToGoFuncArgs(args[1:])
-
-					if err != nil {
-						t.vm.InitErrorObject(errors.TypeError, sourceLine, err.Error())
-					}
-
-					result := metago.CallFunc(r.data, funcName, funcArgs...)
-					return t.vm.InitObjectFromGoType(result)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 				}
+
+				funcName := s.value
+				r := receiver.(*GoObject)
+
+				funcArgs, err := convertToGoFuncArgs(args[1:])
+
+				if err != nil {
+					t.vm.InitErrorObject(errors.TypeError, sourceLine, err.Error())
+				}
+
+				result := metago.CallFunc(r.data, funcName, funcArgs...)
+				return t.vm.InitObjectFromGoType(result)
+
 			},
 		},
 	}

--- a/vm/http.go
+++ b/vm/http.go
@@ -23,155 +23,151 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 		{
 			// Sends a GET request to the target and returns the HTTP response as a string. Will error on non-200 responses, for more control over http requests look at the `start` method.
 			Name: "get",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					arg0, ok := args[0].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
-					}
-
-					uri, err := url.Parse(arg0.value)
-
-					if len(args) > 1 {
-						var arr []string
-
-						for i, v := range args[1:] {
-							argn, ok := v.(*StringObject)
-							if !ok {
-								return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Splat arguments must be a string, got: %s for argument %d", v.Class().Name, i)
-							}
-							arr = append(arr, argn.value)
-						}
-
-						uri.Path = path.Join(arr...)
-					}
-
-					resp, err := http.Get(uri.String())
-					if err != nil {
-						return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
-					}
-					if resp.StatusCode != http.StatusOK {
-						return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Non-200 response, %s (%d)", resp.Status, resp.StatusCode)
-					}
-
-					content, err := ioutil.ReadAll(resp.Body)
-					resp.Body.Close()
-
-					if err != nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
-					}
-
-					return t.vm.InitStringObject(string(content))
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				arg0, ok := args[0].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
 				}
+
+				uri, err := url.Parse(arg0.value)
+
+				if len(args) > 1 {
+					var arr []string
+
+					for i, v := range args[1:] {
+						argn, ok := v.(*StringObject)
+						if !ok {
+							return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Splat arguments must be a string, got: %s for argument %d", v.Class().Name, i)
+						}
+						arr = append(arr, argn.value)
+					}
+
+					uri.Path = path.Join(arr...)
+				}
+
+				resp, err := http.Get(uri.String())
+				if err != nil {
+					return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
+				}
+				if resp.StatusCode != http.StatusOK {
+					return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Non-200 response, %s (%d)", resp.Status, resp.StatusCode)
+				}
+
+				content, err := ioutil.ReadAll(resp.Body)
+				resp.Body.Close()
+
+				if err != nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
+				}
+
+				return t.vm.InitStringObject(string(content))
+
 			},
 		}, {
 			// Sends a POST request to the target with type header and body. Returns the HTTP response as a string. Will error on non-200 responses, for more control over http requests look at the `start` method.
 			Name: "post",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 3 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentFormat, 3, len(args))
-					}
-
-					arg0, ok := args[0].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
-					}
-					host := arg0.value
-
-					arg1, ok := args[1].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument 1 to be string, got: %s", args[0].Class().Name)
-					}
-					contentType := arg1.value
-
-					arg2, ok := args[2].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument 2 to be string, got: %s", args[0].Class().Name)
-					}
-					body := arg2.value
-
-					resp, err := http.Post(host, contentType, strings.NewReader(body))
-					if err != nil {
-						return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
-					}
-					if resp.StatusCode != http.StatusOK {
-						return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Non-200 response, %s (%d)", resp.Status, resp.StatusCode)
-					}
-
-					content, err := ioutil.ReadAll(resp.Body)
-					resp.Body.Close()
-
-					if err != nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
-					}
-
-					return t.vm.InitStringObject(string(content))
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 3 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentFormat, 3, len(args))
 				}
+
+				arg0, ok := args[0].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
+				}
+				host := arg0.value
+
+				arg1, ok := args[1].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument 1 to be string, got: %s", args[0].Class().Name)
+				}
+				contentType := arg1.value
+
+				arg2, ok := args[2].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument 2 to be string, got: %s", args[0].Class().Name)
+				}
+				body := arg2.value
+
+				resp, err := http.Post(host, contentType, strings.NewReader(body))
+				if err != nil {
+					return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
+				}
+				if resp.StatusCode != http.StatusOK {
+					return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Non-200 response, %s (%d)", resp.Status, resp.StatusCode)
+				}
+
+				content, err := ioutil.ReadAll(resp.Body)
+				resp.Body.Close()
+
+				if err != nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
+				}
+
+				return t.vm.InitStringObject(string(content))
+
 			},
 		}, {
 			// Sends a HEAD request to the target with type header and body. Returns the HTTP headers as a map[string]string. Will error on non-200 responses, for more control over http requests look at the `start` method.
 			Name: "head",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					arg0, ok := args[0].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
-					}
-
-					uri, err := url.Parse(arg0.value)
-
-					if len(args) > 1 {
-						var arr []string
-
-						for i, v := range args[1:] {
-							argn, ok := v.(*StringObject)
-							if !ok {
-								return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Splat arguments must be a string, got: %s for argument %d", v.Class().Name, i)
-							}
-							arr = append(arr, argn.value)
-						}
-
-						uri.Path = path.Join(arr...)
-					}
-
-					resp, err := http.Head(uri.String())
-					if err != nil {
-						return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
-					}
-					if resp.StatusCode != http.StatusOK {
-						return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Non-200 response, %s (%d)", resp.Status, resp.StatusCode)
-					}
-
-					ret := t.vm.InitHashObject(map[string]Object{})
-
-					for k, v := range resp.Header {
-						ret.Pairs[k] = t.vm.InitStringObject(strings.Join(v, " "))
-					}
-
-					return ret
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				arg0, ok := args[0].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect argument 0 to be string, got: %s", args[0].Class().Name)
 				}
+
+				uri, err := url.Parse(arg0.value)
+
+				if len(args) > 1 {
+					var arr []string
+
+					for i, v := range args[1:] {
+						argn, ok := v.(*StringObject)
+						if !ok {
+							return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Splat arguments must be a string, got: %s for argument %d", v.Class().Name, i)
+						}
+						arr = append(arr, argn.value)
+					}
+
+					uri.Path = path.Join(arr...)
+				}
+
+				resp, err := http.Head(uri.String())
+				if err != nil {
+					return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
+				}
+				if resp.StatusCode != http.StatusOK {
+					return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Non-200 response, %s (%d)", resp.Status, resp.StatusCode)
+				}
+
+				ret := t.vm.InitHashObject(map[string]Object{})
+
+				for k, v := range resp.Header {
+					ret.Pairs[k] = t.vm.InitStringObject(strings.Join(v, " "))
+				}
+
+				return ret
+
 			},
 		}, {
 			// Starts an HTTP client. This method requires a block which takes a Net::HTTP::Client object. The return value of this method is the last evaluated value of the provided block.
 			Name: "start",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 arguments. got=%v", strconv.Itoa(len(args)))
-					}
-
-					gobyClient := httpClientClass.initializeInstance()
-
-					result := t.builtinMethodYield(blockFrame, gobyClient)
-
-					if err, ok := result.Target.(*Error); ok {
-						return err //an Error object
-					}
-
-					return result.Target
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 arguments. got=%v", strconv.Itoa(len(args)))
 				}
+
+				gobyClient := httpClientClass.initializeInstance()
+
+				result := t.builtinMethodYield(blockFrame, gobyClient)
+
+				if err, ok := result.Target.(*Error); ok {
+					return err //an Error object
+				}
+
+				return result.Target
+
 			},
 		},
 	}

--- a/vm/http_client.go
+++ b/vm/http_client.go
@@ -20,135 +20,130 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 		{
 			// Sends a GET request to the target and returns a `Net::HTTP::Response` object.
 			Name: "get",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentFormat, 1, len(args))
-					}
-
-					u, ok := args[0].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
-					}
-
-					resp, err := goClient.Get(u.value)
-					if err != nil {
-						return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
-					}
-
-					gobyResp, err := responseGoToGoby(t, resp)
-					if err != nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
-					}
-
-					return gobyResp
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentFormat, 1, len(args))
 				}
+
+				u, ok := args[0].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
+				}
+
+				resp, err := goClient.Get(u.value)
+				if err != nil {
+					return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
+				}
+
+				gobyResp, err := responseGoToGoby(t, resp)
+				if err != nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
+				}
+
+				return gobyResp
+
 			},
 		}, {
 			// Sends a POST request to the target and returns a `Net::HTTP::Response` object.
 			Name: "post",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 3 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentFormat, 3, len(args))
-					}
-
-					u, ok := args[0].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
-					}
-
-					contentType, ok := args[1].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
-					}
-
-					body, ok := args[2].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
-					}
-
-					bodyR := strings.NewReader(body.value)
-
-					resp, err := goClient.Post(u.value, contentType.value, bodyR)
-					if err != nil {
-						return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
-					}
-
-					gobyResp, err := responseGoToGoby(t, resp)
-					if err != nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
-					}
-
-					return gobyResp
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 3 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentFormat, 3, len(args))
 				}
+
+				u, ok := args[0].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
+				}
+
+				contentType, ok := args[1].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
+				}
+
+				body, ok := args[2].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
+				}
+
+				bodyR := strings.NewReader(body.value)
+
+				resp, err := goClient.Post(u.value, contentType.value, bodyR)
+				if err != nil {
+					return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
+				}
+
+				gobyResp, err := responseGoToGoby(t, resp)
+				if err != nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
+				}
+
+				return gobyResp
+
 			},
 		}, {
 			// Sends a HEAD request to the target and returns a `Net::HTTP::Response` object.
 			Name: "head",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentFormat, 1, len(args))
-					}
-
-					u, ok := args[0].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
-					}
-
-					resp, err := goClient.Head(u.value)
-					if err != nil {
-						return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
-					}
-
-					gobyResp, err := responseGoToGoby(t, resp)
-					if err != nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
-					}
-
-					return gobyResp
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentFormat, 1, len(args))
 				}
+
+				u, ok := args[0].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, u.Class().Name)
+				}
+
+				resp, err := goClient.Head(u.value)
+				if err != nil {
+					return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
+				}
+
+				gobyResp, err := responseGoToGoby(t, resp)
+				if err != nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
+				}
+
+				return gobyResp
+
 			},
 		}, {
 			// Returns a blank `Net::HTTP::Request` object to be sent with the`exec` method
 			Name: "request",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return httpRequestClass.initializeInstance()
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return httpRequestClass.initializeInstance()
+
 			},
 		}, {
 			// Sends a passed `Net::HTTP::Request` object and returns a `Net::HTTP::Response` object
 			Name: "exec",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentFormat, 1, len(args))
-					}
-
-					if args[0].Class().Name != httpRequestClass.Name {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, "HTTP Response", args[0].Class().Name)
-					}
-
-					goReq, err := requestGobyToGo(args[0])
-					if err != nil {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, err.Error())
-					}
-
-					goResp, err := goClient.Do(goReq)
-					if err != nil {
-						return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
-					}
-
-					gobyResp, err := responseGoToGoby(t, goResp)
-
-					if err != nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
-					}
-
-					return gobyResp
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentFormat, 1, len(args))
 				}
+
+				if args[0].Class().Name != httpRequestClass.Name {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, "HTTP Response", args[0].Class().Name)
+				}
+
+				goReq, err := requestGobyToGo(args[0])
+				if err != nil {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, err.Error())
+				}
+
+				goResp, err := goClient.Do(goReq)
+				if err != nil {
+					return t.vm.InitErrorObject(errors.HTTPError, sourceLine, "Could not complete request, %s", err)
+				}
+
+				gobyResp, err := responseGoToGoby(t, goResp)
+
+				if err != nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
+				}
+
+				return gobyResp
+
 			},
 		},
 	}

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -539,7 +539,7 @@ var builtinActions = map[operationType]*action{
 			switch m := method.(type) {
 			case *MethodObject:
 				callObj := newCallObject(receiver, m, receiverPr, argCount, argSet, blockFrame, sourceLine)
-				t.evalMethodObject(callObj, sourceLine)
+				t.evalMethodObject(callObj)
 			case *BuiltinMethodObject:
 				t.evalBuiltinMethod(receiver, m, receiverPr, argCount, argSet, blockFrame, sourceLine, cf.fileName)
 			case *Error:

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -48,10 +48,9 @@ func builtinIntegerClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
+
 			},
 		},
 	}
@@ -68,17 +67,16 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Numeric]
 			Name: "+",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					intOperation := func(leftValue int, rightValue int) int {
-						return leftValue + rightValue
-					}
-					floatOperation := func(leftValue float64, rightValue float64) float64 {
-						return leftValue + rightValue
-					}
-
-					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				intOperation := func(leftValue int, rightValue int) int {
+					return leftValue + rightValue
 				}
+				floatOperation := func(leftValue float64, rightValue float64) float64 {
+					return leftValue + rightValue
+				}
+
+				return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
+
 			},
 		},
 		{
@@ -89,17 +87,16 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Numeric]
 			Name: "%",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					intOperation := func(leftValue int, rightValue int) int {
-						return leftValue % rightValue
-					}
-					floatOperation := func(leftValue float64, rightValue float64) float64 {
-						return math.Mod(leftValue, rightValue)
-					}
-
-					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, true)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				intOperation := func(leftValue int, rightValue int) int {
+					return leftValue % rightValue
 				}
+				floatOperation := func(leftValue float64, rightValue float64) float64 {
+					return math.Mod(leftValue, rightValue)
+				}
+
+				return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, true)
+
 			},
 		},
 		{
@@ -110,17 +107,16 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Numeric]
 			Name: "-",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					intOperation := func(leftValue int, rightValue int) int {
-						return leftValue - rightValue
-					}
-					floatOperation := func(leftValue float64, rightValue float64) float64 {
-						return leftValue - rightValue
-					}
-
-					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				intOperation := func(leftValue int, rightValue int) int {
+					return leftValue - rightValue
 				}
+				floatOperation := func(leftValue float64, rightValue float64) float64 {
+					return leftValue - rightValue
+				}
+
+				return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
+
 			},
 		},
 		{
@@ -131,17 +127,16 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Numeric]
 			Name: "*",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					intOperation := func(leftValue int, rightValue int) int {
-						return leftValue * rightValue
-					}
-					floatOperation := func(leftValue float64, rightValue float64) float64 {
-						return leftValue * rightValue
-					}
-
-					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				intOperation := func(leftValue int, rightValue int) int {
+					return leftValue * rightValue
 				}
+				floatOperation := func(leftValue float64, rightValue float64) float64 {
+					return leftValue * rightValue
+				}
+
+				return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
+
 			},
 		},
 		{
@@ -152,17 +147,16 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Numeric]
 			Name: "**",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					intOperation := func(leftValue int, rightValue int) int {
-						return int(math.Pow(float64(leftValue), float64(rightValue)))
-					}
-					floatOperation := func(leftValue float64, rightValue float64) float64 {
-						return math.Pow(leftValue, rightValue)
-					}
-
-					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				intOperation := func(leftValue int, rightValue int) int {
+					return int(math.Pow(float64(leftValue), float64(rightValue)))
 				}
+				floatOperation := func(leftValue float64, rightValue float64) float64 {
+					return math.Pow(leftValue, rightValue)
+				}
+
+				return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
+
 			},
 		},
 		{
@@ -173,18 +167,17 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Numeric]
 			Name: "/",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					intOperation := func(leftValue int, rightValue int) int {
-						return leftValue / rightValue
-					}
-					floatOperation := func(leftValue float64, rightValue float64) float64 {
-						return leftValue / rightValue
-					}
-
-					return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, true)
+				intOperation := func(leftValue int, rightValue int) int {
+					return leftValue / rightValue
 				}
+				floatOperation := func(leftValue float64, rightValue float64) float64 {
+					return leftValue / rightValue
+				}
+
+				return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, true)
+
 			},
 		},
 		{
@@ -196,17 +189,16 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: ">",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					intComparison := func(leftValue int, rightValue int) bool {
-						return leftValue > rightValue
-					}
-					floatComparison := func(leftValue float64, rightValue float64) bool {
-						return leftValue > rightValue
-					}
-
-					return receiver.(*IntegerObject).numericComparison(t, args[0], intComparison, floatComparison, sourceLine)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				intComparison := func(leftValue int, rightValue int) bool {
+					return leftValue > rightValue
 				}
+				floatComparison := func(leftValue float64, rightValue float64) bool {
+					return leftValue > rightValue
+				}
+
+				return receiver.(*IntegerObject).numericComparison(t, args[0], intComparison, floatComparison, sourceLine)
+
 			},
 		},
 		{
@@ -218,17 +210,16 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: ">=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					intComparison := func(leftValue int, rightValue int) bool {
-						return leftValue >= rightValue
-					}
-					floatComparison := func(leftValue float64, rightValue float64) bool {
-						return leftValue >= rightValue
-					}
-
-					return receiver.(*IntegerObject).numericComparison(t, args[0], intComparison, floatComparison, sourceLine)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				intComparison := func(leftValue int, rightValue int) bool {
+					return leftValue >= rightValue
 				}
+				floatComparison := func(leftValue float64, rightValue float64) bool {
+					return leftValue >= rightValue
+				}
+
+				return receiver.(*IntegerObject).numericComparison(t, args[0], intComparison, floatComparison, sourceLine)
+
 			},
 		},
 		{
@@ -240,17 +231,16 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "<",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					intComparison := func(leftValue int, rightValue int) bool {
-						return leftValue < rightValue
-					}
-					floatComparison := func(leftValue float64, rightValue float64) bool {
-						return leftValue < rightValue
-					}
-
-					return receiver.(*IntegerObject).numericComparison(t, args[0], intComparison, floatComparison, sourceLine)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				intComparison := func(leftValue int, rightValue int) bool {
+					return leftValue < rightValue
 				}
+				floatComparison := func(leftValue float64, rightValue float64) bool {
+					return leftValue < rightValue
+				}
+
+				return receiver.(*IntegerObject).numericComparison(t, args[0], intComparison, floatComparison, sourceLine)
+
 			},
 		},
 		{
@@ -262,17 +252,16 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "<=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					intComparison := func(leftValue int, rightValue int) bool {
-						return leftValue <= rightValue
-					}
-					floatComparison := func(leftValue float64, rightValue float64) bool {
-						return leftValue <= rightValue
-					}
-
-					return receiver.(*IntegerObject).numericComparison(t, args[0], intComparison, floatComparison, sourceLine)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				intComparison := func(leftValue int, rightValue int) bool {
+					return leftValue <= rightValue
 				}
+				floatComparison := func(leftValue float64, rightValue float64) bool {
+					return leftValue <= rightValue
+				}
+
+				return receiver.(*IntegerObject).numericComparison(t, args[0], intComparison, floatComparison, sourceLine)
+
 			},
 		},
 		{
@@ -285,39 +274,38 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "<=>",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					rightObject := args[0]
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				rightObject := args[0]
 
-					switch rightObject.(type) {
-					case *IntegerObject:
-						leftValue := receiver.(*IntegerObject).value
-						rightValue := rightObject.(*IntegerObject).value
+				switch rightObject.(type) {
+				case *IntegerObject:
+					leftValue := receiver.(*IntegerObject).value
+					rightValue := rightObject.(*IntegerObject).value
 
-						if leftValue < rightValue {
-							return t.vm.InitIntegerObject(-1)
-						}
-						if leftValue > rightValue {
-							return t.vm.InitIntegerObject(1)
-						}
-
-						return t.vm.InitIntegerObject(0)
-					case *FloatObject:
-						leftValue := float64(receiver.(*IntegerObject).value)
-						rightValue := rightObject.(*FloatObject).value
-
-						if leftValue < rightValue {
-							return t.vm.InitIntegerObject(-1)
-						}
-						if leftValue > rightValue {
-							return t.vm.InitIntegerObject(1)
-						}
-
-						return t.vm.InitIntegerObject(0)
-					default:
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, "Numeric", rightObject.Class().Name)
+					if leftValue < rightValue {
+						return t.vm.InitIntegerObject(-1)
 					}
+					if leftValue > rightValue {
+						return t.vm.InitIntegerObject(1)
+					}
+
+					return t.vm.InitIntegerObject(0)
+				case *FloatObject:
+					leftValue := float64(receiver.(*IntegerObject).value)
+					rightValue := rightObject.(*FloatObject).value
+
+					if leftValue < rightValue {
+						return t.vm.InitIntegerObject(-1)
+					}
+					if leftValue > rightValue {
+						return t.vm.InitIntegerObject(1)
+					}
+
+					return t.vm.InitIntegerObject(0)
+				default:
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, "Numeric", rightObject.Class().Name)
 				}
+
 			},
 		},
 		{
@@ -332,12 +320,11 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "==",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					result := receiver.(*IntegerObject).equalityTest(args[0])
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				result := receiver.(*IntegerObject).equalityTest(args[0])
 
-					return toBooleanObject(result)
-				}
+				return toBooleanObject(result)
+
 			},
 		},
 		{
@@ -352,12 +339,11 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "!=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					result := !receiver.(*IntegerObject).equalityTest(args[0])
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				result := !receiver.(*IntegerObject).equalityTest(args[0])
 
-					return toBooleanObject(result)
-				}
+				return toBooleanObject(result)
+
 			},
 		},
 		{
@@ -369,18 +355,17 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "even?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					i := receiver.(*IntegerObject)
-					even := i.value%2 == 0
+				i := receiver.(*IntegerObject)
+				even := i.value%2 == 0
 
-					if even {
-						return TRUE
-					}
-
-					return FALSE
+				if even {
+					return TRUE
 				}
+
+				return FALSE
+
 			},
 		},
 		// Returns the `Decimal` conversion of self.
@@ -391,14 +376,13 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		// @return [Decimal]
 		{
 			Name: "to_d",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) > 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 arguments. got: %d", len(args))
-					}
-					r := receiver.(*IntegerObject)
-					return t.vm.initDecimalObject(intToDecimal(r))
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) > 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 arguments. got: %d", len(args))
 				}
+				r := receiver.(*IntegerObject)
+				return t.vm.initDecimalObject(intToDecimal(r))
+
 			},
 		},
 		// Returns the `Float` conversion of self.
@@ -409,12 +393,11 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 		// @return [Float]
 		{
 			Name: "to_f",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newFloat := t.vm.initFloatObject(float64(r.value))
-					return newFloat
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newFloat := t.vm.initFloatObject(float64(r.value))
+				return newFloat
+
 			},
 		},
 		{
@@ -425,10 +408,9 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "to_i",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return receiver
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return receiver
+
 			},
 		},
 		{
@@ -439,13 +421,12 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [String]
 			Name: "to_s",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					int := receiver.(*IntegerObject)
+				int := receiver.(*IntegerObject)
 
-					return t.vm.InitStringObject(strconv.Itoa(int.value))
-				}
+				return t.vm.InitStringObject(strconv.Itoa(int.value))
+
 			},
 		},
 		{
@@ -456,11 +437,10 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "next",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					i := receiver.(*IntegerObject)
-					return t.vm.InitIntegerObject(i.value + 1)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				i := receiver.(*IntegerObject)
+				return t.vm.InitIntegerObject(i.value + 1)
+
 			},
 		},
 		{
@@ -472,17 +452,16 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Boolean]
 			Name: "odd?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					i := receiver.(*IntegerObject)
-					odd := i.value%2 != 0
-					if odd {
-						return TRUE
-					}
-
-					return FALSE
+				i := receiver.(*IntegerObject)
+				odd := i.value%2 != 0
+				if odd {
+					return TRUE
 				}
+
+				return FALSE
+
 			},
 		},
 		{
@@ -493,11 +472,10 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "pred",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					i := receiver.(*IntegerObject)
-					return t.vm.InitIntegerObject(i.value - 1)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				i := receiver.(*IntegerObject)
+				return t.vm.InitIntegerObject(i.value - 1)
+
 			},
 		},
 		{
@@ -511,165 +489,151 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			// a # => 3
 			// ```
 			Name: "times",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					n := receiver.(*IntegerObject)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				n := receiver.(*IntegerObject)
 
-					if n.value < 0 {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, "Expect integer greater than or equal 0. got: %d", n.value)
-					}
-
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
-
-					for i := 0; i < n.value; i++ {
-						t.builtinMethodYield(blockFrame, t.vm.InitIntegerObject(i))
-					}
-
-					return n
+				if n.value < 0 {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, "Expect integer greater than or equal 0. got: %d", n.value)
 				}
+
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
+				}
+
+				for i := 0; i < n.value; i++ {
+					t.builtinMethodYield(blockFrame, t.vm.InitIntegerObject(i))
+				}
+
+				return n
+
 			},
 		},
 		{
 			Name: "to_int",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newInt := t.vm.InitIntegerObject(r.value)
-					newInt.flag = i
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newInt := t.vm.InitIntegerObject(r.value)
+				newInt.flag = i
+				return newInt
+
 			},
 		},
 		{
 			Name: "to_int8",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newInt := t.vm.InitIntegerObject(r.value)
-					newInt.flag = i8
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newInt := t.vm.InitIntegerObject(r.value)
+				newInt.flag = i8
+				return newInt
+
 			},
 		},
 		{
 			Name: "to_int16",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newInt := t.vm.InitIntegerObject(r.value)
-					newInt.flag = i16
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newInt := t.vm.InitIntegerObject(r.value)
+				newInt.flag = i16
+				return newInt
+
 			},
 		},
 		{
 			Name: "to_int32",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newInt := t.vm.InitIntegerObject(r.value)
-					newInt.flag = i32
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newInt := t.vm.InitIntegerObject(r.value)
+				newInt.flag = i32
+				return newInt
+
 			},
 		},
 		{
 			Name: "to_int64",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newInt := t.vm.InitIntegerObject(r.value)
-					newInt.flag = i64
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newInt := t.vm.InitIntegerObject(r.value)
+				newInt.flag = i64
+				return newInt
+
 			},
 		},
 		{
 			Name: "to_uint",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newInt := t.vm.InitIntegerObject(r.value)
-					newInt.flag = ui
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newInt := t.vm.InitIntegerObject(r.value)
+				newInt.flag = ui
+				return newInt
+
 			},
 		},
 		{
 			Name: "to_uint8",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newInt := t.vm.InitIntegerObject(r.value)
-					newInt.flag = ui8
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newInt := t.vm.InitIntegerObject(r.value)
+				newInt.flag = ui8
+				return newInt
+
 			},
 		},
 		{
 			Name: "to_uint16",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newInt := t.vm.InitIntegerObject(r.value)
-					newInt.flag = ui16
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newInt := t.vm.InitIntegerObject(r.value)
+				newInt.flag = ui16
+				return newInt
+
 			},
 		},
 		{
 			Name: "to_uint32",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newInt := t.vm.InitIntegerObject(r.value)
-					newInt.flag = ui32
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newInt := t.vm.InitIntegerObject(r.value)
+				newInt.flag = ui32
+				return newInt
+
 			},
 		},
 		{
 			Name: "to_uint64",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newInt := t.vm.InitIntegerObject(r.value)
-					newInt.flag = ui64
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newInt := t.vm.InitIntegerObject(r.value)
+				newInt.flag = ui64
+				return newInt
+
 			},
 		},
 		{
 			Name: "to_float32",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newInt := t.vm.InitIntegerObject(r.value)
-					newInt.flag = f32
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newInt := t.vm.InitIntegerObject(r.value)
+				newInt.flag = f32
+				return newInt
+
 			},
 		},
 		{
 			Name: "to_float64",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					newInt := t.vm.InitIntegerObject(r.value)
-					newInt.flag = f64
-					return newInt
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				newInt := t.vm.InitIntegerObject(r.value)
+				newInt.flag = f64
+				return newInt
+
 			},
 		},
 		{
 			Name: "ptr",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*IntegerObject)
-					return t.vm.initGoObject(&r.value)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*IntegerObject)
+				return t.vm.initGoObject(&r.value)
+
 			},
 		},
 	}

--- a/vm/json.go
+++ b/vm/json.go
@@ -15,78 +15,76 @@ func builtinJSONClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "parse",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				}
 
-					j, ok := args[0].(*StringObject)
+				j, ok := args[0].(*StringObject)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
-					}
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+				}
 
-					var obj jsonObj
-					var objs []jsonObj
+				var obj jsonObj
+				var objs []jsonObj
 
-					jsonString := j.value
+				jsonString := j.value
 
-					err := json.Unmarshal([]byte(jsonString), &obj)
+				err := json.Unmarshal([]byte(jsonString), &obj)
+
+				if err != nil {
+					err = json.Unmarshal([]byte(jsonString), &objs)
 
 					if err != nil {
-						err = json.Unmarshal([]byte(jsonString), &objs)
-
-						if err != nil {
-							return t.vm.InitErrorObject(errors.InternalError, sourceLine, "Can't parse string %s as json: %s", jsonString, err.Error())
-						}
-
-						var objects []Object
-
-						for _, obj := range objs {
-							objects = append(objects, t.vm.convertJSONToHashObj(obj))
-						}
-
-						return t.vm.InitArrayObject(objects)
+						return t.vm.InitErrorObject(errors.InternalError, sourceLine, "Can't parse string %s as json: %s", jsonString, err.Error())
 					}
 
-					return t.vm.convertJSONToHashObj(obj)
+					var objects []Object
+
+					for _, obj := range objs {
+						objects = append(objects, t.vm.convertJSONToHashObj(obj))
+					}
+
+					return t.vm.InitArrayObject(objects)
 				}
+
+				return t.vm.convertJSONToHashObj(obj)
+
 			},
 		},
 		{
 			Name: "validate",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				}
 
-					j, ok := args[0].(*StringObject)
+				j, ok := args[0].(*StringObject)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
-					}
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+				}
 
-					var obj jsonObj
-					var objs []jsonObj
+				var obj jsonObj
+				var objs []jsonObj
 
-					jsonString := j.value
+				jsonString := j.value
 
-					err := json.Unmarshal([]byte(jsonString), &obj)
+				err := json.Unmarshal([]byte(jsonString), &obj)
+
+				if err != nil {
+					err = json.Unmarshal([]byte(jsonString), &objs)
 
 					if err != nil {
-						err = json.Unmarshal([]byte(jsonString), &objs)
-
-						if err != nil {
-							return FALSE
-						}
-
-						return TRUE
+						return FALSE
 					}
 
 					return TRUE
 				}
+
+				return TRUE
+
 			},
 		},
 	}

--- a/vm/match_data.go
+++ b/vm/match_data.go
@@ -31,10 +31,9 @@ func builtInMatchDataClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
+
 			},
 		},
 	}
@@ -54,23 +53,22 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "captures",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
-					offset := 1
-
-					g := receiver.(*MatchDataObject).match
-					n := len(g.Groups()) - offset
-					destCaptures := make([]Object, n, n)
-
-					for i := 0; i < n; i++ {
-						destCaptures[i] = t.vm.InitStringObject(g.GroupByNumber(i + offset).String())
-					}
-
-					return t.vm.InitArrayObject(destCaptures)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 				}
+				offset := 1
+
+				g := receiver.(*MatchDataObject).match
+				n := len(g.Groups()) - offset
+				destCaptures := make([]Object, n, n)
+
+				for i := 0; i < n; i++ {
+					destCaptures[i] = t.vm.InitStringObject(g.GroupByNumber(i + offset).String())
+				}
+
+				return t.vm.InitArrayObject(destCaptures)
+
 			},
 		},
 		{
@@ -85,22 +83,21 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "to_a",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
-
-					g := receiver.(*MatchDataObject).match
-					n := len(g.Groups())
-					destCaptures := make([]Object, n, n)
-
-					for i := 0; i < n; i++ {
-						destCaptures[i] = t.vm.InitStringObject(g.GroupByNumber(i).String())
-					}
-
-					return t.vm.InitArrayObject(destCaptures)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 				}
+
+				g := receiver.(*MatchDataObject).match
+				n := len(g.Groups())
+				destCaptures := make([]Object, n, n)
+
+				for i := 0; i < n; i++ {
+					destCaptures[i] = t.vm.InitStringObject(g.GroupByNumber(i).String())
+				}
+
+				return t.vm.InitArrayObject(destCaptures)
+
 			},
 		},
 		{
@@ -117,21 +114,20 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Hash]
 			Name: "to_h",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
-
-					groups := receiver.(*MatchDataObject).match
-					result := make(map[string]Object)
-
-					for _, g := range groups.Groups() {
-						result[g.Name] = t.vm.InitStringObject(g.String())
-					}
-
-					return t.vm.InitHashObject(result)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 				}
+
+				groups := receiver.(*MatchDataObject).match
+				result := make(map[string]Object)
+
+				for _, g := range groups.Groups() {
+					result[g.Name] = t.vm.InitStringObject(g.String())
+				}
+
+				return t.vm.InitHashObject(result)
+
 			},
 		},
 		{
@@ -142,16 +138,15 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			// @return [Integer]
 			Name: "length",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
-
-					m := receiver.(*MatchDataObject).match
-
-					return t.vm.InitIntegerObject(m.GroupCount())
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
 				}
+
+				m := receiver.(*MatchDataObject).match
+
+				return t.vm.InitIntegerObject(m.GroupCount())
+
 			},
 		},
 	}

--- a/vm/method.go
+++ b/vm/method.go
@@ -77,17 +77,15 @@ type BuiltinMethodObject struct {
 }
 
 // Method is a callable function
-type Method = func(t *Thread, args []Object) Object
+type Method = func(receiver Object, line int, t *Thread, args []Object) Object
 
-// MethodBuilder constructs an instance of a method
-type MethodBuilder = func(receiver Object, line int) Method
 
 // ExternalBuiltinMethod is a function that builds a BuiltinMethodObject from an external function
-func ExternalBuiltinMethod(name string, m MethodBuilder) *BuiltinMethodObject {
+func ExternalBuiltinMethod(name string, m Method) *BuiltinMethodObject {
 	return &BuiltinMethodObject{
 		Name: name,
 		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, c *normalCallFrame) Object {
-			return m(receiver, sourceLine)(t, args)
+			return m(receiver, sourceLine, t, args)
 		},
 	}
 }

--- a/vm/method.go
+++ b/vm/method.go
@@ -73,7 +73,7 @@ func (m *MethodObject) isKeywordArgIncluded() bool {
 type BuiltinMethodObject struct {
 	*baseObj
 	Name string
-	Fn   func(receiver Object, sourceLine int) builtinMethodBody
+	Fn   builtinMethodBody
 }
 
 // Method is a callable function
@@ -86,16 +86,13 @@ type MethodBuilder = func(receiver Object, line int) Method
 func ExternalBuiltinMethod(name string, m MethodBuilder) *BuiltinMethodObject {
 	return &BuiltinMethodObject{
 		Name: name,
-		Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-			f := m(receiver, sourceLine)
-			return func(t *Thread, args []Object, c *normalCallFrame) Object {
-				return f(t, args)
-			}
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, c *normalCallFrame) Object {
+			return m(receiver, sourceLine)(t, args)
 		},
 	}
 }
 
-type builtinMethodBody func(*Thread, []Object, *normalCallFrame) Object
+type builtinMethodBody func(Object, int, *Thread, []Object, *normalCallFrame) Object
 
 // Polymorphic helper functions -----------------------------------------
 

--- a/vm/null.go
+++ b/vm/null.go
@@ -22,10 +22,9 @@ func builtinNullClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
+
 			},
 		},
 	}
@@ -43,27 +42,24 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			// # => true
 			// ```
 			Name: "!",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					return TRUE
-				}
+				return TRUE
+
 			},
 		},
 		{
 			Name: "to_i",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.InitIntegerObject(0)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.InitIntegerObject(0)
+
 			},
 		},
 		{
 			Name: "to_s",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.InitStringObject("")
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.InitStringObject("")
+
 			},
 		},
 		{
@@ -75,17 +71,16 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			// # => true
 			// ```
 			Name: "==",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
-					}
-
-					if _, ok := args[0].(*NullObject); ok {
-						return TRUE
-					}
-					return FALSE
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
 				}
+
+				if _, ok := args[0].(*NullObject); ok {
+					return TRUE
+				}
+				return FALSE
+
 			},
 		},
 		{
@@ -97,17 +92,16 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			// # => false
 			// ```
 			Name: "!=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
-					}
-
-					if _, ok := args[0].(*NullObject); !ok {
-						return TRUE
-					}
-					return FALSE
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
 				}
+
+				if _, ok := args[0].(*NullObject); !ok {
+					return TRUE
+				}
+				return FALSE
+
 			},
 		},
 		{
@@ -119,13 +113,12 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			// # => true
 			// ```
 			Name: "nil?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
-					}
-					return TRUE
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
 				}
+				return TRUE
+
 			},
 		},
 	}

--- a/vm/object.go
+++ b/vm/object.go
@@ -143,7 +143,7 @@ func (ro *RObject) toJSON(t *Thread) string {
 	if customToJSONMethod != nil {
 		t.Stack.Push(&Pointer{Target: ro})
 		callObj := newCallObject(ro, customToJSONMethod, t.Stack.pointer, 0, &bytecode.ArgSet{}, nil, customToJSONMethod.instructionSet.instructions[0].sourceLine)
-		t.evalMethodObject(callObj, customToJSONMethod.instructionSet.instructions[0].sourceLine)
+		t.evalMethodObject(callObj)
 		result := t.Stack.Pop().Target
 		return result.toString()
 	}

--- a/vm/plugin_integration_test.go
+++ b/vm/plugin_integration_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package vm
 
 import (

--- a/vm/regexp.go
+++ b/vm/regexp.go
@@ -45,23 +45,22 @@ func builtInRegexpClassMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
-					}
-
-					arg, ok := args[0].(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
-					}
-
-					r := t.vm.initRegexpObject(args[0].toString())
-					if r == nil {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Invalid regexp: %v", args[0].toString())
-					}
-					return r
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
 				}
+
+				arg, ok := args[0].(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
+				}
+
+				r := t.vm.initRegexpObject(args[0].toString())
+				if r == nil {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Invalid regexp: %v", args[0].toString())
+				}
+				return r
+
 			},
 		},
 	}
@@ -87,25 +86,24 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 			// @param regexp [Regexp]
 			// @return [Boolean]
 			Name: "==",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
-					}
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+				}
 
-					right, ok := args[0].(*RegexpObject)
-					if !ok {
-						return FALSE
-					}
-
-					left := receiver.(*RegexpObject)
-
-					if left.Value() == right.Value() {
-						return TRUE
-					}
+				right, ok := args[0].(*RegexpObject)
+				if !ok {
 					return FALSE
 				}
+
+				left := receiver.(*RegexpObject)
+
+				if left.Value() == right.Value() {
+					return TRUE
+				}
+				return FALSE
+
 			},
 		},
 		{
@@ -120,24 +118,23 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 			// @param string [String]
 			// @return [Boolean]
 			Name: "match?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
-					}
-
-					arg := args[0]
-					input, ok := arg.(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
-					}
-
-					re := receiver.(*RegexpObject).regexp
-					m, _ := re.MatchString(input.value)
-
-					return toBooleanObject(m)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
 				}
+
+				arg := args[0]
+				input, ok := arg.(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, arg.Class().Name)
+				}
+
+				re := receiver.(*RegexpObject).regexp
+				m, _ := re.MatchString(input.value)
+
+				return toBooleanObject(m)
+
 			},
 		},
 	}

--- a/vm/string.go
+++ b/vm/string.go
@@ -49,41 +49,39 @@ func builtinStringClassMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "fmt",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) < 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect at least 1 argument. got=%v", strconv.Itoa(len(args)))
-					}
-
-					formatObj, ok := args[0].(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
-					}
-
-					format := formatObj.value
-					arguments := []interface{}{}
-
-					for _, arg := range args[1:] {
-						arguments = append(arguments, arg.toString())
-					}
-
-					count := strings.Count(format, "%s")
-
-					if len(args[1:]) != count {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect %d string arguments. got=%d", count, len(args[1:]))
-					}
-
-					return t.vm.InitStringObject(fmt.Sprintf(format, arguments...))
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) < 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect at least 1 argument. got=%v", strconv.Itoa(len(args)))
 				}
+
+				formatObj, ok := args[0].(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+				}
+
+				format := formatObj.value
+				arguments := []interface{}{}
+
+				for _, arg := range args[1:] {
+					arguments = append(arguments, arg.toString())
+				}
+
+				count := strings.Count(format, "%s")
+
+				if len(args[1:]) != count {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect %d string arguments. got=%d", count, len(args[1:]))
+				}
+
+				return t.vm.InitStringObject(fmt.Sprintf(format, arguments...))
+
 			},
 		},
 		{
 			Name: "new",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				return t.vm.initUnsupportedMethodError(sourceLine, "#new", receiver)
+
 			},
 		},
 	}
@@ -102,20 +100,19 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "+",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					leftValue := receiver.(*StringObject).value
-					r := args[0]
-					right, ok := r.(*StringObject)
+				leftValue := receiver.(*StringObject).value
+				r := args[0]
+				right, ok := r.(*StringObject)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
-					}
-
-					rightValue := right.value
-					return t.vm.InitStringObject(leftValue + rightValue)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
 				}
+
+				rightValue := right.value
+				return t.vm.InitStringObject(leftValue + rightValue)
+
 			},
 		},
 		{
@@ -127,29 +124,28 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "*",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					leftValue := receiver.(*StringObject).value
-					r := args[0]
-					right, ok := r.(*IntegerObject)
+				leftValue := receiver.(*StringObject).value
+				r := args[0]
+				right, ok := r.(*IntegerObject)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, r.Class().Name)
-					}
-
-					if right.value < 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Second argument must be greater than or equal to 0. got=%v", right.value)
-					}
-
-					var result string
-
-					for i := 0; i < right.value; i++ {
-						result += leftValue
-					}
-
-					return t.vm.InitStringObject(result)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, r.Class().Name)
 				}
+
+				if right.value < 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Second argument must be greater than or equal to 0. got=%v", right.value)
+				}
+
+				var result string
+
+				for i := 0; i < right.value; i++ {
+					result += leftValue
+				}
+
+				return t.vm.InitStringObject(result)
+
 			},
 		},
 		{
@@ -161,25 +157,24 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: ">",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					leftValue := receiver.(*StringObject).value
-					r := args[0]
-					right, ok := r.(*StringObject)
+				leftValue := receiver.(*StringObject).value
+				r := args[0]
+				right, ok := r.(*StringObject)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
-					}
-
-					rightValue := right.value
-
-					if leftValue > rightValue {
-						return TRUE
-					}
-
-					return FALSE
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
 				}
+
+				rightValue := right.value
+
+				if leftValue > rightValue {
+					return TRUE
+				}
+
+				return FALSE
+
 			},
 		},
 		{
@@ -191,25 +186,24 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "<",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					leftValue := receiver.(*StringObject).value
-					r := args[0]
-					right, ok := r.(*StringObject)
+				leftValue := receiver.(*StringObject).value
+				r := args[0]
+				right, ok := r.(*StringObject)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
-					}
-
-					rightValue := right.value
-
-					if leftValue < rightValue {
-						return TRUE
-					}
-
-					return FALSE
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
 				}
+
+				rightValue := right.value
+
+				if leftValue < rightValue {
+					return TRUE
+				}
+
+				return FALSE
+
 			},
 		},
 		{
@@ -222,25 +216,24 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "==",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					leftValue := receiver.(*StringObject).value
-					r := args[0]
-					right, ok := r.(*StringObject)
+				leftValue := receiver.(*StringObject).value
+				r := args[0]
+				right, ok := r.(*StringObject)
 
-					if !ok {
-						return FALSE
-					}
-
-					rightValue := right.value
-
-					if leftValue == rightValue {
-						return TRUE
-					}
-
+				if !ok {
 					return FALSE
 				}
+
+				rightValue := right.value
+
+				if leftValue == rightValue {
+					return TRUE
+				}
+
+				return FALSE
+
 			},
 		},
 		{
@@ -253,32 +246,31 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "=~",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
-					}
-
-					arg := args[0]
-
-					re, ok := arg.(*RegexpObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.RegexpClass, arg.Class().Name)
-					}
-
-					text := receiver.(*StringObject).value
-
-					match, _ := re.regexp.FindStringMatch(text)
-
-					if match == nil {
-						return NULL
-					}
-
-					position := match.Groups()[0].Captures[0].Index
-
-					return t.vm.InitIntegerObject(position)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
 				}
+
+				arg := args[0]
+
+				re, ok := arg.(*RegexpObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.RegexpClass, arg.Class().Name)
+				}
+
+				text := receiver.(*StringObject).value
+
+				match, _ := re.regexp.FindStringMatch(text)
+
+				if match == nil {
+					return NULL
+				}
+
+				position := match.Groups()[0].Captures[0].Index
+
+				return t.vm.InitIntegerObject(position)
+
 			},
 		},
 		{
@@ -293,28 +285,27 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "<=>",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					leftValue := receiver.(*StringObject).value
-					r := args[0]
-					right, ok := r.(*StringObject)
+				leftValue := receiver.(*StringObject).value
+				r := args[0]
+				right, ok := r.(*StringObject)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
-					}
-
-					rightValue := right.value
-
-					if leftValue < rightValue {
-						return t.vm.InitIntegerObject(-1)
-					}
-					if leftValue > rightValue {
-						return t.vm.InitIntegerObject(1)
-					}
-
-					return t.vm.InitIntegerObject(0)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
 				}
+
+				rightValue := right.value
+
+				if leftValue < rightValue {
+					return t.vm.InitIntegerObject(-1)
+				}
+				if leftValue > rightValue {
+					return t.vm.InitIntegerObject(1)
+				}
+
+				return t.vm.InitIntegerObject(0)
+
 			},
 		},
 		{
@@ -327,24 +318,23 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "!=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					leftValue := receiver.(*StringObject).value
-					right, ok := args[0].(*StringObject)
+				leftValue := receiver.(*StringObject).value
+				right, ok := args[0].(*StringObject)
 
-					if !ok {
-						return TRUE
-					}
-
-					rightValue := right.value
-
-					if leftValue != rightValue {
-						return TRUE
-					}
-
-					return FALSE
+				if !ok {
+					return TRUE
 				}
+
+				rightValue := right.value
+
+				if leftValue != rightValue {
+					return TRUE
+				}
+
+				return FALSE
+
 			},
 		},
 		{
@@ -363,62 +353,61 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "[]",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+				}
 
-					str := receiver.(*StringObject).value
-					i := args[0]
+				str := receiver.(*StringObject).value
+				i := args[0]
 
-					switch index := i.(type) {
-					case *IntegerObject:
-						indexValue := index.value
+				switch index := i.(type) {
+				case *IntegerObject:
+					indexValue := index.value
 
-						if indexValue < 0 {
-							strLength := utf8.RuneCountInString(str)
-							if -indexValue > strLength {
-								return NULL
-							}
-							return t.vm.InitStringObject(string([]rune(str)[strLength+indexValue]))
-						}
-
-						if len(str) > indexValue {
-							return t.vm.InitStringObject(string([]rune(str)[indexValue]))
-						}
-
-						return NULL
-					case *RangeObject:
+					if indexValue < 0 {
 						strLength := utf8.RuneCountInString(str)
-						start := index.Start
-						end := index.End
-
-						if start < 0 {
-							start = strLength + start
-
-							if start < 0 {
-								return NULL
-							}
-						}
-
-						if end < 0 {
-							end = strLength + end
-						}
-
-						if start > strLength {
+						if -indexValue > strLength {
 							return NULL
 						}
-
-						if end >= strLength {
-							end = strLength - 1
-						}
-
-						return t.vm.InitStringObject(string([]rune(str)[start : end+1]))
-					default:
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
+						return t.vm.InitStringObject(string([]rune(str)[strLength+indexValue]))
 					}
+
+					if len(str) > indexValue {
+						return t.vm.InitStringObject(string([]rune(str)[indexValue]))
+					}
+
+					return NULL
+				case *RangeObject:
+					strLength := utf8.RuneCountInString(str)
+					start := index.Start
+					end := index.End
+
+					if start < 0 {
+						start = strLength + start
+
+						if start < 0 {
+							return NULL
+						}
+					}
+
+					if end < 0 {
+						end = strLength + end
+					}
+
+					if start > strLength {
+						return NULL
+					}
+
+					if end >= strLength {
+						end = strLength - 1
+					}
+
+					return t.vm.InitStringObject(string([]rune(str)[start : end+1]))
+				default:
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
 				}
+
 			},
 		},
 		{
@@ -439,51 +428,50 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "[]=",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 2 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got=%v", strconv.Itoa(len(args)))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got=%v", strconv.Itoa(len(args)))
+				}
 
-					str := receiver.(*StringObject).value
-					i := args[0]
-					index, ok := i.(*IntegerObject)
+				str := receiver.(*StringObject).value
+				i := args[0]
+				index, ok := i.(*IntegerObject)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
-					}
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
+				}
 
-					indexValue := index.value
-					strLength := utf8.RuneCountInString(str)
+				indexValue := index.value
+				strLength := utf8.RuneCountInString(str)
 
-					if strLength < indexValue {
+				if strLength < indexValue {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Index value out of range. got=%v", strconv.Itoa(indexValue))
+				}
+
+				r := args[1]
+				replaceStr, ok := r.(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
+				}
+				replaceStrValue := replaceStr.value
+
+				// Negative Index Case
+				if indexValue < 0 {
+					if -indexValue > strLength {
 						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Index value out of range. got=%v", strconv.Itoa(indexValue))
 					}
-
-					r := args[1]
-					replaceStr, ok := r.(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, r.Class().Name)
-					}
-					replaceStrValue := replaceStr.value
-
-					// Negative Index Case
-					if indexValue < 0 {
-						if -indexValue > strLength {
-							return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Index value out of range. got=%v", strconv.Itoa(indexValue))
-						}
-						// Change to positive index to replace the string
-						indexValue += strLength
-					}
-
-					if strLength == indexValue {
-						return t.vm.InitStringObject(str + replaceStrValue)
-					}
-					// Using rune type to support UTF-8 encoding to replace character
-					result := string([]rune(str)[:indexValue]) + replaceStrValue + string([]rune(str)[indexValue+1:])
-					return t.vm.InitStringObject(result)
+					// Change to positive index to replace the string
+					indexValue += strLength
 				}
+
+				if strLength == indexValue {
+					return t.vm.InitStringObject(str + replaceStrValue)
+				}
+				// Using rune type to support UTF-8 encoding to replace character
+				result := string([]rune(str)[:indexValue]) + replaceStrValue + string([]rune(str)[indexValue+1:])
+				return t.vm.InitStringObject(result)
+
 			},
 		},
 		{
@@ -498,16 +486,15 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "capitalize",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject).value
-					start := string([]rune(str)[0])
-					rest := string([]rune(str)[1:])
-					result := strings.ToUpper(start) + strings.ToLower(rest)
+				str := receiver.(*StringObject).value
+				start := string([]rune(str)[0])
+				rest := string([]rune(str)[1:])
+				result := strings.ToUpper(start) + strings.ToLower(rest)
 
-					return t.vm.InitStringObject(result)
-				}
+				return t.vm.InitStringObject(result)
+
 			},
 		},
 		{
@@ -521,15 +508,14 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "chop",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject).value
-					strLength := utf8.RuneCountInString(str)
+				str := receiver.(*StringObject).value
+				strLength := utf8.RuneCountInString(str)
 
-					// Support UTF-8 Encoding
-					return t.vm.InitStringObject(string([]rune(str)[:strLength-1]))
-				}
+				// Support UTF-8 Encoding
+				return t.vm.InitStringObject(string([]rune(str)[:strLength-1]))
+
 			},
 		},
 		{
@@ -542,22 +528,21 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "concat",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
-					}
-
-					str := receiver.(*StringObject).value
-					c := args[0]
-					concatStr, ok := c.(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
-					}
-
-					return t.vm.InitStringObject(str + concatStr.value)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 				}
+
+				str := receiver.(*StringObject).value
+				c := args[0]
+				concatStr, ok := c.(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
+				}
+
+				return t.vm.InitStringObject(str + concatStr.value)
+
 			},
 		},
 		{
@@ -572,14 +557,13 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "count",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject).value
+				str := receiver.(*StringObject).value
 
-					// Support UTF-8 Encoding
-					return t.vm.InitIntegerObject(utf8.RuneCountInString(str))
-				}
+				// Support UTF-8 Encoding
+				return t.vm.InitIntegerObject(utf8.RuneCountInString(str))
+
 			},
 		},
 		{
@@ -594,22 +578,21 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "delete",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
-					}
-
-					str := receiver.(*StringObject).value
-					d := args[0]
-					deleteStr, ok := d.(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, d.Class().Name)
-					}
-
-					return t.vm.InitStringObject(strings.Replace(str, deleteStr.value, "", -1))
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 				}
+
+				str := receiver.(*StringObject).value
+				d := args[0]
+				deleteStr, ok := d.(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, d.Class().Name)
+				}
+
+				return t.vm.InitStringObject(strings.Replace(str, deleteStr.value, "", -1))
+
 			},
 		},
 		{
@@ -622,13 +605,12 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "downcase",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject).value
+				str := receiver.(*StringObject).value
 
-					return t.vm.InitStringObject(strings.ToLower(str))
-				}
+				return t.vm.InitStringObject(strings.ToLower(str))
+
 			},
 		},
 		{
@@ -652,26 +634,25 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "each_byte",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
+				}
 
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
-					str := receiver.(*StringObject).value
-					if blockIsEmpty(blockFrame) {
-						return t.vm.InitStringObject(str)
-					}
-
-					for _, byte := range []byte(str) {
-						t.builtinMethodYield(blockFrame, t.vm.InitIntegerObject(int(byte)))
-					}
-
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
+				}
+				str := receiver.(*StringObject).value
+				if blockIsEmpty(blockFrame) {
 					return t.vm.InitStringObject(str)
 				}
+
+				for _, byte := range []byte(str) {
+					t.builtinMethodYield(blockFrame, t.vm.InitIntegerObject(int(byte)))
+				}
+
+				return t.vm.InitStringObject(str)
+
 			},
 		},
 		{
@@ -692,27 +673,26 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "each_char",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
+				}
 
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
+				}
 
-					str := receiver.(*StringObject).value
-					if blockIsEmpty(blockFrame) {
-						return t.vm.InitStringObject(str)
-					}
-
-					for _, char := range []rune(str) {
-						t.builtinMethodYield(blockFrame, t.vm.InitStringObject(string(char)))
-					}
-
+				str := receiver.(*StringObject).value
+				if blockIsEmpty(blockFrame) {
 					return t.vm.InitStringObject(str)
 				}
+
+				for _, char := range []rune(str) {
+					t.builtinMethodYield(blockFrame, t.vm.InitStringObject(string(char)))
+				}
+
+				return t.vm.InitStringObject(str)
+
 			},
 		},
 		{
@@ -729,28 +709,27 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "each_line",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
+				}
 
-					if blockFrame == nil {
-						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-					}
+				if blockFrame == nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
+				}
 
-					str := receiver.(*StringObject).value
-					if blockIsEmpty(blockFrame) {
-						return t.vm.InitStringObject(str)
-					}
-					lineArray := strings.Split(str, "\n")
-
-					for _, line := range lineArray {
-						t.builtinMethodYield(blockFrame, t.vm.InitStringObject(line))
-					}
-
+				str := receiver.(*StringObject).value
+				if blockIsEmpty(blockFrame) {
 					return t.vm.InitStringObject(str)
 				}
+				lineArray := strings.Split(str, "\n")
+
+				for _, line := range lineArray {
+					t.builtinMethodYield(blockFrame, t.vm.InitStringObject(line))
+				}
+
+				return t.vm.InitStringObject(str)
+
 			},
 		},
 		{
@@ -763,16 +742,15 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "empty?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject).value
+				str := receiver.(*StringObject).value
 
-					if str == "" {
-						return TRUE
-					}
-					return FALSE
+				if str == "" {
+					return TRUE
 				}
+				return FALSE
+
 			},
 		},
 		{
@@ -787,33 +765,32 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "end_with?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				}
 
-					str := receiver.(*StringObject).value
-					c := args[0]
-					compareStr, ok := c.(*StringObject)
+				str := receiver.(*StringObject).value
+				c := args[0]
+				compareStr, ok := c.(*StringObject)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
-					}
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
+				}
 
-					compareStrValue := compareStr.value
-					compareStrLength := utf8.RuneCountInString(compareStrValue)
-					strLength := utf8.RuneCountInString(str)
+				compareStrValue := compareStr.value
+				compareStrLength := utf8.RuneCountInString(compareStrValue)
+				strLength := utf8.RuneCountInString(str)
 
-					if compareStrLength > strLength {
-						return FALSE
-					}
-
-					if compareStrValue == string([]rune(str)[strLength-compareStrLength:]) {
-						return TRUE
-					}
+				if compareStrLength > strLength {
 					return FALSE
 				}
+
+				if compareStrValue == string([]rune(str)[strLength-compareStrLength:]) {
+					return TRUE
+				}
+				return FALSE
+
 			},
 		},
 		{
@@ -827,22 +804,21 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "eql?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
-					}
-
-					str := receiver.(*StringObject).value
-					compareStr, ok := args[0].(*StringObject)
-
-					if !ok {
-						return FALSE
-					} else if compareStr.value == str {
-						return TRUE
-					}
-					return FALSE
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 				}
+
+				str := receiver.(*StringObject).value
+				compareStr, ok := args[0].(*StringObject)
+
+				if !ok {
+					return FALSE
+				} else if compareStr.value == str {
+					return TRUE
+				}
+				return FALSE
+
 			},
 		},
 		{
@@ -855,26 +831,25 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Bool]
 			Name: "include?",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
-					}
-
-					str := receiver.(*StringObject).value
-					i := args[0]
-					includeStr, ok := i.(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
-					}
-
-					if strings.Contains(str, includeStr.value) {
-						return TRUE
-					}
-
-					return FALSE
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 				}
+
+				str := receiver.(*StringObject).value
+				i := args[0]
+				includeStr, ok := i.(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
+				}
+
+				if strings.Contains(str, includeStr.value) {
+					return TRUE
+				}
+
+				return FALSE
+
 			},
 		},
 		{
@@ -895,46 +870,45 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "insert",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 2 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got=%d", len(args))
-					}
-
-					str := receiver.(*StringObject).value
-					i := args[0]
-					index, ok := i.(*IntegerObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
-					}
-
-					indexValue := index.value
-					ins := args[1]
-					insertStr, ok := ins.(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect insert string to be String. got: %s", ins.Class().Name)
-					}
-					strLength := utf8.RuneCountInString(str)
-
-					if indexValue < 0 {
-						if -indexValue > strLength+1 {
-							return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Index value out of range. got=%v", indexValue)
-						} else if -indexValue == strLength+1 {
-							return t.vm.InitStringObject(insertStr.value + str)
-						}
-						// Change it to positive index value to replace the string via index
-						indexValue += strLength
-					}
-
-					if strLength < indexValue {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Index value out of range. got=%v", indexValue)
-					}
-
-					// Support UTF-8 Encoding
-					return t.vm.InitStringObject(string([]rune(str)[:indexValue]) + insertStr.value + string([]rune(str)[indexValue:]))
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got=%d", len(args))
 				}
+
+				str := receiver.(*StringObject).value
+				i := args[0]
+				index, ok := i.(*IntegerObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
+				}
+
+				indexValue := index.value
+				ins := args[1]
+				insertStr, ok := ins.(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect insert string to be String. got: %s", ins.Class().Name)
+				}
+				strLength := utf8.RuneCountInString(str)
+
+				if indexValue < 0 {
+					if -indexValue > strLength+1 {
+						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Index value out of range. got=%v", indexValue)
+					} else if -indexValue == strLength+1 {
+						return t.vm.InitStringObject(insertStr.value + str)
+					}
+					// Change it to positive index value to replace the string via index
+					indexValue += strLength
+				}
+
+				if strLength < indexValue {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Index value out of range. got=%v", indexValue)
+				}
+
+				// Support UTF-8 Encoding
+				return t.vm.InitStringObject(string([]rune(str)[:indexValue]) + insertStr.value + string([]rune(str)[indexValue:]))
+
 			},
 		},
 		{
@@ -949,14 +923,13 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "length",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject).value
+				str := receiver.(*StringObject).value
 
-					// Support UTF-8 Encoding
-					return t.vm.InitIntegerObject(utf8.RuneCountInString(str))
-				}
+				// Support UTF-8 Encoding
+				return t.vm.InitIntegerObject(utf8.RuneCountInString(str))
+
 			},
 		},
 		{
@@ -975,50 +948,49 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "ljust",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 && len(args) != 2 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 && len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
+				}
 
-					str := receiver.(*StringObject).value
+				str := receiver.(*StringObject).value
 
-					l := args[0]
-					strLength, ok := l.(*IntegerObject)
+				l := args[0]
+				strLength, ok := l.(*IntegerObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect justify width to be Integer. got: %s", l.Class().Name)
+				}
+
+				strLengthValue := strLength.value
+
+				var padStrValue string
+				if len(args) == 1 {
+					padStrValue = " "
+				} else {
+					p := args[1]
+					padStr, ok := p.(*StringObject)
 
 					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect justify width to be Integer. got: %s", l.Class().Name)
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect padding string to be String. got: %s", p.Class().Name)
 					}
 
-					strLengthValue := strLength.value
-
-					var padStrValue string
-					if len(args) == 1 {
-						padStrValue = " "
-					} else {
-						p := args[1]
-						padStr, ok := p.(*StringObject)
-
-						if !ok {
-							return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect padding string to be String. got: %s", p.Class().Name)
-						}
-
-						padStrValue = padStr.value
-					}
-
-					currentStrLength := utf8.RuneCountInString(str)
-					padStrLength := utf8.RuneCountInString(padStrValue)
-
-					if strLengthValue > currentStrLength {
-						for i := currentStrLength; i < strLengthValue; i += padStrLength {
-							str += padStrValue
-						}
-						str = string([]rune(str)[:strLengthValue])
-					}
-
-					// Support UTF-8 Encoding
-					return t.vm.InitStringObject(str)
+					padStrValue = padStr.value
 				}
+
+				currentStrLength := utf8.RuneCountInString(str)
+				padStrLength := utf8.RuneCountInString(padStrValue)
+
+				if strLengthValue > currentStrLength {
+					for i := currentStrLength; i < strLengthValue; i += padStrLength {
+						str += padStrValue
+					}
+					str = string([]rune(str)[:strLengthValue])
+				}
+
+				// Support UTF-8 Encoding
+				return t.vm.InitStringObject(str)
+
 			},
 		},
 		{
@@ -1032,30 +1004,29 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @param string [Regexp]
 			// @return [MatchData]
 			Name: "match",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
-					}
-
-					arg := args[0]
-					regexpObj, ok := arg.(*RegexpObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.RegexpClass, arg.Class().Name)
-					}
-
-					re := regexpObj.regexp
-					text := receiver.(*StringObject).value
-
-					match, _ := re.FindStringMatch(text)
-
-					if match == nil {
-						return NULL
-					}
-
-					return t.vm.initMatchDataObject(match, re.String(), text)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
 				}
+
+				arg := args[0]
+				regexpObj, ok := arg.(*RegexpObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.RegexpClass, arg.Class().Name)
+				}
+
+				re := regexpObj.regexp
+				text := receiver.(*StringObject).value
+
+				match, _ := re.FindStringMatch(text)
+
+				if match == nil {
+					return NULL
+				}
+
+				return t.vm.initMatchDataObject(match, re.String(), text)
+
 			},
 		},
 		{
@@ -1076,36 +1047,35 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @param [String/Regexp] the old string or regexp, [String] the new string
 			// @return [String]
 			Name: "replace",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 2 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got=%v", len(args))
-					}
-					r := args[1]
-					replacement, ok := r.(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect replacement to be String. got: %s", r.Class().Name)
-					}
-
-					var result string
-					var err error
-					target := receiver.(*StringObject).value
-					switch args[0].(type) {
-					case *StringObject:
-						pattern := args[0].(*StringObject)
-						result = strings.Replace(target, pattern.value, replacement.value, -1)
-					case *RegexpObject:
-						pattern := args[0].(*RegexpObject)
-						result, err = pattern.regexp.Replace(target, replacement.value, 0, -1)
-						if err != nil {
-							return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Replacement failure with the Regexp. got: %s", args[0].Class().Name)
-						}
-					default:
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect pattern to be String or Regexp. got: %s", args[0].Class().Name)
-					}
-
-					return t.vm.InitStringObject(result)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got=%v", len(args))
 				}
+				r := args[1]
+				replacement, ok := r.(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect replacement to be String. got: %s", r.Class().Name)
+				}
+
+				var result string
+				var err error
+				target := receiver.(*StringObject).value
+				switch args[0].(type) {
+				case *StringObject:
+					pattern := args[0].(*StringObject)
+					result = strings.Replace(target, pattern.value, replacement.value, -1)
+				case *RegexpObject:
+					pattern := args[0].(*RegexpObject)
+					result, err = pattern.regexp.Replace(target, replacement.value, 0, -1)
+					if err != nil {
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Replacement failure with the Regexp. got: %s", args[0].Class().Name)
+					}
+				default:
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect pattern to be String or Regexp. got: %s", args[0].Class().Name)
+				}
+
+				return t.vm.InitStringObject(result)
+
 			},
 		},
 		{
@@ -1124,36 +1094,35 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @param [String/Regexp] the old string or regexp, [String] the new string
 			// @return [String]
 			Name: "replace_once",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 2 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got=%v", len(args))
-					}
-					r := args[1]
-					replacement, ok := r.(*StringObject)
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect replacement to be String. got: %s", r.Class().Name)
-					}
-
-					var result string
-					var err error
-					target := receiver.(*StringObject).value
-					switch args[0].(type) {
-					case *StringObject:
-						pattern := args[0].(*StringObject)
-						result = strings.Replace(target, pattern.value, replacement.value, 1)
-					case *RegexpObject:
-						pattern := args[0].(*RegexpObject)
-						result, err = pattern.regexp.Replace(target, replacement.value, 0, 1)
-						if err != nil {
-							return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Replacement failure with the Regexp. got: %s", args[0].Class().Name)
-						}
-					default:
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect pattern to be String or Regexp. got: %s", args[0].Class().Name)
-					}
-
-					return t.vm.InitStringObject(result)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got=%v", len(args))
 				}
+				r := args[1]
+				replacement, ok := r.(*StringObject)
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect replacement to be String. got: %s", r.Class().Name)
+				}
+
+				var result string
+				var err error
+				target := receiver.(*StringObject).value
+				switch args[0].(type) {
+				case *StringObject:
+					pattern := args[0].(*StringObject)
+					result = strings.Replace(target, pattern.value, replacement.value, 1)
+				case *RegexpObject:
+					pattern := args[0].(*RegexpObject)
+					result, err = pattern.regexp.Replace(target, replacement.value, 0, 1)
+					if err != nil {
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Replacement failure with the Regexp. got: %s", args[0].Class().Name)
+					}
+				default:
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect pattern to be String or Regexp. got: %s", args[0].Class().Name)
+				}
+
+				return t.vm.InitStringObject(result)
+
 			},
 		},
 		{
@@ -1168,19 +1137,18 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "reverse",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject).value
+				str := receiver.(*StringObject).value
 
-					var revert string
-					for i := utf8.RuneCountInString(str) - 1; i >= 0; i-- {
-						revert += string([]rune(str)[i])
-					}
-
-					// Support UTF-8 Encoding
-					return t.vm.InitStringObject(revert)
+				var revert string
+				for i := utf8.RuneCountInString(str) - 1; i >= 0; i-- {
+					revert += string([]rune(str)[i])
 				}
+
+				// Support UTF-8 Encoding
+				return t.vm.InitStringObject(revert)
+
 			},
 		},
 		{
@@ -1199,54 +1167,53 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "rjust",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 && len(args) != 2 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 && len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
+				}
 
-					str := receiver.(*StringObject).value
-					l := args[0]
-					strLength, ok := l.(*IntegerObject)
+				str := receiver.(*StringObject).value
+				l := args[0]
+				strLength, ok := l.(*IntegerObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect justify width to be Integer. got: %s", l.Class().Name)
+				}
+
+				strLengthValue := strLength.value
+
+				var padStrValue string
+				if len(args) == 1 {
+					padStrValue = " "
+				} else {
+					p := args[1]
+					padStr, ok := p.(*StringObject)
 
 					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect justify width to be Integer. got: %s", l.Class().Name)
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect padding string to be String. got: %s", p.Class().Name)
 					}
 
-					strLengthValue := strLength.value
-
-					var padStrValue string
-					if len(args) == 1 {
-						padStrValue = " "
-					} else {
-						p := args[1]
-						padStr, ok := p.(*StringObject)
-
-						if !ok {
-							return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect padding string to be String. got: %s", p.Class().Name)
-						}
-
-						padStrValue = padStr.value
-					}
-
-					padStrLength := utf8.RuneCountInString(padStrValue)
-
-					if strLengthValue > len(str) {
-						origin := str
-						originStrLength := utf8.RuneCountInString(origin)
-						for i := originStrLength; i < strLengthValue; i += padStrLength {
-							str = padStrValue + str
-						}
-						currentStrLength := utf8.RuneCountInString(str)
-						if currentStrLength > strLengthValue {
-							chopLength := currentStrLength - strLengthValue
-							str = string([]rune(str)[:currentStrLength-originStrLength-chopLength]) + origin
-						}
-					}
-
-					// Support UTF-8 Encoding
-					return t.vm.InitStringObject(str)
+					padStrValue = padStr.value
 				}
+
+				padStrLength := utf8.RuneCountInString(padStrValue)
+
+				if strLengthValue > len(str) {
+					origin := str
+					originStrLength := utf8.RuneCountInString(origin)
+					for i := originStrLength; i < strLengthValue; i += padStrLength {
+						str = padStrValue + str
+					}
+					currentStrLength := utf8.RuneCountInString(str)
+					if currentStrLength > strLengthValue {
+						chopLength := currentStrLength - strLengthValue
+						str = string([]rune(str)[:currentStrLength-originStrLength-chopLength]) + origin
+					}
+				}
+
+				// Support UTF-8 Encoding
+				return t.vm.InitStringObject(str)
+
 			},
 		},
 		{
@@ -1261,14 +1228,13 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "size",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject).value
+				str := receiver.(*StringObject).value
 
-					// Support UTF-8 Encoding
-					return t.vm.InitIntegerObject(utf8.RuneCountInString(str))
-				}
+				// Support UTF-8 Encoding
+				return t.vm.InitIntegerObject(utf8.RuneCountInString(str))
+
 			},
 		},
 		{
@@ -1310,71 +1276,70 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "slice",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				}
+
+				str := receiver.(*StringObject).value
+				strLength := utf8.RuneCountInString(str)
+
+				// All Case Support UTF-8 Encoding
+				switch args[0].(type) {
+				case *RangeObject:
+					ran := args[0].(*RangeObject)
+					switch {
+					case ran.Start >= 0 && ran.End >= 0:
+						if ran.Start > strLength {
+							return NULL
+						} else if ran.Start > ran.End {
+							return t.vm.InitStringObject("")
+						}
+						return t.vm.InitStringObject(string([]rune(str)[ran.Start : ran.End+1]))
+					case ran.Start < 0 && ran.End >= 0:
+						positiveStart := strLength + ran.Start
+						if -ran.Start > strLength {
+							return NULL
+						} else if positiveStart > ran.End {
+							return t.vm.InitStringObject("")
+						}
+						return t.vm.InitStringObject(string([]rune(str)[positiveStart : ran.End+1]))
+					case ran.Start >= 0 && ran.End < 0:
+						positiveEnd := strLength + ran.End
+						if ran.Start > strLength {
+							return NULL
+						} else if positiveEnd < 0 || ran.Start > positiveEnd {
+							return t.vm.InitStringObject("")
+						}
+						return t.vm.InitStringObject(string([]rune(str)[ran.Start : positiveEnd+1]))
+					default:
+						positiveStart := strLength + ran.Start
+						positiveEnd := strLength + ran.End
+						if positiveStart < 0 {
+							return NULL
+						} else if positiveStart > positiveEnd {
+							return t.vm.InitStringObject("")
+						}
+						return t.vm.InitStringObject(string([]rune(str)[positiveStart : positiveEnd+1]))
 					}
 
-					str := receiver.(*StringObject).value
-					strLength := utf8.RuneCountInString(str)
-
-					// All Case Support UTF-8 Encoding
-					switch args[0].(type) {
-					case *RangeObject:
-						ran := args[0].(*RangeObject)
-						switch {
-						case ran.Start >= 0 && ran.End >= 0:
-							if ran.Start > strLength {
-								return NULL
-							} else if ran.Start > ran.End {
-								return t.vm.InitStringObject("")
-							}
-							return t.vm.InitStringObject(string([]rune(str)[ran.Start : ran.End+1]))
-						case ran.Start < 0 && ran.End >= 0:
-							positiveStart := strLength + ran.Start
-							if -ran.Start > strLength {
-								return NULL
-							} else if positiveStart > ran.End {
-								return t.vm.InitStringObject("")
-							}
-							return t.vm.InitStringObject(string([]rune(str)[positiveStart : ran.End+1]))
-						case ran.Start >= 0 && ran.End < 0:
-							positiveEnd := strLength + ran.End
-							if ran.Start > strLength {
-								return NULL
-							} else if positiveEnd < 0 || ran.Start > positiveEnd {
-								return t.vm.InitStringObject("")
-							}
-							return t.vm.InitStringObject(string([]rune(str)[ran.Start : positiveEnd+1]))
-						default:
-							positiveStart := strLength + ran.Start
-							positiveEnd := strLength + ran.End
-							if positiveStart < 0 {
-								return NULL
-							} else if positiveStart > positiveEnd {
-								return t.vm.InitStringObject("")
-							}
-							return t.vm.InitStringObject(string([]rune(str)[positiveStart : positiveEnd+1]))
-						}
-
-					case *IntegerObject:
-						intValue := args[0].(*IntegerObject).value
-						if intValue < 0 {
-							if -intValue > strLength {
-								return NULL
-							}
-							return t.vm.InitStringObject(string([]rune(str)[strLength+intValue]))
-						}
-						if intValue > strLength-1 {
+				case *IntegerObject:
+					intValue := args[0].(*IntegerObject).value
+					if intValue < 0 {
+						if -intValue > strLength {
 							return NULL
 						}
-						return t.vm.InitStringObject(string([]rune(str)[intValue]))
-
-					default:
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect slice range to be Range or Integer. got: %s", args[0].Class().Name)
+						return t.vm.InitStringObject(string([]rune(str)[strLength+intValue]))
 					}
+					if intValue > strLength-1 {
+						return NULL
+					}
+					return t.vm.InitStringObject(string([]rune(str)[intValue]))
+
+				default:
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect slice range to be Range or Integer. got: %s", args[0].Class().Name)
 				}
+
 			},
 		},
 		{
@@ -1389,29 +1354,28 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Array]
 			Name: "split",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
-					}
-
-					s := args[0]
-					seperator, ok := s.(*StringObject)
-
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, s.Class().Name)
-					}
-
-					str := receiver.(*StringObject).value
-					arr := strings.Split(str, seperator.value)
-
-					var elements []Object
-					for i := 0; i < len(arr); i++ {
-						elements = append(elements, t.vm.InitStringObject(arr[i]))
-					}
-
-					return t.vm.InitArrayObject(elements)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
 				}
+
+				s := args[0]
+				seperator, ok := s.(*StringObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, s.Class().Name)
+				}
+
+				str := receiver.(*StringObject).value
+				arr := strings.Split(str, seperator.value)
+
+				var elements []Object
+				for i := 0; i < len(arr); i++ {
+					elements = append(elements, t.vm.InitStringObject(arr[i]))
+				}
+
+				return t.vm.InitArrayObject(elements)
+
 			},
 		},
 		{
@@ -1426,33 +1390,32 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Boolean]
 			Name: "start_with",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					if len(args) != 1 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
-					}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				}
 
-					str := receiver.(*StringObject).value
-					c := args[0]
-					compareStr, ok := c.(*StringObject)
+				str := receiver.(*StringObject).value
+				c := args[0]
+				compareStr, ok := c.(*StringObject)
 
-					if !ok {
-						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
-					}
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
+				}
 
-					compareStrValue := compareStr.value
-					compareStrLength := utf8.RuneCountInString(compareStrValue)
-					strLength := utf8.RuneCountInString(str)
+				compareStrValue := compareStr.value
+				compareStrLength := utf8.RuneCountInString(compareStrValue)
+				strLength := utf8.RuneCountInString(str)
 
-					if compareStrLength > strLength {
-						return FALSE
-					}
-
-					if compareStrValue == string([]rune(str)[:compareStrLength]) {
-						return TRUE
-					}
+				if compareStrLength > strLength {
 					return FALSE
 				}
+
+				if compareStrValue == string([]rune(str)[:compareStrLength]) {
+					return TRUE
+				}
+				return FALSE
+
 			},
 		},
 		{
@@ -1467,26 +1430,25 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "strip",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject).value
+				str := receiver.(*StringObject).value
 
-					for {
-						str = strings.Trim(str, " ")
+				for {
+					str = strings.Trim(str, " ")
 
-						if strings.HasPrefix(str, "\n") || strings.HasPrefix(str, "\t") || strings.HasPrefix(str, "\r") || strings.HasPrefix(str, "\v") {
-							str = string([]rune(str)[1:])
-							continue
-						}
-						if strings.HasSuffix(str, "\n") || strings.HasSuffix(str, "\t") || strings.HasSuffix(str, "\r") || strings.HasSuffix(str, "\v") {
-							str = string([]rune(str)[:utf8.RuneCountInString(str)-2])
-							continue
-						}
-						break
+					if strings.HasPrefix(str, "\n") || strings.HasPrefix(str, "\t") || strings.HasPrefix(str, "\r") || strings.HasPrefix(str, "\v") {
+						str = string([]rune(str)[1:])
+						continue
 					}
-					return t.vm.InitStringObject(str)
+					if strings.HasSuffix(str, "\n") || strings.HasSuffix(str, "\t") || strings.HasSuffix(str, "\r") || strings.HasSuffix(str, "\v") {
+						str = string([]rune(str)[:utf8.RuneCountInString(str)-2])
+						continue
+					}
+					break
 				}
+				return t.vm.InitStringObject(str)
+
 			},
 		},
 		{
@@ -1499,19 +1461,18 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "to_a",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject)
-					strLength := utf8.RuneCountInString(str.value)
-					elems := []Object{}
+				str := receiver.(*StringObject)
+				strLength := utf8.RuneCountInString(str.value)
+				elems := []Object{}
 
-					for i := 0; i < strLength; i++ {
-						elems = append(elems, t.vm.InitStringObject(string([]rune(str.value)[i])))
-					}
-
-					return t.vm.InitArrayObject(elems)
+				for i := 0; i < strLength; i++ {
+					elems = append(elems, t.vm.InitStringObject(string([]rune(str.value)[i])))
 				}
+
+				return t.vm.InitArrayObject(elems)
+
 			},
 		},
 		{
@@ -1525,22 +1486,21 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "to_d",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%v", strconv.Itoa(len(args)))
-					}
-
-					str := receiver.(*StringObject).value
-
-					de, err := new(Decimal).SetString(str)
-					if err == false {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Invalid numeric string. got=%v", str)
-					}
-
-					return t.vm.initDecimalObject(de)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%v", strconv.Itoa(len(args)))
 				}
+
+				str := receiver.(*StringObject).value
+
+				de, err := new(Decimal).SetString(str)
+				if err == false {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Invalid numeric string. got=%v", str)
+				}
+
+				return t.vm.initDecimalObject(de)
+
 			},
 		},
 		{
@@ -1558,25 +1518,24 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Float]
 			Name: "to_f",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					str := receiver.(*StringObject).value
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				str := receiver.(*StringObject).value
 
-					for i, char := range str {
-						if !unicode.IsSpace(char) {
-							str = str[i:]
-							break
-						}
+				for i, char := range str {
+					if !unicode.IsSpace(char) {
+						str = str[i:]
+						break
 					}
-
-					parsedStr, err := strconv.ParseFloat(str, 64)
-
-					if err != nil {
-						return t.vm.initFloatObject(0)
-					}
-
-					return t.vm.initFloatObject(parsedStr)
 				}
+
+				parsedStr, err := strconv.ParseFloat(str, 64)
+
+				if err != nil {
+					return t.vm.initFloatObject(0)
+				}
+
+				return t.vm.initFloatObject(parsedStr)
+
 			},
 		},
 		{
@@ -1591,34 +1550,33 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [Integer]
 			Name: "to_i",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject).value
-					parsedStr, err := strconv.ParseInt(str, 10, 0)
+				str := receiver.(*StringObject).value
+				parsedStr, err := strconv.ParseInt(str, 10, 0)
 
-					if err == nil {
-						return t.vm.InitIntegerObject(int(parsedStr))
-					}
-
-					var digits string
-					for _, char := range str {
-						if unicode.IsDigit(char) {
-							digits += string(char)
-						} else if unicode.IsSpace(char) && len(digits) == 0 {
-							// do nothing; allow trailing spaces
-						} else {
-							break
-						}
-					}
-
-					if len(digits) > 0 {
-						parsedStr, _ = strconv.ParseInt(digits, 10, 0)
-						return t.vm.InitIntegerObject(int(parsedStr))
-					}
-
-					return t.vm.InitIntegerObject(0)
+				if err == nil {
+					return t.vm.InitIntegerObject(int(parsedStr))
 				}
+
+				var digits string
+				for _, char := range str {
+					if unicode.IsDigit(char) {
+						digits += string(char)
+					} else if unicode.IsSpace(char) && len(digits) == 0 {
+						// do nothing; allow trailing spaces
+					} else {
+						break
+					}
+				}
+
+				if len(digits) > 0 {
+					parsedStr, _ = strconv.ParseInt(digits, 10, 0)
+					return t.vm.InitIntegerObject(int(parsedStr))
+				}
+
+				return t.vm.InitIntegerObject(0)
+
 			},
 		},
 		{
@@ -1630,13 +1588,11 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "to_s",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject).value
+				str := receiver.(*StringObject).value
 
-					return t.vm.InitStringObject(str)
-				}
+				return t.vm.InitStringObject(str)
 			},
 		},
 		{
@@ -1648,22 +1604,19 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			//
 			// @return [String]
 			Name: "upcase",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-					str := receiver.(*StringObject).value
+				str := receiver.(*StringObject).value
 
-					return t.vm.InitStringObject(strings.ToUpper(str))
-				}
+				return t.vm.InitStringObject(strings.ToUpper(str))
+
 			},
 		},
 		{
 			Name: "to_bytes",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					r := receiver.(*StringObject)
-					return t.vm.initGoObject([]byte(r.value))
-				}
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*StringObject)
+				return t.vm.initGoObject([]byte(r.value))
 			},
 		},
 	}

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -346,11 +346,18 @@ func (t *Thread) sendMethod(methodName string, argCount int, blockFrame *normalC
 }
 
 func (t *Thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame, sourceLine int, fileName string) {
-	cf := newGoMethodCallFrame(method.Fn, receiver, method.Name, fileName, sourceLine)
-	cf.sourceLine = sourceLine
-	cf.blockFrame = blockFrame
-	cf.argPtr = receiverPtr + 1
-	cf.argCount = argCount
+	argPtr := receiverPtr + 1
+
+	cf := newGoMethodCallFrame(
+		method.Fn,
+		receiver,
+		argCount,
+		argPtr,
+		method.Name,
+		fileName,
+		sourceLine,
+		blockFrame,
+	)
 
 	t.callFrameStack.push(cf)
 	t.startFromTopFrame()

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -338,8 +338,8 @@ func (t *Thread) sendMethod(methodName string, argCount int, blockFrame *normalC
 
 	switch m := method.(type) {
 	case *MethodObject:
-		callObj := newCallObject(receiver, m, receiverPr, argCount, &bytecode.ArgSet{}, blockFrame, sendCallFrame.SourceLine())
-		t.evalMethodObject(callObj, sourceLine)
+		callObj := newCallObject(receiver, m, receiverPr, argCount, &bytecode.ArgSet{}, blockFrame, 1)
+		t.evalMethodObject(callObj)
 	case *BuiltinMethodObject:
 		t.evalBuiltinMethod(receiver, m, receiverPr, argCount, &bytecode.ArgSet{}, blockFrame, sourceLine, sendCallFrame.FileName())
 	case *Error:
@@ -366,7 +366,7 @@ func (t *Thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject,
 		instance, ok := evaluated.Target.(*RObject)
 		if ok && instance.InitializeMethod != nil {
 			callObj := newCallObject(instance, instance.InitializeMethod, receiverPtr, argCount, argSet, blockFrame, sourceLine)
-			t.evalMethodObject(callObj, sourceLine)
+			t.evalMethodObject(callObj)
 		}
 	}
 
@@ -379,11 +379,12 @@ func (t *Thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject,
 }
 
 // TODO: Move instruction into call object
-func (t *Thread) evalMethodObject(call *callObject, sourceLine int) {
+func (t *Thread) evalMethodObject(call *callObject) {
 	normalParamsCount := call.normalParamsCount()
 	paramTypes := call.paramTypes()
 	paramsCount := len(call.paramTypes())
 	stack := t.Stack.data
+	sourceLine := call.sourceLine
 
 	if call.argCount > paramsCount && !call.method.isSplatArgIncluded() {
 		t.reportArgumentError(sourceLine, paramsCount, call.methodName(), call.argCount, call.receiverPtr)

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -169,7 +169,7 @@ func (t *Thread) evalCallFrame(cf callFrame) {
 		}
 		//fmt.Println("-----------------------")
 		//fmt.Println(t.callFrameStack.inspect())
-		result := cf.method(t, args, cf.blockFrame)
+		result := cf.method(cf.receiver, cf.sourceLine, t, args, cf.blockFrame)
 		t.Stack.Push(&Pointer{Target: result})
 		//fmt.Println(t.callFrameStack.inspect())
 		//fmt.Println("-----------------------")
@@ -353,7 +353,7 @@ func (t *Thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject,
 	oldSourceLine := t.sourceLine
 	t.sourceLine = sl
 
-	cf := newGoMethodCallFrame(method.Fn(receiver, t.sourceLine), method.Name, fileName, t.sourceLine)
+	cf := newGoMethodCallFrame(method.Fn, receiver, method.Name, fileName, t.sourceLine)
 	cf.sourceLine = t.sourceLine
 	cf.blockFrame = blockFrame
 

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -25,6 +25,8 @@ type Thread struct {
 	// theads have an id so they can be looked up in the vm. The main thread is always 0
 	id int64
 
+	sourceLine int
+
 	vm *VM
 }
 
@@ -347,10 +349,14 @@ func (t *Thread) sendMethod(methodName string, argCount int, blockFrame *normalC
 	}
 }
 
-func (t *Thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame, sourceLine int, fileName string) {
-	cf := newGoMethodCallFrame(method.Fn(receiver, sourceLine), method.Name, fileName, sourceLine)
-	cf.sourceLine = sourceLine
+func (t *Thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject, receiverPtr, argCount int, argSet *bytecode.ArgSet, blockFrame *normalCallFrame, sl int, fileName string) {
+	oldSourceLine := t.sourceLine
+	t.sourceLine = sl
+
+	cf := newGoMethodCallFrame(method.Fn(receiver, t.sourceLine), method.Name, fileName, t.sourceLine)
+	cf.sourceLine = t.sourceLine
 	cf.blockFrame = blockFrame
+
 	argPtr := receiverPtr + 1
 
 	for i := 0; i < argCount; i++ {
@@ -365,7 +371,7 @@ func (t *Thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject,
 	if method.Name == "new" && ok {
 		instance, ok := evaluated.Target.(*RObject)
 		if ok && instance.InitializeMethod != nil {
-			callObj := newCallObject(instance, instance.InitializeMethod, receiverPtr, argCount, argSet, blockFrame, sourceLine)
+			callObj := newCallObject(instance, instance.InitializeMethod, receiverPtr, argCount, argSet, blockFrame, t.sourceLine)
 			t.evalMethodObject(callObj)
 		}
 	}
@@ -373,6 +379,7 @@ func (t *Thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject,
 	t.Stack.Set(receiverPtr, evaluated)
 	t.Stack.pointer = argPtr
 
+	t.sourceLine = oldSourceLine
 	if err, ok := evaluated.Target.(*Error); ok {
 		panic(err.Message())
 	}
@@ -384,14 +391,16 @@ func (t *Thread) evalMethodObject(call *callObject) {
 	paramTypes := call.paramTypes()
 	paramsCount := len(call.paramTypes())
 	stack := t.Stack.data
-	sourceLine := call.sourceLine
+
+	oldSourceLine := t.sourceLine
+	t.sourceLine = call.sourceLine
 
 	if call.argCount > paramsCount && !call.method.isSplatArgIncluded() {
-		t.reportArgumentError(sourceLine, paramsCount, call.methodName(), call.argCount, call.receiverPtr)
+		t.reportArgumentError(t.sourceLine, paramsCount, call.methodName(), call.argCount, call.receiverPtr)
 	}
 
 	if normalParamsCount > call.argCount {
-		t.reportArgumentError(sourceLine, normalParamsCount, call.methodName(), call.argCount, call.receiverPtr)
+		t.reportArgumentError(t.sourceLine, normalParamsCount, call.methodName(), call.argCount, call.receiverPtr)
 	}
 
 	// Check if arguments include all the required keys before assign keyword arguments
@@ -400,7 +409,7 @@ func (t *Thread) evalMethodObject(call *callObject) {
 		case bytecode.RequiredKeywordArg:
 			paramName := call.paramNames()[paramIndex]
 			if _, ok := call.hasKeywordArgument(paramName); !ok {
-				t.setErrorObject(call.receiverPtr, call.argPtr(), errors.ArgumentError, sourceLine, "Method %s requires key argument %s", call.methodName(), paramName)
+				t.setErrorObject(call.receiverPtr, call.argPtr(), errors.ArgumentError, t.sourceLine, "Method %s requires key argument %s", call.methodName(), paramName)
 			}
 		}
 	}
@@ -408,7 +417,7 @@ func (t *Thread) evalMethodObject(call *callObject) {
 	err := call.assignKeywordArguments(stack)
 
 	if err != nil {
-		t.setErrorObject(call.receiverPtr, call.argPtr(), errors.ArgumentError, sourceLine, err.Error())
+		t.setErrorObject(call.receiverPtr, call.argPtr(), errors.ArgumentError, t.sourceLine, err.Error())
 	}
 
 	// If given arguments is more than the normal arguments.
@@ -433,6 +442,7 @@ func (t *Thread) evalMethodObject(call *callObject) {
 
 	t.Stack.Set(call.receiverPtr, t.Stack.top())
 	t.Stack.pointer = call.argPtr()
+	t.sourceLine = oldSourceLine
 }
 
 func (t *Thread) reportArgumentError(sourceLine, idealArgNumber int, methodName string, exactArgNumber int, receiverPtr int) {

--- a/vm/uri.go
+++ b/vm/uri.go
@@ -21,84 +21,83 @@ func builtinURIClassMethods() []*BuiltinMethodObject {
 			// u.path # => "/"
 			// ```
 			Name: "parse",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					uri := args[0].(*StringObject).value
-					uriModule := t.vm.topLevelClass("URI")
-					u, err := url.Parse(uri)
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				uri := args[0].(*StringObject).value
+				uriModule := t.vm.topLevelClass("URI")
+				u, err := url.Parse(uri)
+
+				if err != nil {
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
+				}
+
+				uriAttrs := map[string]Object{
+					"@user":     NULL,
+					"@password": NULL,
+					"@query":    NULL,
+					"@path":     t.vm.InitStringObject("/"),
+				}
+
+				// Scheme
+				uriAttrs["@scheme"] = t.vm.InitStringObject(u.Scheme)
+
+				// Host
+				uriAttrs["@host"] = t.vm.InitStringObject(u.Host)
+
+				// Port
+				if len(u.Port()) == 0 {
+					switch u.Scheme {
+					case "http":
+						uriAttrs["@port"] = t.vm.InitIntegerObject(80)
+					case "https":
+						uriAttrs["@port"] = t.vm.InitIntegerObject(443)
+					}
+				} else {
+					p, err := strconv.ParseInt(u.Port(), 0, 64)
 
 					if err != nil {
 						return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
 					}
 
-					uriAttrs := map[string]Object{
-						"@user":     NULL,
-						"@password": NULL,
-						"@query":    NULL,
-						"@path":     t.vm.InitStringObject("/"),
-					}
-
-					// Scheme
-					uriAttrs["@scheme"] = t.vm.InitStringObject(u.Scheme)
-
-					// Host
-					uriAttrs["@host"] = t.vm.InitStringObject(u.Host)
-
-					// Port
-					if len(u.Port()) == 0 {
-						switch u.Scheme {
-						case "http":
-							uriAttrs["@port"] = t.vm.InitIntegerObject(80)
-						case "https":
-							uriAttrs["@port"] = t.vm.InitIntegerObject(443)
-						}
-					} else {
-						p, err := strconv.ParseInt(u.Port(), 0, 64)
-
-						if err != nil {
-							return t.vm.InitErrorObject(errors.InternalError, sourceLine, err.Error())
-						}
-
-						uriAttrs["@port"] = t.vm.InitIntegerObject(int(p))
-					}
-
-					// Path
-					if len(u.Path) != 0 {
-						uriAttrs["@path"] = t.vm.InitStringObject(u.Path)
-					}
-
-					// Query
-					if len(u.RawQuery) != 0 {
-						uriAttrs["@query"] = t.vm.InitStringObject(u.RawQuery)
-					}
-
-					// User
-					if u.User != nil {
-						if len(u.User.Username()) != 0 {
-							uriAttrs["@user"] = t.vm.InitStringObject(u.User.Username())
-						}
-
-						if p, ok := u.User.Password(); ok {
-							uriAttrs["@password"] = t.vm.InitStringObject(p)
-						}
-					}
-
-					var c *RClass
-
-					if u.Scheme == "https" {
-						c = uriModule.getClassConstant("HTTPS")
-					} else {
-						c = uriModule.getClassConstant("HTTP")
-					}
-
-					i := c.initializeInstance()
-
-					for varName, value := range uriAttrs {
-						i.InstanceVariables.set(varName, value)
-					}
-
-					return i
+					uriAttrs["@port"] = t.vm.InitIntegerObject(int(p))
 				}
+
+				// Path
+				if len(u.Path) != 0 {
+					uriAttrs["@path"] = t.vm.InitStringObject(u.Path)
+				}
+
+				// Query
+				if len(u.RawQuery) != 0 {
+					uriAttrs["@query"] = t.vm.InitStringObject(u.RawQuery)
+				}
+
+				// User
+				if u.User != nil {
+					if len(u.User.Username()) != 0 {
+						uriAttrs["@user"] = t.vm.InitStringObject(u.User.Username())
+					}
+
+					if p, ok := u.User.Password(); ok {
+						uriAttrs["@password"] = t.vm.InitStringObject(p)
+					}
+				}
+
+				var c *RClass
+
+				if u.Scheme == "https" {
+					c = uriModule.getClassConstant("HTTPS")
+				} else {
+					c = uriModule.getClassConstant("HTTP")
+				}
+
+				i := c.initializeInstance()
+
+				for varName, value := range uriAttrs {
+					i.InstanceVariables.set(varName, value)
+				}
+
+				return i
+
 			},
 		},
 	}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -203,10 +203,9 @@ func builtinMainObjSingletonMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
 			Name: "to_s",
-			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
-				return func(thread *Thread, objects []Object, frame *normalCallFrame) Object {
-					return thread.vm.InitStringObject("main")
-				}
+			Fn: func(receiver Object, sourceLine int, thread *Thread, objects []Object, frame *normalCallFrame) Object {
+				return thread.vm.InitStringObject("main")
+
 			},
 		},
 	}


### PR DESCRIPTION
Benchmark result:

```
benchmarking abcb9c02399812108599eed08aa31311180a726a
benchmarking 8efae0e78c03469eafa684eeb0ff0dfca837885b
x86_64-linux
benchmark                         old ns/op     new ns/op     delta
BenchmarkBasicMath/add-2          9440          8496          -10.00%
BenchmarkBasicMath/subtract-2     8860          8323          -6.06%
BenchmarkBasicMath/multiply-2     8809          8547          -2.97%
BenchmarkBasicMath/divide-2       8878          8693          -2.08%
benchmark                         old allocs     new allocs     delta
BenchmarkBasicMath/add-2          78             75             -3.85%
BenchmarkBasicMath/subtract-2     78             75             -3.85%
BenchmarkBasicMath/multiply-2     78             75             -3.85%
BenchmarkBasicMath/divide-2       78             75             -3.85%
benchmark                         old bytes     new bytes     delta
BenchmarkBasicMath/add-2          3792          3152          -16.88%
BenchmarkBasicMath/subtract-2     3792          3152          -16.88%
BenchmarkBasicMath/multiply-2     3792          3152          -16.88%
BenchmarkBasicMath/divide-2       3792          3152          -16.88%
```