### PR TITLE
NullObject now converts to a blank string in all the cases

### DIFF
--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -144,7 +144,7 @@ func TestArrayIndex(t *testing.T) {
 			code[102] = 'Processing'
 			code[200] = 'OK'
 			code.to_s
-		`, `[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "Continue", "Switching Protocols", "Processing", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "OK"]`},
+		`, `[, , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , "Continue", "Switching Protocols", "Processing", , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , "OK"]`},
 	}
 
 	for i, tt := range tests {
@@ -1553,7 +1553,7 @@ func TestArrayPushMethod(t *testing.T) {
 			`, "[1, 2, 3, 4, 5, 6, 7]"},
 		{`
 			[].push(nil, "", '').to_s
-	`, `[nil, "", ""]`},
+	`, `[, "", ""]`},
 	}
 
 	for i, tt := range tests {

--- a/vm/concurrent_array_test.go
+++ b/vm/concurrent_array_test.go
@@ -99,7 +99,7 @@ func TestConcurrentArrayIndex(t *testing.T) {
 		code[3] = 'Switching Protocols'
 		code[5] = 'OK'
 		code.to_s
-		`, `[nil, nil, "Continue", "Switching Protocols", nil, "OK"]`},
+		`, `[, , "Continue", "Switching Protocols", , "OK"]`},
 	}
 
 	for i, tt := range tests {

--- a/vm/null.go
+++ b/vm/null.go
@@ -62,6 +62,10 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			Name: "to_s",
 			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
 				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+					if len(args) != 0 {
+						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+					}
+
 					n := receiver.(*NullObject)
 					return t.vm.InitStringObject(n.toString())
 				}

--- a/vm/null.go
+++ b/vm/null.go
@@ -62,7 +62,8 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			Name: "to_s",
 			Fn: func(receiver Object, sourceLine int) builtinMethodBody {
 				return func(t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-					return t.vm.InitStringObject("")
+					n := receiver.(*NullObject)
+					return t.vm.InitStringObject(n.toString())
 				}
 			},
 		},
@@ -152,7 +153,7 @@ func (n *NullObject) Value() interface{} {
 
 // toString returns the object's name as the string format
 func (n *NullObject) toString() string {
-	return "nil"
+	return ""
 }
 
 // toJSON just delegates to toString

--- a/vm/null_test.go
+++ b/vm/null_test.go
@@ -98,6 +98,20 @@ func TestNullTypeConversion(t *testing.T) {
 	}
 }
 
+func TestNullTypeConversionFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`nil.to_s(1)`, "ArgumentError: Expect 0 argument. got: 1", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
 // Method test
 
 func TestNullBangPrefixMethod(t *testing.T) {


### PR DESCRIPTION
Previously, the internal NullObject#toString would convert to `nil`, which is not correct.

Closes #695.

Will need some rework when #698 is implemented.