### PR TITLE
Fix plugin's travis failure 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.vscode
 
 .idea
 
@@ -35,4 +36,5 @@ profile.out
 
 .tmp_benchmarks
 .tmp_benchmark_comparison
-.vscode
+
+vm/plugins

--- a/vm/plugin_integration_test.go
+++ b/vm/plugin_integration_test.go
@@ -73,7 +73,7 @@ func TestPluginGenerationNoRaceDetection(t *testing.T) {
 
 	conn, err = p.go_func("Open", "postgres", "")
 	err = conn.go_func("Ping")
-	!err.nil? && err.go_func("Error").is_a?(String)
+	err.nil?
 	`
 
 	v := initTestVM()


### PR DESCRIPTION
The old test case assumes that we'll get a `pq: SSL is not enabled on the server` error from pinging postgresql. But now on `travis` they supported ssl connection for some reason so there won't be any error messages.