### PR TITLE
Improve error handling

### DIFF
--- a/vm/repl.go
+++ b/vm/repl.go
@@ -1,8 +1,6 @@
 package vm
 
 import (
-	"fmt"
-
 	"github.com/goby-lang/goby/compiler/bytecode"
 )
 
@@ -47,10 +45,11 @@ func (vm *VM) REPLExec(sets []*bytecode.InstructionSet) {
 	vm.mainThread.callFrameStack.push(cf)
 
 	defer func() {
-		_, ok := recover().(*Error)
+		e := recover()
 
-		if !ok && recover() != nil {
-			fmt.Printf("%v\n", recover())
+		switch err := e.(type) {
+		case error:
+			panic(err)
 		}
 	}()
 

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -122,17 +122,16 @@ func (t *Thread) execFile(fpath string) (err error) {
 }
 
 func (t *Thread) startFromTopFrame() {
-	cf := t.callFrameStack.top()
-	t.evalCallFrame(cf)
-}
-
-func (t *Thread) evalCallFrame(cf callFrame) {
 	defer func() {
 		if r := recover(); r != nil {
 			t.reportErrorAndStop(r)
 		}
 	}()
+	cf := t.callFrameStack.top()
+	t.evalCallFrame(cf)
+}
 
+func (t *Thread) evalCallFrame(cf callFrame) {
 	t.currentFrame = cf
 
 	switch cf := cf.(type) {

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -122,27 +121,7 @@ func (t *Thread) execFile(fpath string) (err error) {
 	return
 }
 
-func (t *Thread) captureAndHandlePanic() {
-	switch e := recover().(type) {
-	case *Error:
-		if t.vm.mode == NormalMode {
-			fmt.Println(e.Message())
-			if t.isMainThread() {
-				os.Exit(1)
-			}
-		} else {
-			log.Println(e)
-			panic(e)
-		}
-	case nil:
-		return
-	default:
-		panic(e)
-	}
-}
-
 func (t *Thread) startFromTopFrame() {
-	defer t.captureAndHandlePanic()
 	cf := t.callFrameStack.top()
 	t.evalCallFrame(cf)
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -178,10 +178,13 @@ func (vm *VM) ExecInstructions(sets []*bytecode.InstructionSet, fn string) {
 	vm.mainThread.callFrameStack.push(cf)
 
 	defer func() {
-		err, ok := recover().(*Error)
-
-		if ok && vm.mode == NormalMode {
-			fmt.Println(err.Message())
+		switch err := recover().(type) {
+		case error:
+			panic(err)
+		case *Error:
+			if vm.mode == NormalMode {
+				fmt.Println(err.Message())
+			}
 		}
 	}()
 


### PR DESCRIPTION
I changed the vm's error handling to have the following behaviors:

### Normal mode
- Goby error 
	- return error object 
	- show stack traces
	- exit program with status 1
- Go panic - panic
### Test mode
- Goby error 
	- return error object
- Go panic - panic
### REPL mode
- Goby error
	- return error object
	- show stack traces
- Go panic - panic