### PR TITLE
Unify to CantYieldWithoutBlockFormat

### DIFF
--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -556,7 +556,7 @@ var builtinActions = map[operationType]*action{
 			receiver := t.Stack.data[receiverPr].Target
 
 			if cf.blockFrame == nil {
-				t.pushErrorObject(errors.InternalError, sourceLine, "Can't yield without a block")
+				t.pushErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 			}
 
 			blockFrame := cf.blockFrame


### PR DESCRIPTION
First PR to reduce inconsistent error message literals in Goby's codebase.