### PR TITLE
bugfix: allow more than 5 local variables

### DIFF
--- a/vm/call_frame.go
+++ b/vm/call_frame.go
@@ -128,7 +128,9 @@ func (b *baseFrame) getLCL(index, depth int) (p *Pointer) {
 
 	if depth == 0 {
 		b.RLock()
-		p = b.locals[index]
+		if index < len(b.locals) {
+			p = b.locals[index]
+		}
 		b.RUnlock()
 		return
 	}

--- a/vm/call_frame.go
+++ b/vm/call_frame.go
@@ -128,9 +128,13 @@ func (b *baseFrame) getLCL(index, depth int) (p *Pointer) {
 
 	if depth == 0 {
 		b.RLock()
-		if index < len(b.locals) {
-			p = b.locals[index]
+
+		if index >= len(b.locals) {
+			b.RUnlock()
+			return
 		}
+		p = b.locals[index]
+
 		b.RUnlock()
 		return
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -217,6 +217,26 @@ func TestVM_REPLExecFail(t *testing.T) {
 	}
 }
 
+func TestAutoIncrementLocalVariable(t *testing.T) {
+	input := `
+		a1 = 1
+		a2 = 1
+		a3 = 1
+		a4 = 1
+		a5 = 1
+		# defaults to 5 variables, auto increment must work to set 6th
+		a6 = 10
+		(a1 + a2 + a3 + a4 + a5 + a6).to_s
+	`
+	expected := `15`
+
+	vm := initTestVM()
+	evaluated := vm.testEval(t, input, getFilename())
+	VerifyExpected(t, i, evaluated, expected)
+	vm.checkCFP(t, i, 0)
+	vm.checkSP(t, i, 1)
+}
+
 func TestLoadingGobyLibraryFail(t *testing.T) {
 	vm := initTestVM()
 


### PR DESCRIPTION
Bugfix: allow more than 5 local variables.

The method `insertLCL` auto-expands appropriately, but calls to `getLCL` attempt to read outside the bounds of the current array.

introduced in 8c3addf0f40a4bc71484c9461670e3602419c625