### PR TITLE
Unify argument errors (continue)

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"strings"
 
+	"sort"
+
 	"github.com/goby-lang/goby/vm/classes"
 	"github.com/goby-lang/goby/vm/errors"
-	"sort"
 )
 
 // ArrayObject represents an instance from Array class.
@@ -104,10 +105,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "*",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
-				
+
 				arr := receiver.(*ArrayObject)
 
 				copiesNumber, ok := args[0].(*IntegerObject)
@@ -132,8 +133,8 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "+",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				otherArrayArg := args[0]
@@ -226,10 +227,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 
 				// First argument is an index: there exists two cases which will be described in the following code
 				aLen := len(args)
-				if l, u := 2, 3;l > aLen || u < aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, l, u, aLen)
+				if aLen < 2 || aLen > 3 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, 2, 3, aLen)
 				}
-				
+
 				i := args[0]
 				index, ok := i.(*IntegerObject)
 
@@ -405,10 +406,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "at",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
-				
+
 				arr := receiver.(*ArrayObject)
 				return arr.index(t, args, sourceLine)
 
@@ -426,10 +427,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "clear",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
-				
+
 				arr := receiver.(*ArrayObject)
 				arr.Elements = []Object{}
 
@@ -492,8 +493,8 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Name: "count",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if u := 1; u < aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
+				if aLen > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, 1, aLen)
 				}
 
 				arr := receiver.(*ArrayObject)
@@ -567,10 +568,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "delete_at",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
-				
+
 				i := args[0]
 				index, ok := i.(*IntegerObject)
 
@@ -611,10 +612,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "dig",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if l, aLen := 1, len(args); l > aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, l, aLen)
+				if len(args) < 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, 1, len(args))
 				}
-				
+
 				array := receiver.(*ArrayObject)
 				value := array.dig(t, args, sourceLine)
 
@@ -644,10 +645,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "each",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
-				
+
 				if blockFrame == nil {
 					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
@@ -692,10 +693,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "each_index",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
-				
+
 				if blockFrame == nil {
 					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
@@ -730,10 +731,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "empty?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
-				
+
 				arr := receiver.(*ArrayObject)
 
 				if arr.Len() == 0 {
@@ -759,10 +760,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Name: "first",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if u := 1; u < aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
+				if aLen > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, 1, aLen)
 				}
-				
+
 				arr := receiver.(*ArrayObject)
 				arrLength := len(arr.Elements)
 				if arrLength == 0 {
@@ -806,10 +807,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "flatten",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
-				
+
 				arr := receiver.(*ArrayObject)
 				newElements := arr.flatten()
 
@@ -834,23 +835,23 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Name: "join",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if l, u := 0, 1;l > aLen || u < aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, l, u, aLen)
+				if aLen < 0 || aLen > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, 0, 1, aLen)
 				}
-				
+
 				var sep string
 				if aLen == 0 {
 					sep = ""
 				} else {
 					arg, ok := args[0].(*StringObject)
-					
+
 					if !ok {
 						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 					}
-					
+
 					sep = arg.value
 				}
-				
+
 				arr := receiver.(*ArrayObject)
 				elements := []string{}
 				for _, e := range arr.flatten() {
@@ -876,8 +877,8 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Name: "last",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if u := 1; u < aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
+				if aLen > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, 1, aLen)
 				}
 
 				arr := receiver.(*ArrayObject)
@@ -915,10 +916,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "length",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
-				
+
 				arr := receiver.(*ArrayObject)
 				return t.vm.InitIntegerObject(arr.Len())
 
@@ -989,10 +990,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "pop",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
-				
+
 				arr := receiver.(*ArrayObject)
 				return arr.pop()
 
@@ -1059,8 +1060,8 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Name: "reduce",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if u := 1; u < aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
+				if aLen > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, 1, aLen)
 				}
 				if blockFrame == nil {
 					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
@@ -1108,10 +1109,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "reverse",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
-				
+
 				arr := receiver.(*ArrayObject)
 				return arr.reverse()
 
@@ -1137,10 +1138,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "reverse_each",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
-				
+
 				if blockFrame == nil {
 					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
@@ -1192,10 +1193,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Name: "rotate",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if u := 1; u < aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
+				if aLen > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, 1, aLen)
 				}
-				
+
 				var rotate int
 				arr := receiver.(*ArrayObject)
 				rotArr := t.vm.InitArrayObject(arr.Elements)
@@ -1244,10 +1245,10 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "select",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
-				
+
 				arr := receiver.(*ArrayObject)
 				var elements []Object
 
@@ -1288,8 +1289,8 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "shift",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				arr := receiver.(*ArrayObject)
@@ -1495,10 +1496,10 @@ func (a *ArrayObject) dig(t *Thread, keys []Object, sourceLine int) Object {
 // Retrieves an object in an array using Integer index; common to `[]` and `at()`.
 func (a *ArrayObject) index(t *Thread, args []Object, sourceLine int) Object {
 	aLen := len(args)
-	if l, u := 1, 2;l > aLen || u < aLen {
-		return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, l, u, aLen)
+	if aLen < 1 || aLen > 2 {
+		return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, 1, 2, aLen)
 	}
-	
+
 	i := args[0]
 	index, ok := i.(*IntegerObject)
 	arrLength := a.Len()

--- a/vm/array.go
+++ b/vm/array.go
@@ -492,7 +492,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Name: "count",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if 	u := 1; u < aLen {
+				if u := 1; u < aLen {
 					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
 				}
 
@@ -611,7 +611,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "dig",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if 	l, aLen := 1, len(args); l > aLen {
+				if l, aLen := 1, len(args); l > aLen {
 					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, l, aLen)
 				}
 				
@@ -759,7 +759,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Name: "first",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if 	u := 1; u < aLen {
+				if u := 1; u < aLen {
 					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
 				}
 				
@@ -876,7 +876,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Name: "last",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if 	u := 1; u < aLen {
+				if u := 1; u < aLen {
 					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
 				}
 
@@ -1059,7 +1059,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Name: "reduce",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if 	u := 1; u < aLen {
+				if u := 1; u < aLen {
 					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
 				}
 				if blockFrame == nil {
@@ -1192,7 +1192,7 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 			Name: "rotate",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if 	u := 1; u < aLen {
+				if u := 1; u < aLen {
 					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
 				}
 				

--- a/vm/channel.go
+++ b/vm/channel.go
@@ -138,8 +138,8 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 			// @return [Null]
 			Name: "close",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 				c := receiver.(*ChannelObject)
 
@@ -179,8 +179,8 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "deliver",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 				c := receiver.(*ChannelObject)
 
@@ -217,10 +217,8 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "receive",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					if len(args) != 0 {
-						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
-					}
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 				c := receiver.(*ChannelObject)
 

--- a/vm/channel.go
+++ b/vm/channel.go
@@ -138,9 +138,10 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 			// @return [Null]
 			Name: "close",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
+				
 				c := receiver.(*ChannelObject)
 
 				if c.ChannelState == chClosed {
@@ -179,9 +180,10 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "deliver",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
+				
 				c := receiver.(*ChannelObject)
 
 				if c.ChannelState == chClosed {
@@ -217,9 +219,10 @@ func builtinChannelInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "receive",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
+				
 				c := receiver.(*ChannelObject)
 
 				if c.ChannelState == chClosed {

--- a/vm/class.go
+++ b/vm/class.go
@@ -603,8 +603,8 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @return [String] Converted receiver name
 			Name: "name",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				n, ok := receiver.(*RClass)
@@ -631,8 +631,8 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "respond_to?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				arg, ok := args[0].(*StringObject)
@@ -678,8 +678,8 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @return [Object] Superclass object of the receiver
 			Name: "superclass",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				c, ok := receiver.(*RClass)
@@ -861,7 +861,12 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "exit",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				switch len(args) {
+				aLen := len(args)
+				if u := 1; u < aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
+				}
+				
+				switch aLen {
 				case 0:
 					os.Exit(0)
 				case 1:
@@ -872,8 +877,6 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					os.Exit(exitCode.value)
-				default:
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected at most 1 argument; got: %d", len(args))
 				}
 
 				return NULL
@@ -898,8 +901,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "is_a?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				c := args[0]
@@ -928,8 +931,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "inherits_method_missing?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				if receiver.Class().inheritsMethodMissing {
@@ -943,7 +946,12 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "instance_eval",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				switch len(args) {
+				aLen := len(args)
+				if u := 1; u < aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
+				}
+				
+				switch aLen {
 				case 0:
 				case 1:
 					if args[0].Class().Name == classes.BlockClass {
@@ -955,8 +963,6 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 					} else {
 						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.BlockClass, args[0].Class().Name)
 					}
-				default:
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect at most 1 arguments. got: %d", len(args))
 				}
 
 				if blockFrame == nil {
@@ -993,9 +999,10 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "instance_variable_get",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 arguments. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
+				
 				arg, isStr := args[0].(*StringObject)
 
 				if !isStr {
@@ -1030,8 +1037,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object] value
 			Name: "instance_variable_set",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 2 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got: %d", len(args))
+				if e, aLen := 2, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				argName, isStr := args[0].(*StringObject)
@@ -1092,8 +1099,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "nil?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 				return FALSE
 
@@ -1160,7 +1167,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "raise",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				switch len(args) {
+				aLen := len(args)
+				switch aLen {
 				case 0:
 					return t.vm.InitErrorObject(errors.InternalError, sourceLine, "")
 				case 1:
@@ -1174,8 +1182,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 
 					return t.vm.InitErrorObject(errorClass.Name, sourceLine, "'%s'", args[1].ToString())
 				}
-
-				return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect at most 2 arguments. got: %d", len(args))
+				
+				return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, 2, aLen)
 
 			},
 		},
@@ -1193,8 +1201,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "respond_to?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				arg, ok := args[0].(*StringObject)
@@ -1225,9 +1233,10 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean] Result of loading module
 			Name: "require",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
+				
 				switch args[0].(type) {
 				case *StringObject:
 					libName := args[0].(*StringObject).value
@@ -1273,9 +1282,10 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean] Result of loading module
 			Name: "require_relative",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
+				
 				switch args[0].(type) {
 				case *StringObject:
 					callerDir := path.Dir(t.vm.currentFilePath())
@@ -1388,8 +1398,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer] actual time slept in sec
 			Name: "sleep",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				int, ok := args[0].(*IntegerObject)

--- a/vm/class.go
+++ b/vm/class.go
@@ -603,8 +603,8 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @return [String] Converted receiver name
 			Name: "name",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				n, ok := receiver.(*RClass)
@@ -631,8 +631,8 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "respond_to?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				arg, ok := args[0].(*StringObject)
@@ -678,8 +678,8 @@ func builtinModuleCommonClassMethods() []*BuiltinMethodObject {
 			// @return [Object] Superclass object of the receiver
 			Name: "superclass",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				c, ok := receiver.(*RClass)
@@ -862,10 +862,6 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			Name: "exit",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if u := 1; u < aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
-				}
-				
 				switch aLen {
 				case 0:
 					os.Exit(0)
@@ -877,6 +873,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 					}
 
 					os.Exit(exitCode.value)
+				default:
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, 1, aLen)
 				}
 
 				return NULL
@@ -901,8 +899,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "is_a?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				c := args[0]
@@ -931,8 +929,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "inherits_method_missing?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				if receiver.Class().inheritsMethodMissing {
@@ -947,10 +945,6 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			Name: "instance_eval",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if u := 1; u < aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
-				}
-				
 				switch aLen {
 				case 0:
 				case 1:
@@ -963,6 +957,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 					} else {
 						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.BlockClass, args[0].Class().Name)
 					}
+				default:
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, 1, aLen)
 				}
 
 				if blockFrame == nil {
@@ -999,8 +995,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "instance_variable_get",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 				
 				arg, isStr := args[0].(*StringObject)
@@ -1037,8 +1033,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object] value
 			Name: "instance_variable_set",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 2, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 2, len(args))
 				}
 
 				argName, isStr := args[0].(*StringObject)
@@ -1099,8 +1095,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "nil?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 				return FALSE
 
@@ -1201,8 +1197,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "respond_to?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				arg, ok := args[0].(*StringObject)
@@ -1233,8 +1229,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean] Result of loading module
 			Name: "require",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 				
 				switch args[0].(type) {
@@ -1282,8 +1278,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean] Result of loading module
 			Name: "require_relative",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 				
 				switch args[0].(type) {
@@ -1398,8 +1394,8 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer] actual time slept in sec
 			Name: "sleep",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				int, ok := args[0].(*IntegerObject)

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -171,35 +171,35 @@ func TestClassInstanceVariableFail(t *testing.T) {
 		end
 
 		Bar.instance_variable_get
-		`, "ArgumentError: Expect 1 arguments. got: 0", 1},
+		`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
 		{`
 		class Bar
 		  @foo = 1
 		end
 
 		Bar.instance_variable_get("@foo", 2)
-		`, "ArgumentError: Expect 1 arguments. got: 2", 1},
+		`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 		{`
 		class Bar
 		  @foo = 1
 		end
 
 		Bar.instance_variable_set
-				`, "ArgumentError: Expect 2 arguments. got: 0", 1},
+				`, "ArgumentError: Expect 2 argument(s). got: 0", 1},
 		{`
 		class Bar
 		  @foo = 1
 		end
 
 		Bar.instance_variable_set("@bar")
-				`, "ArgumentError: Expect 2 arguments. got: 1", 1},
+				`, "ArgumentError: Expect 2 argument(s). got: 1", 1},
 		{`
 		class Bar
 		  @foo = 1
 		end
 
 		Bar.instance_variable_set("@bar", 2, 3)
-				`, "ArgumentError: Expect 2 arguments. got: 3", 1},
+				`, "ArgumentError: Expect 2 argument(s). got: 3", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1132,8 +1132,8 @@ func TestRequireMethod(t *testing.T) {
 func TestRequireMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`require "bar"`, `InternalError: Can't require "bar"`, 1},
-		{`require "db", "json"`, `ArgumentError: Expect 1 argument. got: 2`, 1},
-		{`require_relative "db", "json"`, `ArgumentError: Expect 1 argument. got: 2`, 1},
+		{`require "db", "json"`, `ArgumentError: Expect 1 argument(s). got: 2`, 1},
+		{`require_relative "db", "json"`, `ArgumentError: Expect 1 argument(s). got: 2`, 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1186,7 +1186,7 @@ func TestRaiseMethodFail(t *testing.T) {
 		{`raise "Foo", "Bar"`, "ArgumentError: Expect error class, got: String", 1},
 		{`
 		class BarError; end
-		raise BarError, "Foo", "Bar"`, "ArgumentError: Expect at most 2 arguments. got: 3", 1},
+		raise BarError, "Foo", "Bar"`, "ArgumentError: Expect 2 or less argument(s). got: 3", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1198,7 +1198,7 @@ func TestRaiseMethodFail(t *testing.T) {
 	}
 }
 
-func TestResponseToMethod(t *testing.T) {
+func TestRespondToMethod(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected bool
@@ -1228,11 +1228,25 @@ func TestResponseToMethod(t *testing.T) {
 	}
 }
 
+func TestRespondToMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`1.respond_to?`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+	}
+	
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
 // With the current framework, only exit() failures can be tested.
 func TestExitMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`exit("abc")`, "TypeError: Expect argument to be Integer. got: String", 1},
-		{`exit(1, 2)`, "ArgumentError: Expected at most 1 argument; got: 2", 1},
+		{`exit(1, 2)`, "ArgumentError: Expect 1 or less argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1293,10 +1307,10 @@ func TestGeneralIsAMethod(t *testing.T) {
 
 func TestGeneralIsAMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`123.is_a?`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`Class.is_a?`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`123.is_a?(123, 456)`, "ArgumentError: Expect 1 argument. got: 2", 1},
-		{`123.is_a?(Integer, String)`, "ArgumentError: Expect 1 argument. got: 2", 1},
+		{`123.is_a?`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+		{`Class.is_a?`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+		{`123.is_a?(123, 456)`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
+		{`123.is_a?(Integer, String)`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 		{`123.is_a?(true)`, "TypeError: Expect argument to be Class. got: Boolean", 1},
 		{`Class.is_a?(true)`, "TypeError: Expect argument to be Class. got: Boolean", 1},
 	}
@@ -1336,11 +1350,11 @@ func TestGeneralIsNilMethod(t *testing.T) {
 
 func TestGeneralIsNilMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`123.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`"Fail".nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`[1, 2, 3].nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2, c: 3 }.nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`(1..10).nil?("Hello")`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`123.nil?("Hello")`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`"Fail".nil?("Hello")`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`[1, 2, 3].nil?("Hello")`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`{ a: 1, b: 2, c: 3 }.nil?("Hello")`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`(1..10).nil?("Hello")`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1381,8 +1395,8 @@ func TestClassNameClassMethodFail(t *testing.T) {
 		{`"Taipei".name`, "NoMethodError: Undefined Method 'name' for Taipei", 1},
 		{`123.name`, "NoMethodError: Undefined Method 'name' for 123", 1},
 		{`true.name`, "NoMethodError: Undefined Method 'name' for true", 1},
-		{`Integer.name(Integer)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`String.name(Hash, Array)`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`Integer.name(Integer)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`String.name(Hash, Array)`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1433,8 +1447,8 @@ func TestClassSuperclassClassMethodFail(t *testing.T) {
 		{`"Taipei".superclass`, "NoMethodError: Undefined Method 'superclass' for Taipei", 1},
 		{`123.superclass`, "NoMethodError: Undefined Method 'superclass' for 123", 1},
 		{`true.superclass`, "NoMethodError: Undefined Method 'superclass' for true", 1},
-		{`Integer.superclass(Integer)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`String.superclass(Hash, Array)`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`Integer.superclass(Integer)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`String.superclass(Hash, Array)`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1550,7 +1564,7 @@ func TestInstanceEvalMethod(t *testing.T) {
 
 func TestInstanceEvalMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"s".instance_eval(1, 1)`, "ArgumentError: Expect at most 1 arguments. got: 2", 1},
+		{`"s".instance_eval(1, 1)`, "ArgumentError: Expect 1 or less argument(s). got: 2", 1},
 		{`"s".instance_eval(true)`, "TypeError: Expect argument to be Block. got: Boolean", 1},
 	}
 

--- a/vm/concurrent_array.go
+++ b/vm/concurrent_array.go
@@ -63,22 +63,24 @@ func builtinConcurrentArrayClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) > 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 or 1 arguments, got %d", len(args))
-				}
-
-				if len(args) == 0 {
+				aLen := len(args)
+				
+				switch aLen {
+				case 0:
 					return t.vm.initConcurrentArrayObject([]Object{})
+				case 1:
+					arg := args[0]
+					arrayArg, ok := arg.(*ArrayObject)
+					
+					if !ok {
+						return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.ArrayClass, arg.Class().Name)
+					}
+					
+					return t.vm.initConcurrentArrayObject(arrayArg.Elements)
+				default:
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, 1, aLen)
 				}
-
-				arg := args[0]
-				arrayArg, ok := arg.(*ArrayObject)
-
-				if !ok {
-					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.ArrayClass, arg.Class().Name)
-				}
-
-				return t.vm.initConcurrentArrayObject(arrayArg.Elements)
+				
 			},
 		},
 	}

--- a/vm/concurrent_array_test.go
+++ b/vm/concurrent_array_test.go
@@ -117,6 +117,10 @@ func TestConcurrentArrayIndexFail(t *testing.T) {
 		require 'concurrent/array'
 		Concurrent::Array.new([1, "a", 10, "b"])[-5]
 		`, "ArgumentError: Index value -5 too small for array. minimum: -4", 1},
+		{`
+		require 'concurrent/array'
+		Concurrent::Array.new([1, "a", 10, "b"], 1)[-5]
+		`, "ArgumentError: Expect 1 or less argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/concurrent_hash.go
+++ b/vm/concurrent_hash.go
@@ -39,8 +39,8 @@ func builtinConcurrentHashClassMethods() []*BuiltinMethodObject {
 			Name: "new",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if u := 1; u < aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
+				if aLen > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, 1, aLen)
 				}
 
 				if aLen == 0 {
@@ -78,8 +78,8 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "[]",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				i := args[0]
@@ -116,8 +116,8 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				// First arg is index
 				// Second arg is assigned value
-				if e, aLen := 2, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 2, len(args))
 				}
 
 				k := args[0]
@@ -146,8 +146,8 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [NULL]
 			Name: "delete",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				h := receiver.(*ConcurrentHashObject)
@@ -182,8 +182,8 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash] self
 			Name: "each",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 				
 				if blockFrame == nil {
@@ -225,8 +225,8 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "has_key?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				h := receiver.(*ConcurrentHashObject)
@@ -257,8 +257,8 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_json",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				r := receiver.(*ConcurrentHashObject)
@@ -278,8 +278,8 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_s",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				h := receiver.(*ConcurrentHashObject)

--- a/vm/concurrent_hash.go
+++ b/vm/concurrent_hash.go
@@ -38,11 +38,12 @@ func builtinConcurrentHashClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) > 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 or 1 arguments, got %d", len(args))
+				aLen := len(args)
+				if u := 1; u < aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
 				}
 
-				if len(args) == 0 {
+				if aLen == 0 {
 					return t.vm.initConcurrentHashObject(make(map[string]Object))
 				}
 
@@ -77,9 +78,8 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "[]",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				i := args[0]
@@ -114,11 +114,10 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object] The value
 			Name: "[]=",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-
 				// First arg is index
 				// Second arg is assigned value
-				if len(args) != 2 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got: %d", len(args))
+				if e, aLen := 2, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				k := args[0]
@@ -147,8 +146,8 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [NULL]
 			Name: "delete",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*ConcurrentHashObject)
@@ -183,14 +182,14 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash] self
 			Name: "each",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				}
+				
 				if blockFrame == nil {
 					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
-
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 arguments. got: %d", len(args))
-				}
-
+				
 				hash := receiver.(*ConcurrentHashObject)
 				framePopped := false
 
@@ -226,8 +225,8 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "has_key?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*ConcurrentHashObject)
@@ -258,8 +257,8 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_json",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				r := receiver.(*ConcurrentHashObject)
@@ -279,8 +278,8 @@ func builtinConcurrentHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_s",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*ConcurrentHashObject)

--- a/vm/concurrent_hash_test.go
+++ b/vm/concurrent_hash_test.go
@@ -61,7 +61,7 @@ func TestConcurrentHashInitializationFail(t *testing.T) {
 		{`
 		require 'concurrent/hash'
 		Concurrent::Hash.new(1, 2)
-		`, "ArgumentError: Expect 0 or 1 arguments, got 2", 3},
+		`, "ArgumentError: Expect 1 or less argument(s). got: 2", 3},
 	}
 
 	for i, tt := range testsFail {
@@ -199,7 +199,7 @@ func TestConcurrentHashAccessOperationFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`
 		require 'concurrent/hash'
-		Concurrent::Hash.new({ a: 1, b: 2 })[]`, "ArgumentError: Expect 1 argument. got: 0", 3},
+		Concurrent::Hash.new({ a: 1, b: 2 })[]`, "ArgumentError: Expect 1 argument(s). got: 0", 3},
 		{`
 		require 'concurrent/hash'
 		Concurrent::Hash.new({ a: 1, b: 2 })[true]`, "TypeError: Expect argument to be String. got: Boolean", 3},
@@ -291,10 +291,10 @@ func TestConcurrentHashDeleteMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`
 		require 'concurrent/hash'
-		Concurrent::Hash.new({ a: 1, b: "Hello", c: true }).delete`, "ArgumentError: Expect 1 argument. got: 0", 3},
+		Concurrent::Hash.new({ a: 1, b: "Hello", c: true }).delete`, "ArgumentError: Expect 1 argument(s). got: 0", 3},
 		{`
 		require 'concurrent/hash'
-		Concurrent::Hash.new({ a: 1, b: "Hello", c: true }).delete("a", "b")`, "ArgumentError: Expect 1 argument. got: 2", 3},
+		Concurrent::Hash.new({ a: 1, b: "Hello", c: true }).delete("a", "b")`, "ArgumentError: Expect 1 argument(s). got: 2", 3},
 		{`
 		require 'concurrent/hash'
 		Concurrent::Hash.new({ a: 1, b: "Hello", c: true }).delete(123)`, "TypeError: Expect argument to be String. got: Integer", 3},
@@ -366,7 +366,7 @@ func TestConcurrentHashEachMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`
 		require 'concurrent/hash'
-		Concurrent::Hash.new({ a: 1, b: 2}).each("Hello") do end`, "ArgumentError: Expect 0 arguments. got: 1", 1},
+		Concurrent::Hash.new({ a: 1, b: 2}).each("Hello") do end`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 		{`
 		require 'concurrent/hash'
 		Concurrent::Hash.new({ a: 1, b: 2}).each`, "InternalError: Can't yield without a block", 1},
@@ -407,10 +407,10 @@ func TestConcurrentHashHasKeyMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`
 		require 'concurrent/hash'
-		Concurrent::Hash.new({ a: 1, b: 2 }).has_key?`, "ArgumentError: Expect 1 argument. got: 0", 3},
+		Concurrent::Hash.new({ a: 1, b: 2 }).has_key?`, "ArgumentError: Expect 1 argument(s). got: 0", 3},
 		{`
 		require 'concurrent/hash'
-		Concurrent::Hash.new({ a: 1, b: 2 }).has_key?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 3},
+		Concurrent::Hash.new({ a: 1, b: 2 }).has_key?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument(s). got: 2", 3},
 		{`
 		require 'concurrent/hash'
 		Concurrent::Hash.new({ a: 1, b: 2 }).has_key?(true)`, "TypeError: Expect argument to be String. got: Boolean", 3},
@@ -592,10 +592,10 @@ func TestConcurrentHashToJSONMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`
 		require 'concurrent/hash'
-		Concurrent::Hash.new({ a: 1, b: 2 }).to_json(123)`, "ArgumentError: Expect 0 argument. got: 1", 3},
+		Concurrent::Hash.new({ a: 1, b: 2 }).to_json(123)`, "ArgumentError: Expect 0 argument(s). got: 1", 3},
 		{`
 		require 'concurrent/hash'
-		Concurrent::Hash.new({ a: 1, b: 2 }).to_json(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 3},
+		Concurrent::Hash.new({ a: 1, b: 2 }).to_json(true, { hello: "World" })`, "ArgumentError: Expect 0 argument(s). got: 2", 3},
 	}
 
 	for i, tt := range testsFail {
@@ -633,10 +633,10 @@ func TestConcurrentHashToStringMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`
 		require 'concurrent/hash'
-		Concurrent::Hash.new({ a: 1, b: 2 }).to_s(123)`, "ArgumentError: Expect 0 argument. got: 1", 3},
+		Concurrent::Hash.new({ a: 1, b: 2 }).to_s(123)`, "ArgumentError: Expect 0 argument(s). got: 1", 3},
 		{`
 		require 'concurrent/hash'
-		Concurrent::Hash.new({ a: 1, b: 2 }).to_s(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 3},
+		Concurrent::Hash.new({ a: 1, b: 2 }).to_s(true, { hello: "World" })`, "ArgumentError: Expect 0 argument(s). got: 2", 3},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/concurrent_rw_lock.go
+++ b/vm/concurrent_rw_lock.go
@@ -33,8 +33,8 @@ func builtinConcurrentRWLockClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				return t.vm.initConcurrentRWLockObject()
@@ -60,8 +60,8 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "acquire_read_lock",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				lockObject := receiver.(*ConcurrentRWLockObject)
@@ -85,8 +85,8 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "acquire_write_lock",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				lockObject := receiver.(*ConcurrentRWLockObject)
@@ -110,8 +110,8 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "release_read_lock",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				lockObject := receiver.(*ConcurrentRWLockObject)
@@ -135,8 +135,8 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "release_write_lock",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				lockObject := receiver.(*ConcurrentRWLockObject)
@@ -161,12 +161,12 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "with_read_lock",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				}
+				
 				if blockFrame == nil {
 					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
-				}
-
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
 				}
 
 				lockObject := receiver.(*ConcurrentRWLockObject)
@@ -195,14 +195,14 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "with_write_lock",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				}
+				
 				if blockFrame == nil {
 					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
-
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 arguments, got %d", len(args))
-				}
-
+				
 				lockObject := receiver.(*ConcurrentRWLockObject)
 
 				lockObject.mutex.Lock()

--- a/vm/concurrent_rw_lock.go
+++ b/vm/concurrent_rw_lock.go
@@ -33,8 +33,8 @@ func builtinConcurrentRWLockClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				return t.vm.initConcurrentRWLockObject()
@@ -60,8 +60,8 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "acquire_read_lock",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				lockObject := receiver.(*ConcurrentRWLockObject)
@@ -85,8 +85,8 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "acquire_write_lock",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				lockObject := receiver.(*ConcurrentRWLockObject)
@@ -110,8 +110,8 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "release_read_lock",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				lockObject := receiver.(*ConcurrentRWLockObject)
@@ -135,8 +135,8 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "release_write_lock",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				lockObject := receiver.(*ConcurrentRWLockObject)
@@ -161,8 +161,8 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "with_read_lock",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 				
 				if blockFrame == nil {
@@ -195,8 +195,8 @@ func builtinConcurrentRWLockInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "with_write_lock",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 				
 				if blockFrame == nil {

--- a/vm/concurrent_rw_lock_test.go
+++ b/vm/concurrent_rw_lock_test.go
@@ -12,7 +12,7 @@ func TestRWLockNewMethodFail(t *testing.T) {
 		{`
 		require 'concurrent/rw_lock'
 		Concurrent::RWLock.new(5)
-		`, "ArgumentError: Expected 0 arguments, got 1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -29,7 +29,7 @@ func TestRWLockAcquireReadLockMethodFail(t *testing.T) {
 		{`
 		require 'concurrent/rw_lock'
 		Concurrent::RWLock.new.acquire_read_lock(5)
-		`, "ArgumentError: Expected 0 arguments, got 1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -46,7 +46,7 @@ func TestRWLockReleaseReadLockMethodFail(t *testing.T) {
 		{`
 		require 'concurrent/rw_lock'
 		Concurrent::RWLock.new.release_read_lock(5)
-		`, "ArgumentError: Expected 0 arguments, got 1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -63,7 +63,7 @@ func TestRWLockAcquireWriteLockMethodFail(t *testing.T) {
 		{`
 		require 'concurrent/rw_lock'
 		Concurrent::RWLock.new.acquire_write_lock(5)
-		`, "ArgumentError: Expected 0 arguments, got 1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -80,7 +80,7 @@ func TestRWLockReleaseWriteLockMethodFail(t *testing.T) {
 		{`
 		require 'concurrent/rw_lock'
 		Concurrent::RWLock.new.release_write_lock(5)
-		`, "ArgumentError: Expected 0 arguments, got 1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -101,7 +101,7 @@ func TestRWLockWithReadLockMethodFail(t *testing.T) {
 		{`
 		require 'concurrent/rw_lock'
 		Concurrent::RWLock.new.with_read_lock(5) do end
-		`, "ArgumentError: Expected 0 arguments, got 1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -122,7 +122,7 @@ func TestRWLockWithWriteLockMethodFail(t *testing.T) {
 		{`
 		require 'concurrent/rw_lock'
 		Concurrent::RWLock.new.with_write_lock(5) do end
-		`, "ArgumentError: Expected 0 arguments, got 1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/decimal_test.go
+++ b/vm/decimal_test.go
@@ -338,14 +338,14 @@ func TestDecimalToStringMethod(t *testing.T) {
 
 func TestDecimalToStringFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`'1.1.1'.to_d`, "ArgumentError: Invalid numeric string. got=1.1.1", 1},
-		{`'1/1/1'.to_d`, "ArgumentError: Invalid numeric string. got=1/1/1", 1},
-		{`'1.1/1'.to_d`, "ArgumentError: Invalid numeric string. got=1.1/1", 1},
-		{`'1/1.1'.to_d`, "ArgumentError: Invalid numeric string. got=1/1.1", 1},
-		{`'1..1'.to_d`, "ArgumentError: Invalid numeric string. got=1..1", 1},
-		{`'..1'.to_d`, "ArgumentError: Invalid numeric string. got=..1", 1},
-		{`'1//1'.to_d`, "ArgumentError: Invalid numeric string. got=1//1", 1},
-		{`'abc'.to_d`, "ArgumentError: Invalid numeric string. got=abc", 1},
+		{`'1.1.1'.to_d`, "ArgumentError: Invalid numeric string. got: 1.1.1", 1},
+		{`'1/1/1'.to_d`, "ArgumentError: Invalid numeric string. got: 1/1/1", 1},
+		{`'1.1/1'.to_d`, "ArgumentError: Invalid numeric string. got: 1.1/1", 1},
+		{`'1/1.1'.to_d`, "ArgumentError: Invalid numeric string. got: 1/1.1", 1},
+		{`'1..1'.to_d`, "ArgumentError: Invalid numeric string. got: 1..1", 1},
+		{`'..1'.to_d`, "ArgumentError: Invalid numeric string. got: ..1", 1},
+		{`'1//1'.to_d`, "ArgumentError: Invalid numeric string. got: 1//1", 1},
+		{`'abc'.to_d`, "ArgumentError: Invalid numeric string. got: abc", 1},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/error_test.go
+++ b/vm/error_test.go
@@ -248,10 +248,10 @@ func TestArgumentError(t *testing.T) {
 			"ArgumentError: Expect at most 2 args for method 'foo'. got: 3",
 			4, 1, 1},
 		{`"1234567890".include? "123", Class`,
-			"ArgumentError: Expect 1 argument. got=2",
+			"ArgumentError: Expect 1 argument(s). got: 2",
 			1, 1, 1},
 		{`"1234567890".include? "123", Class, String`,
-			"ArgumentError: Expect 1 argument. got=3",
+			"ArgumentError: Expect 1 argument(s). got: 3",
 			1, 1, 1},
 		{`def foo(a, *b)
 		end

--- a/vm/errors/error.go
+++ b/vm/errors/error.go
@@ -32,6 +32,7 @@ const (
 	WrongNumberOfArgumentLess   = "Expect %d or less argument(s). got: %d"
 	WrongNumberOfArgumentRange  = "Expect %d to %d argument(s). got: %d"
 	WrongArgumentTypeFormat     = "Expect argument to be %s. got: %s"
+	WrongArgumentTypeFormatNum     = "Expect argument #%d to be %s. got: %s"
 	CantYieldWithoutBlockFormat = "Can't yield without a block"
 	DividedByZero               = "Divided by 0"
 	ChannelIsClosed             = "The channel is already closed."

--- a/vm/float.go
+++ b/vm/float.go
@@ -318,10 +318,6 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			Name: "to_d",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%v", strconv.Itoa(len(args)))
-				}
-
 				fl := receiver.(*FloatObject).value
 				fs := strconv.FormatFloat(fl, 'f', -1, 64)
 				de, err := new(Decimal).SetString(fs)

--- a/vm/go_map.go
+++ b/vm/go_map.go
@@ -53,8 +53,8 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "get",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				key, ok := args[0].(*StringObject)
@@ -84,8 +84,8 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "set",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 2, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 2, len(args))
 				}
 
 				key, ok := args[0].(*StringObject)
@@ -105,8 +105,8 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_hash",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 				
 				m := receiver.(*GoMap)

--- a/vm/go_map.go
+++ b/vm/go_map.go
@@ -51,30 +51,10 @@ func builtinGoMapClassMethods() []*BuiltinMethodObject {
 func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 	return []*BuiltinMethodObject{
 		{
-			Name: "to_hash",
-			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
-				}
-
-				m := receiver.(*GoMap)
-
-				pairs := map[string]Object{}
-
-				for k, obj := range m.data {
-					pairs[k] = t.vm.InitObjectFromGoType(obj)
-
-				}
-
-				return t.vm.InitHashObject(pairs)
-
-			},
-		},
-		{
 			Name: "get",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				key, ok := args[0].(*StringObject)
@@ -104,14 +84,14 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "set",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 2 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 argument. got: %d", len(args))
+				if e, aLen := 2, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				key, ok := args[0].(*StringObject)
 
 				if !ok {
-					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormatNum, 1, classes.StringClass, args[0].Class().Name)
 				}
 
 				m := receiver.(*GoMap).data
@@ -120,6 +100,26 @@ func builtinGoMapInstanceMethods() []*BuiltinMethodObject {
 
 				return args[1]
 
+			},
+		},
+		{
+			Name: "to_hash",
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				}
+				
+				m := receiver.(*GoMap)
+				
+				pairs := map[string]Object{}
+				
+				for k, obj := range m.data {
+					pairs[k] = t.vm.InitObjectFromGoType(obj)
+					
+				}
+				
+				return t.vm.InitHashObject(pairs)
+				
 			},
 		},
 	}

--- a/vm/go_map_test.go
+++ b/vm/go_map_test.go
@@ -70,6 +70,22 @@ func TestGoMapGetMethod(t *testing.T) {
 	}
 }
 
+func TestGoMapGetMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`m = GoMap.new;m.get("foo", 1)`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
+		{`m = GoMap.new;m.get`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+		{`m = GoMap.new;m.get(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
+	}
+	
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestGoMapSetMethod(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -91,6 +107,22 @@ func TestGoMapSetMethod(t *testing.T) {
 	}
 }
 
+func TestGoMapSetMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`m = GoMap.new;m.set("foo")`, "ArgumentError: Expect 2 argument(s). got: 1", 1},
+		{`m = GoMap.new;m.set("foo", "bar", "baz")`, "ArgumentError: Expect 2 argument(s). got: 3", 1},
+		{`m = GoMap.new;m.set(1, "foo")`, "TypeError: Expect argument #1 to be String. got: Integer", 1},
+	}
+	
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestGoMapToHashMethod(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -108,12 +140,27 @@ func TestGoMapToHashMethod(t *testing.T) {
 		h[:foo]
 		`, nil},
 	}
-
+	
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())
 		VerifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestGoMapToHashMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`m = GoMap.new;m.to_hash(1)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`m = GoMap.new;m.to_hash(1, 2)`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
+	}
+	
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -86,9 +86,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "[]",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				i := args[0]
@@ -129,13 +128,11 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object] The value
 			Name: "[]=",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-
 				// First arg is index
 				// Second arg is assigned value
-				if len(args) != 2 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got: %d", len(args))
+				if e, aLen := 2, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
-
 				k := args[0]
 				key, ok := k.(*StringObject)
 
@@ -178,8 +175,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "any?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				if blockFrame == nil {
@@ -236,8 +233,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "clear",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*HashObject)
@@ -261,8 +258,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "default",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 0 argument, got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				hash := receiver.(*HashObject)
@@ -290,8 +287,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "default=",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 1 argument, got %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				// Arrays and Hashes are generally a mistake, since a single instance would be used for all the accesses
@@ -321,8 +318,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "delete",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*HashObject)
@@ -357,8 +354,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "delete_if",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				if blockFrame == nil {
@@ -409,8 +406,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "dig",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) == 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 1+ arguments, got 0")
+				if l, aLen := 1, len(args); l > aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, l, aLen)
 				}
 
 				hash := receiver.(*HashObject)
@@ -437,8 +434,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "each",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 arguments. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				if blockFrame == nil {
@@ -482,8 +479,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "each_key",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				if blockFrame == nil {
@@ -526,8 +523,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			Name: "each_value",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				if blockFrame == nil {
@@ -564,8 +561,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "empty?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*HashObject)
@@ -586,8 +583,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "eql?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*HashObject)
@@ -618,39 +615,39 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "fetch",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if !(len(args) == 1 || len(args) == 2) {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 1 or 2 arguments, got %d", len(args))
-				} else if len(args) == 2 && blockFrame != nil {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "The default argument can't be passed along with a block")
+				aLen := len(args)
+				l, u := 1, 2
+				if aLen < l || aLen > u {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, l, u, aLen)
 				}
-
-				hash := receiver.(*HashObject)
+				
 				key, ok := args[0].(*StringObject)
-
 				if !ok {
 					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, key.Class().Name)
 				}
-
+				
+				if aLen == u {
+					if blockFrame != nil {
+						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "The default argument can't be passed along with a block")
+					}
+					return args[1]
+				}
+				
+				hash := receiver.(*HashObject)
 				value, ok := hash.Pairs[key.value]
-
+				
 				if ok {
 					if blockFrame != nil {
 						t.callFrameStack.pop()
 					}
-
 					return value
 				}
-
-				if len(args) == 2 {
-					return args[1]
-				}
-
+				
 				if blockFrame != nil {
 					return t.builtinMethodYield(blockFrame, key).Target
 				}
-
 				return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "The value was not found, and no block has been provided")
-
+				
 			},
 		},
 		{
@@ -668,11 +665,12 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [ArrayObject]
 			Name: "fetch_values",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) == 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expected 1+ arguments, got 0")
+				aLen := len(args)
+				if l := 1; l > aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, l, aLen)
 				}
 
-				values := make([]Object, len(args))
+				values := make([]Object, aLen)
 
 				hash := receiver.(*HashObject)
 				blockFramePopped := false
@@ -722,8 +720,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "has_key?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*HashObject)
@@ -756,8 +754,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "has_value?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*HashObject)
@@ -782,8 +780,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "keys",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*HashObject)
@@ -806,8 +804,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "length",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*HashObject)
@@ -831,8 +829,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "map_values",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				if blockFrame == nil {
@@ -869,8 +867,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "merge",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) < 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect at least 1 argument. got: %d", len(args))
+				if l, aLen := 1, len(args); l > aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, l, aLen)
 				}
 
 				h := receiver.(*HashObject)
@@ -915,8 +913,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "select",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				if blockFrame == nil {
@@ -964,8 +962,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "sorted_keys",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*HashObject)
@@ -996,14 +994,14 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "to_a",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				aLen := len(args)
+				if u := 1; aLen > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
+				}
 
-				h := receiver.(*HashObject)
 				var sorted bool
-
-				if len(args) == 0 {
+				if aLen == 0 {
 					sorted = false
-				} else if len(args) > 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0..1 argument. got: %d", len(args))
 				} else {
 					s := args[0]
 					st, ok := s.(*BooleanObject)
@@ -1013,6 +1011,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 					sorted = st.value
 				}
 
+				h := receiver.(*HashObject)
 				var resultArr []Object
 				if sorted {
 					for _, k := range h.sortedKeys() {
@@ -1045,8 +1044,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_json",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				r := receiver.(*HashObject)
@@ -1066,8 +1065,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_s",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				h := receiver.(*HashObject)
@@ -1092,8 +1091,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "transform_values",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				if blockFrame == nil {
@@ -1126,10 +1125,10 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "values",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
-
+				
 				h := receiver.(*HashObject)
 				var keys []Object
 				for _, v := range h.Pairs {

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -86,8 +86,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "[]",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				i := args[0]
@@ -130,8 +130,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				// First arg is index
 				// Second arg is assigned value
-				if e, aLen := 2, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 2, len(args))
 				}
 				k := args[0]
 				key, ok := k.(*StringObject)
@@ -175,8 +175,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "any?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				if blockFrame == nil {
@@ -233,8 +233,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "clear",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				h := receiver.(*HashObject)
@@ -258,8 +258,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "default",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				hash := receiver.(*HashObject)
@@ -287,8 +287,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "default=",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				// Arrays and Hashes are generally a mistake, since a single instance would be used for all the accesses
@@ -318,8 +318,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "delete",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				h := receiver.(*HashObject)
@@ -354,10 +354,10 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "delete_if",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
-
+				
 				if blockFrame == nil {
 					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
@@ -406,8 +406,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Object]
 			Name: "dig",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if l, aLen := 1, len(args); l > aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, l, aLen)
+				if len(args) < 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, 1, len(args))
 				}
 
 				hash := receiver.(*HashObject)
@@ -434,8 +434,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "each",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				if blockFrame == nil {
@@ -479,8 +479,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "each_key",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				if blockFrame == nil {
@@ -523,8 +523,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			//
 			Name: "each_value",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				if blockFrame == nil {
@@ -561,8 +561,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "empty?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				h := receiver.(*HashObject)
@@ -583,8 +583,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "eql?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				h := receiver.(*HashObject)
@@ -616,9 +616,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Name: "fetch",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				l, u := 1, 2
-				if aLen < l || aLen > u {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, l, u, aLen)
+				if aLen < 1 || aLen > 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, 1, 2, aLen)
 				}
 				
 				key, ok := args[0].(*StringObject)
@@ -626,7 +625,7 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, key.Class().Name)
 				}
 				
-				if aLen == u {
+				if aLen == 2 {
 					if blockFrame != nil {
 						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "The default argument can't be passed along with a block")
 					}
@@ -666,8 +665,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Name: "fetch_values",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if l := 1; l > aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, l, aLen)
+				if aLen <1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, 1, aLen)
 				}
 
 				values := make([]Object, aLen)
@@ -720,8 +719,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "has_key?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				h := receiver.(*HashObject)
@@ -754,8 +753,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "has_value?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				h := receiver.(*HashObject)
@@ -780,8 +779,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "keys",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				h := receiver.(*HashObject)
@@ -804,8 +803,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "length",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				h := receiver.(*HashObject)
@@ -829,8 +828,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "map_values",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				if blockFrame == nil {
@@ -867,8 +866,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "merge",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if l, aLen := 1, len(args); l > aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, l, aLen)
+				if len(args) < 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, 1, len(args))
 				}
 
 				h := receiver.(*HashObject)
@@ -913,8 +912,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// ```
 			Name: "select",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				if blockFrame == nil {
@@ -962,8 +961,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "sorted_keys",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				h := receiver.(*HashObject)
@@ -995,8 +994,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			Name: "to_a",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if u := 1; aLen > 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, u, aLen)
+				if aLen > 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, 1, aLen)
 				}
 
 				var sorted bool
@@ -1044,8 +1043,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_json",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				r := receiver.(*HashObject)
@@ -1065,8 +1064,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_s",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				h := receiver.(*HashObject)
@@ -1091,8 +1090,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "transform_values",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				if blockFrame == nil {
@@ -1125,8 +1124,8 @@ func builtinHashInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "values",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 				
 				h := receiver.(*HashObject)

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -181,11 +181,11 @@ func TestHashAccessWithDefaultOperation(t *testing.T) {
 
 func TestHashAccessOperationFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }[]`, "ArgumentError: Expect 1 argument. got: 0", 1},
+		{`{ a: 1, b: 2 }[]`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
 		{`{ a: 1, b: 2 }[true]`, "TypeError: Expect argument to be String. got: Boolean", 1},
 		{`{ a: 1, b: 2 }[true] = 1`, "TypeError: Expect argument to be String. got: Boolean", 1},
-		{`{ a: 1, b: 2 }["a", "b"]`, "ArgumentError: Expect 1 argument. got: 2", 1},
-		{`{ a: 1, b: 2 }["a", "b"] = 123`, "ArgumentError: Expect 2 arguments. got: 3", 1},
+		{`{ a: 1, b: 2 }["a", "b"]`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
+		{`{ a: 1, b: 2 }["a", "b"] = 123`, "ArgumentError: Expect 2 argument(s). got: 3", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -305,7 +305,7 @@ func TestHashAnyMethod(t *testing.T) {
 
 func TestHashAnyMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{  }.any?(123) do end`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{  }.any?(123) do end`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 		{`{  }.any?`, "InternalError: Can't yield without a block", 1},
 	}
 
@@ -347,8 +347,8 @@ func TestHashClearMethod(t *testing.T) {
 
 func TestHashClearMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.clear(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.clear(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.clear(123)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`{ a: 1, b: 2 }.clear(true, { hello: "World" })`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -387,7 +387,7 @@ func TestHashDefaultOperation(t *testing.T) {
 
 func TestHashDefaultSetOperationFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ }.default = *[1, 2]`, "ArgumentError: Expected 1 argument, got 2", 1},
+		{`{ }.default = *[1, 2]`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 		{`{ }.default = []`, "ArgumentError: Arrays and Hashes are not accepted as default values", 1},
 		{`{ }.default = {}`, "ArgumentError: Arrays and Hashes are not accepted as default values", 1},
 	}
@@ -455,8 +455,8 @@ func TestHashDeleteMethod(t *testing.T) {
 
 func TestHashDeleteMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: "Hello", c: true }.delete`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`{ a: 1, b: "Hello", c: true }.delete("a", "b")`, "ArgumentError: Expect 1 argument. got: 2", 1},
+		{`{ a: 1, b: "Hello", c: true }.delete`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+		{`{ a: 1, b: "Hello", c: true }.delete("a", "b")`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 		{`{ a: 1, b: "Hello", c: true }.delete(123)`, "TypeError: Expect argument to be String. got: Integer", 1},
 		{`{ a: 1, b: "Hello", c: true }.delete(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
 	}
@@ -524,7 +524,7 @@ func TestHashDeleteIfMethod(t *testing.T) {
 
 func TestHashDeleteIfMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ }.delete_if(123) do end`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ }.delete_if(123) do end`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 		{`{ }.delete_if`, "InternalError: Can't yield without a block", 1},
 	}
 
@@ -564,7 +564,7 @@ func TestHashDigMethod(t *testing.T) {
 
 func TestHashDigMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: [], b: 2 }.dig`, "ArgumentError: Expected 1+ arguments, got 0", 1},
+		{`{ a: [], b: 2 }.dig`, "ArgumentError: Expect 1 or more argument(s). got: 0", 1},
 		{`{ a: 1, b: 2 }.dig(:a, :b)`, "TypeError: Expect target to be Diggable, got Integer", 1},
 	}
 
@@ -627,7 +627,7 @@ func TestHashEachMethod(t *testing.T) {
 func TestHashEachMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`{ a: 1, b: 2}.each("Hello") do end
-		`, "ArgumentError: Expect 0 arguments. got: 1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 		{`{ a: 1, b: 2}.each`, "InternalError: Can't yield without a block", 1},
 	}
 
@@ -693,7 +693,7 @@ func TestHashEachKeyMethodFail(t *testing.T) {
 		{`{ a: 1, b: 2, c: 3 }.each_key("Hello") do |key|
 			puts key
 		end
-		`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 		{`{ a: 1, b: 2, c: 3 }.each_key`, "InternalError: Can't yield without a block", 1},
 	}
 
@@ -792,7 +792,7 @@ func TestHashEachValueMethodFail(t *testing.T) {
 		{`{ a: 1, b: 2, c: 3 }.each_value("Hello") do |value|
 			puts value
 		end
-		`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 		{`{ a: 1, b: 2, c: 3 }.each_value`, "InternalError: Can't yield without a block", 1},
 	}
 
@@ -825,8 +825,8 @@ func TestHashEmptyMethod(t *testing.T) {
 
 func TestHashEmptyMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.empty?(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.empty?(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.empty?(123)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`{ a: 1, b: 2 }.empty?(true, { hello: "World" })`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -868,8 +868,8 @@ func TestHashEqualMethod(t *testing.T) {
 
 func TestHashEqualMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.eql?`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`{ a: 1, b: 2 }.eql?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.eql?`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+		{`{ a: 1, b: 2 }.eql?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -908,8 +908,8 @@ func TestHashFetchMethod(t *testing.T) {
 
 func TestHashFetchMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ spaghetti: "eat" }.fetch()`, "ArgumentError: Expected 1 or 2 arguments, got 0", 1},
-		{`{ spaghetti: "eat" }.fetch("a", "b", "c")`, "ArgumentError: Expected 1 or 2 arguments, got 3", 1},
+		{`{ spaghetti: "eat" }.fetch()`, "ArgumentError: Expect 1 to 2 argument(s). got: 0", 1},
+		{`{ spaghetti: "eat" }.fetch("a", "b", "c")`, "ArgumentError: Expect 1 to 2 argument(s). got: 3", 1},
 		{`{ spaghetti: "eat" }.fetch("a", "b") do end`, "ArgumentError: The default argument can't be passed along with a block", 1},
 		{`{ spaghetti: "eat" }.fetch("pizza")`, "ArgumentError: The value was not found, and no block has been provided", 1},
 	}
@@ -947,7 +947,7 @@ func TestHashFetchValuesMethod(t *testing.T) {
 
 func TestHashFetchValuesMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ cat: "feline" }.fetch_values()`, "ArgumentError: Expected 1+ arguments, got 0", 1},
+		{`{ cat: "feline" }.fetch_values()`, "ArgumentError: Expect 1 or more argument(s). got: 0", 1},
 		{`{ cat: "feline" }.fetch_values(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
 		{`{ cat: "feline" }.fetch_values("dog")`, "ArgumentError: There is no value for the key `dog`, and no block has been provided", 1},
 	}
@@ -981,8 +981,8 @@ func TestHashHasKeyMethod(t *testing.T) {
 
 func TestHashHasKeyMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.has_key?`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`{ a: 1, b: 2 }.has_key?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.has_key?`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+		{`{ a: 1, b: 2 }.has_key?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 		{`{ a: 1, b: 2 }.has_key?(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
 		{`{ a: 1, b: 2 }.has_key?(123)`, "TypeError: Expect argument to be String. got: Integer", 1},
 	}
@@ -1021,8 +1021,8 @@ func TestHashHasValueMethod(t *testing.T) {
 
 func TestHashHasValueMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.has_value?`, "ArgumentError: Expect 1 argument. got: 0", 1},
-		{`{ a: 1, b: 2 }.has_value?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.has_value?`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+		{`{ a: 1, b: 2 }.has_value?(true, { hello: "World" })`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1064,8 +1064,8 @@ func TestHashKeysMethod(t *testing.T) {
 
 func TestHashKeysMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.keys(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.keys(123)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`{ a: 1, b: 2 }.keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1101,8 +1101,8 @@ func TestHashLengthMethod(t *testing.T) {
 
 func TestHashLengthMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.length(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.length(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.length(123)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`{ a: 1, b: 2 }.length(true, { hello: "World" })`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1192,7 +1192,7 @@ func TestHashMapValuesMethodFail(t *testing.T) {
 		{`{ a: 1, b: 2, c: 3 }.map_values("Hello") do |value|
 			value * 3
 		end
-		`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 		{`{ a: 1, b: 2, c: 3 }.map_values`, "InternalError: Can't yield without a block", 1},
 	}
 
@@ -1240,7 +1240,7 @@ func TestHashMergeMethod(t *testing.T) {
 
 func TestHashMergeMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.merge`, "ArgumentError: Expect at least 1 argument. got: 0", 1},
+		{`{ a: 1, b: 2 }.merge`, "ArgumentError: Expect 1 or more argument(s). got: 0", 1},
 		{`{ a: 1, b: 2 }.merge(true, { hello: "World" })`, "TypeError: Expect argument to be Hash. got: Boolean", 1},
 		{`{ a: 1, b: 2 }.merge({ hello: "World" }, 123, "Hello")`, "TypeError: Expect argument to be Hash. got: Integer", 1},
 	}
@@ -1250,27 +1250,6 @@ func TestHashMergeMethodFail(t *testing.T) {
 		evaluated := v.testEval(t, tt.input, getFilename())
 		checkErrorMsg(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, tt.expectedCFP)
-		v.checkSP(t, i, 1)
-	}
-}
-
-func TestHashSortedKeysMethod(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected []interface{}
-	}{
-		{`{ a: 1, b: 2, c: 3 }.sorted_keys`, []interface{}{"a", "b", "c"}},
-		{`{ c: 1, b: 2, a: 3 }.sorted_keys`, []interface{}{"a", "b", "c"}},
-		{`{ b: 1, a: 2, c: 3 }.sorted_keys`, []interface{}{"a", "b", "c"}},
-		{`{ b: 1, a: 2, b: 3 }.sorted_keys`, []interface{}{"a", "b"}},
-		{`{ c: 1, a: 2, a: 3 }.sorted_keys`, []interface{}{"a", "c"}},
-	}
-
-	for i, tt := range tests {
-		v := initTestVM()
-		evaluated := v.testEval(t, tt.input, getFilename())
-		verifyArrayObject(t, i, evaluated, tt.expected)
-		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -1332,7 +1311,7 @@ func TestHashSelectMethod(t *testing.T) {
 
 func TestHashSelectMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ }.select(123) do end`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`{ }.select(123) do end`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 		{`{ }.select`, "InternalError: Can't yield without a block", 1},
 	}
 
@@ -1345,10 +1324,31 @@ func TestHashSelectMethodFail(t *testing.T) {
 	}
 }
 
+func TestHashSortedKeysMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []interface{}
+	}{
+		{`{ a: 1, b: 2, c: 3 }.sorted_keys`, []interface{}{"a", "b", "c"}},
+		{`{ c: 1, b: 2, a: 3 }.sorted_keys`, []interface{}{"a", "b", "c"}},
+		{`{ b: 1, a: 2, c: 3 }.sorted_keys`, []interface{}{"a", "b", "c"}},
+		{`{ b: 1, a: 2, b: 3 }.sorted_keys`, []interface{}{"a", "b"}},
+		{`{ c: 1, a: 2, a: 3 }.sorted_keys`, []interface{}{"a", "c"}},
+	}
+	
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		verifyArrayObject(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestHashSortedKeysMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.sorted_keys(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.sorted_keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.sorted_keys(123)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`{ a: 1, b: 2 }.sorted_keys(true, { hello: "World" })`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1418,7 +1418,7 @@ func TestHashToArrayMethod(t *testing.T) {
 
 func TestHashToArrayMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.to_a(true, { hello: "World" })`, "ArgumentError: Expect 0..1 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.to_a(true, { hello: "World" })`, "ArgumentError: Expect 1 or less argument(s). got: 2", 1},
 		{`{ a: 1, b: 2 }.to_a(123)`, "TypeError: Expect argument to be Boolean. got: Integer", 1},
 	}
 
@@ -1670,8 +1670,8 @@ func TestHashToJSONMethodWithBasicTypes(t *testing.T) {
 
 func TestHashToJSONMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.to_json(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.to_json(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.to_json(123)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`{ a: 1, b: 2 }.to_json(true, { hello: "World" })`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1704,8 +1704,8 @@ func TestHashToStringMethod(t *testing.T) {
 
 func TestHashToStringMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.to_s(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.to_s(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.to_s(123)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`{ a: 1, b: 2 }.to_s(true, { hello: "World" })`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1787,7 +1787,7 @@ func TestHashTransformValuesMethodFail(t *testing.T) {
 		{`{ a: 1, b: 2, c: 3 }.transform_values("Hello") do |value|
 			value * 3
 		end
-		`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 		{`{ a: 1, b: 2, c: 3 }.transform_values`, "InternalError: Can't yield without a block", 1},
 	}
 
@@ -1833,8 +1833,8 @@ func TestHashValuesMethod(t *testing.T) {
 
 func TestHashValuesMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`{ a: 1, b: 2 }.values(123)`, "ArgumentError: Expect 0 argument. got: 1", 1},
-		{`{ a: 1, b: 2 }.values(true, { hello: "World" })`, "ArgumentError: Expect 0 argument. got: 2", 1},
+		{`{ a: 1, b: 2 }.values(123)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`{ a: 1, b: 2 }.values(true, { hello: "World" })`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/http.go
+++ b/vm/http.go
@@ -5,9 +5,8 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"strconv"
 	"strings"
-
+	
 	"github.com/goby-lang/goby/vm/errors"
 )
 
@@ -67,8 +66,8 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 			// Sends a POST request to the target with type header and body. Returns the HTTP response as a string. Will error on non-200 responses, for more control over http requests look at the `start` method.
 			Name: "post",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 3 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 3, len(args))
+				if e, aLen := 3, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				arg0, ok := args[0].(*StringObject)
@@ -153,9 +152,8 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 			// Starts an HTTP client. This method requires a block which takes a Net::HTTP::Client object. The return value of this method is the last evaluated value of the provided block.
 			Name: "start",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 arguments. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				gobyClient := httpClientClass.initializeInstance()

--- a/vm/http.go
+++ b/vm/http.go
@@ -66,8 +66,8 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 			// Sends a POST request to the target with type header and body. Returns the HTTP response as a string. Will error on non-200 responses, for more control over http requests look at the `start` method.
 			Name: "post",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 3, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 3 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 3, len(args))
 				}
 
 				arg0, ok := args[0].(*StringObject)
@@ -152,8 +152,8 @@ func builtinHTTPClassMethods() []*BuiltinMethodObject {
 			// Starts an HTTP client. This method requires a block which takes a Net::HTTP::Client object. The return value of this method is the last evaluated value of the provided block.
 			Name: "start",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				gobyClient := httpClientClass.initializeInstance()

--- a/vm/http_client.go
+++ b/vm/http_client.go
@@ -21,8 +21,8 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Sends a GET request to the target and returns a `Net::HTTP::Response` object.
 			Name: "get",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				u, ok := args[0].(*StringObject)
@@ -47,8 +47,8 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Sends a POST request to the target and returns a `Net::HTTP::Response` object.
 			Name: "post",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 3, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 3 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 3, len(args))
 				}
 
 				u, ok := args[0].(*StringObject)
@@ -85,8 +85,8 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Sends a HEAD request to the target and returns a `Net::HTTP::Response` object.
 			Name: "head",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				u, ok := args[0].(*StringObject)
@@ -118,8 +118,8 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Sends a passed `Net::HTTP::Request` object and returns a `Net::HTTP::Response` object
 			Name: "exec",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				if args[0].Class().Name != httpRequestClass.Name {

--- a/vm/http_client.go
+++ b/vm/http_client.go
@@ -21,8 +21,8 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Sends a GET request to the target and returns a `Net::HTTP::Response` object.
 			Name: "get",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				u, ok := args[0].(*StringObject)
@@ -47,8 +47,8 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Sends a POST request to the target and returns a `Net::HTTP::Response` object.
 			Name: "post",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 3 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 3, len(args))
+				if e, aLen := 3, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				u, ok := args[0].(*StringObject)
@@ -85,8 +85,8 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Sends a HEAD request to the target and returns a `Net::HTTP::Response` object.
 			Name: "head",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				u, ok := args[0].(*StringObject)
@@ -118,8 +118,8 @@ func builtinHTTPClientInstanceMethods() []*BuiltinMethodObject {
 			// Sends a passed `Net::HTTP::Request` object and returns a `Net::HTTP::Response` object
 			Name: "exec",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				if args[0].Class().Name != httpRequestClass.Name {

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -368,7 +368,7 @@ func init() {
 					inheritedClass, ok := superClass.Target.(*RClass)
 
 					if !ok {
-						t.pushErrorObject(errors.InternalError, sourceLine, "Constant %s is not a class. got=%s", superClassName, string(superClass.Target.Class().ReturnName()))
+						t.pushErrorObject(errors.InternalError, sourceLine, "Constant %s is not a class. got: %s", superClassName, string(superClass.Target.Class().ReturnName()))
 					}
 
 					if inheritedClass.isModule {

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -512,7 +512,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 				n := receiver.(*IntegerObject)
 
 				if n.value < 0 {
-					return t.vm.InitErrorObject(errors.InternalError, sourceLine, "Expect integer greater than or equal 0. got: %d", n.value)
+					return t.vm.InitErrorObject(errors.InternalError, sourceLine, "Expect integer to be positive value. got: %d", n.value)
 				}
 
 				if blockFrame == nil {

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -357,7 +357,7 @@ func TestIntegerTimesMethod(t *testing.T) {
 
 func TestIntegerTimesMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`(-2).times`, "InternalError: Expect integer greater than or equal 0. got: -2", 1},
+		{`(-2).times`, "InternalError: Expect integer to be positive value. got: -2", 1},
 		{`2.times`, "InternalError: Can't yield without a block", 1},
 	}
 

--- a/vm/json.go
+++ b/vm/json.go
@@ -14,8 +14,8 @@ func builtinJSONClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "parse",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				j, ok := args[0].(*StringObject)
@@ -54,8 +54,8 @@ func builtinJSONClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "validate",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				j, ok := args[0].(*StringObject)

--- a/vm/json.go
+++ b/vm/json.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"encoding/json"
-	"strconv"
-
 	"github.com/goby-lang/goby/vm/classes"
 	"github.com/goby-lang/goby/vm/errors"
 )
@@ -16,8 +14,8 @@ func builtinJSONClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "parse",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				j, ok := args[0].(*StringObject)
@@ -56,8 +54,8 @@ func builtinJSONClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "validate",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				j, ok := args[0].(*StringObject)

--- a/vm/json_test.go
+++ b/vm/json_test.go
@@ -34,6 +34,22 @@ func TestJSONValidateMethod(t *testing.T) {
 	}
 }
 
+func TestJSONValidateFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`require "json";JSON.validate`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+		{`require "json";JSON.validate('{"Name": "Stan"}', '{"Name": "hachi8833"}')`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
+		{`require "json";JSON.validate(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
+	}
+	
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestJSONObjectParsing(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -75,6 +91,22 @@ func TestJSONObjectParsing(t *testing.T) {
 		evaluated := v.testEval(t, tt.input, getFilename())
 		VerifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestJSONParseFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`require "json";JSON.parse`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+		{`require "json";JSON.parse('{"Name": "Stan"}', '{"Name": "hachi8833"}')`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
+		{`require "json";JSON.parse(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
+	}
+	
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
 		v.checkSP(t, i, 1)
 	}
 }
@@ -127,3 +159,4 @@ func TestJSONObjectArrayParsing(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+

--- a/vm/match_data.go
+++ b/vm/match_data.go
@@ -54,8 +54,8 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "captures",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 				
 				offset := 1
@@ -85,8 +85,8 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "to_a",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				g := receiver.(*MatchDataObject).match
@@ -116,8 +116,8 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "to_h",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				groups := receiver.(*MatchDataObject).match
@@ -140,8 +140,8 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "length",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				m := receiver.(*MatchDataObject).match

--- a/vm/match_data.go
+++ b/vm/match_data.go
@@ -54,9 +54,10 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "captures",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
+				
 				offset := 1
 
 				g := receiver.(*MatchDataObject).match
@@ -84,8 +85,8 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "to_a",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				g := receiver.(*MatchDataObject).match
@@ -115,8 +116,8 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			// @return [Hash]
 			Name: "to_h",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				groups := receiver.(*MatchDataObject).match
@@ -139,8 +140,8 @@ func builtinMatchDataInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "length",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				m := receiver.(*MatchDataObject).match

--- a/vm/match_data_test.go
+++ b/vm/match_data_test.go
@@ -44,8 +44,10 @@ func TestMatchDataCaptures(t *testing.T) {
 
 func TestMatchDataCapturesFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`'a1bca2'.match(1, 2)`, "ArgumentError: Expect 1 argument. got=2", 1},
+		{`'a1bca2'.match(1, 2)`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 		{`'a1bca2'.match('a.')`, "TypeError: Expect argument to be Regexp. got: String", 1},
+		{`'a1bca2'.match(Regexp.new('a')).captures('a')`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`'a1bca2'.match(Regexp.new('a')).captures('a', 'b')`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -78,7 +80,8 @@ func TestMatchDataToAMethod(t *testing.T) {
 
 func TestMatchDataToAMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`'a1bca2'.match(Regexp.new('a.')).to_a(1)`, "ArgumentError: Expect 0 argument. got=1", 1},
+		{`'a1bca2'.match(Regexp.new('a.')).to_a(1)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`'a1bca2'.match(Regexp.new('a.')).to_a(1, 2)`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -111,7 +114,8 @@ func TestMatchDataLengthMethod(t *testing.T) {
 
 func TestMatchDataLengthMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`'abc'.match(Regexp.new('(a)(b)c')).length(1)`, "ArgumentError: Expect 0 argument. got=1", 1},
+		{`'abc'.match(Regexp.new('(a)(b)c')).length(1)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`'abc'.match(Regexp.new('(a)(b)c')).length(1, 2)`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -139,5 +143,20 @@ func TestMatchDataToHMethod(t *testing.T) {
 		verifyHashObject(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
+	}
+}
+
+func TestMatchDataToHMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`'abcd'.match(Regexp.new('a.')).to_h(1)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`'abcd'.match(Regexp.new('a.')).to_h(1, 2)`, "ArgumentError: Expect 0 argument(s). got: 2", 1},
+	}
+	
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
 	}
 }

--- a/vm/null.go
+++ b/vm/null.go
@@ -51,8 +51,8 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_i",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 				
 				return t.vm.InitIntegerObject(0)
@@ -63,8 +63,8 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			Name: "to_s",
 
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				n := receiver.(*NullObject)

--- a/vm/null.go
+++ b/vm/null.go
@@ -51,6 +51,10 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 		{
 			Name: "to_i",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				}
+				
 				return t.vm.InitIntegerObject(0)
 
 			},
@@ -59,8 +63,8 @@ func builtinNullInstanceMethods() []*BuiltinMethodObject {
 			Name: "to_s",
 
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				n := receiver.(*NullObject)

--- a/vm/null_test.go
+++ b/vm/null_test.go
@@ -100,7 +100,8 @@ func TestNullTypeConversion(t *testing.T) {
 
 func TestNullTypeConversionFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`nil.to_s(1)`, "ArgumentError: Expect 0 argument. got: 1", 1},
+		{`nil.to_i(1)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`nil.to_s(1)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/range.go
+++ b/vm/range.go
@@ -342,8 +342,8 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "map",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 				
 				if blockFrame == nil {

--- a/vm/range.go
+++ b/vm/range.go
@@ -342,16 +342,15 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "map",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				r := receiver.(*RangeObject)
-
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				}
+				
 				if blockFrame == nil {
 					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
 
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
-				}
-
+				r := receiver.(*RangeObject)
 				var elements []Object
 
 				r.each(func(i int) error {
@@ -423,12 +422,11 @@ func builtinRangeInstanceMethods() []*BuiltinMethodObject {
 			// @return [Range]
 			Name: "step",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				ran := receiver.(*RangeObject)
-
 				if blockFrame == nil {
 					return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.CantYieldWithoutBlockFormat)
 				}
 
+				ran := receiver.(*RangeObject)
 				stepValue := args[0].(*IntegerObject).value
 				if stepValue == 0 {
 					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Step can't be 0")

--- a/vm/range_test.go
+++ b/vm/range_test.go
@@ -567,7 +567,7 @@ func TestRangeMapMethodFail(t *testing.T) {
 		{
 			`
 			(1..10).map(1) do |x| x * x; end
-		`, "ArgumentError: Expect 0 argument. got=1", 2},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 2},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/regexp.go
+++ b/vm/regexp.go
@@ -46,8 +46,8 @@ func builtInRegexpClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				arg, ok := args[0].(*StringObject)
@@ -87,9 +87,8 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "==",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				right, ok := args[0].(*RegexpObject)
@@ -119,9 +118,8 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "match?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				arg := args[0]

--- a/vm/regexp.go
+++ b/vm/regexp.go
@@ -46,8 +46,8 @@ func builtInRegexpClassMethods() []*BuiltinMethodObject {
 		{
 			Name: "new",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				arg, ok := args[0].(*StringObject)
@@ -87,8 +87,8 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "==",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				right, ok := args[0].(*RegexpObject)
@@ -118,8 +118,8 @@ func builtinRegexpInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "match?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				arg := args[0]

--- a/vm/regexp_test.go
+++ b/vm/regexp_test.go
@@ -40,6 +40,20 @@ func TestRegexpClassCreation(t *testing.T) {
 	}
 }
 
+func TestRegexpNewMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`Regexp.new`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+	}
+	
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestRegexpComparison(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -171,7 +185,7 @@ func TestRegexpMatchMethod(t *testing.T) {
 
 func TestRegexpMatchMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`Regexp.new("abc").match?('a', 'b')`, "ArgumentError: Expect 1 argument. got=2", 1},
+		{`Regexp.new("abc").match?('a', 'b')`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 		{`Regexp.new("abc").match?(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
 	}
 

--- a/vm/string.go
+++ b/vm/string.go
@@ -50,8 +50,8 @@ func builtinStringClassMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "fmt",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if l, aLen := 1, len(args); l > aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, l, aLen)
+				if len(args) < 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, 1, len(args))
 				}
 
 				formatObj, ok := args[0].(*StringObject)
@@ -247,8 +247,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "=~",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				arg := args[0]
@@ -354,8 +354,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "[]",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				str := receiver.(*StringObject).value
@@ -429,8 +429,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "[]=",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 2, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 2, len(args))
 				}
 				
 				i := args[0]
@@ -529,8 +529,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "concat",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				c := args[0]
@@ -579,8 +579,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "delete",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				d := args[0]
@@ -710,8 +710,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "each_line",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				if blockFrame == nil {
@@ -766,8 +766,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "end_with?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				c := args[0]
@@ -806,8 +806,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "eql?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				str := receiver.(*StringObject).value
@@ -833,8 +833,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Bool]
 			Name: "include?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				i := args[0]
@@ -872,8 +872,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "insert",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 2, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 2, len(args))
 				}
 
 				i := args[0]
@@ -952,8 +952,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Name: "ljust",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if l, u := 1, 2;l > aLen || u < aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, l, u, aLen)
+				if aLen < 1 || aLen > 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, 1, 2, aLen)
 				}
 
 				l := args[0]
@@ -1007,8 +1007,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [MatchData]
 			Name: "match",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 				
 				arg := args[0]
@@ -1050,8 +1050,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "replace",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 2, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 2, len(args))
 				}
 				
 				r := args[1]
@@ -1098,8 +1098,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "replace_once",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 2, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 2, len(args))
 				}
 				
 				r := args[1]
@@ -1173,8 +1173,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Name: "rjust",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				aLen := len(args)
-				if l, u := 1, 2;l > aLen || u < aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, l, u, aLen)
+				if aLen < 1 || aLen > 2 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, 1, 2, aLen)
 				}
 
 				str := receiver.(*StringObject).value
@@ -1282,8 +1282,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "slice",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				str := receiver.(*StringObject).value
@@ -1360,8 +1360,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "split",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				s := args[0]
@@ -1395,8 +1395,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "start_with",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 1, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 1 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
 				}
 
 				c := args[0]
@@ -1467,8 +1467,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_a",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				str := receiver.(*StringObject)
@@ -1503,8 +1503,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_d",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				str := receiver.(*StringObject).value
@@ -1534,8 +1534,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Float]
 			Name: "to_f",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 				
 				str := receiver.(*StringObject).value
@@ -1570,8 +1570,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "to_i",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				str := receiver.(*StringObject).value
@@ -1611,8 +1611,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_s",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if e, aLen := 0, len(args); e != aLen {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				if len(args) != 0 {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 0, len(args))
 				}
 
 				str := receiver.(*StringObject).value

--- a/vm/string.go
+++ b/vm/string.go
@@ -50,8 +50,8 @@ func builtinStringClassMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "fmt",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) < 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect at least 1 argument. got=%v", strconv.Itoa(len(args)))
+				if l, aLen := 1, len(args); l > aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentMore, l, aLen)
 				}
 
 				formatObj, ok := args[0].(*StringObject)
@@ -70,7 +70,7 @@ func builtinStringClassMethods() []*BuiltinMethodObject {
 				count := strings.Count(format, "%s")
 
 				if len(args[1:]) != count {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect %d string arguments. got=%d", count, len(args[1:]))
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect %d additional string(s) to insert. got: %d", count, len(args[1:]))
 				}
 
 				return t.vm.InitStringObject(fmt.Sprintf(format, arguments...))
@@ -102,7 +102,6 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Name: "+",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-				leftValue := receiver.(*StringObject).value
 				r := args[0]
 				right, ok := r.(*StringObject)
 
@@ -111,6 +110,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 				}
 
 				rightValue := right.value
+				leftValue := receiver.(*StringObject).value
 				return t.vm.InitStringObject(leftValue + rightValue)
 
 			},
@@ -126,20 +126,20 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Name: "*",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-				leftValue := receiver.(*StringObject).value
 				r := args[0]
 				right, ok := r.(*IntegerObject)
-
+				
 				if !ok {
 					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, r.Class().Name)
 				}
-
+				
 				if right.value < 0 {
 					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Second argument must be greater than or equal to 0. got=%v", right.value)
 				}
-
+				
 				var result string
-
+				
+				leftValue := receiver.(*StringObject).value
 				for i := 0; i < right.value; i++ {
 					result += leftValue
 				}
@@ -159,7 +159,6 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Name: ">",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-				leftValue := receiver.(*StringObject).value
 				r := args[0]
 				right, ok := r.(*StringObject)
 
@@ -169,6 +168,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 
 				rightValue := right.value
 
+				leftValue := receiver.(*StringObject).value
 				if leftValue > rightValue {
 					return TRUE
 				}
@@ -188,7 +188,6 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Name: "<",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-				leftValue := receiver.(*StringObject).value
 				r := args[0]
 				right, ok := r.(*StringObject)
 
@@ -198,6 +197,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 
 				rightValue := right.value
 
+				leftValue := receiver.(*StringObject).value
 				if leftValue < rightValue {
 					return TRUE
 				}
@@ -218,7 +218,6 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Name: "==",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-				leftValue := receiver.(*StringObject).value
 				r := args[0]
 				right, ok := r.(*StringObject)
 
@@ -228,6 +227,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 
 				rightValue := right.value
 
+				leftValue := receiver.(*StringObject).value
 				if leftValue == rightValue {
 					return TRUE
 				}
@@ -247,8 +247,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "=~",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				arg := args[0]
@@ -287,7 +287,6 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Name: "<=>",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-				leftValue := receiver.(*StringObject).value
 				r := args[0]
 				right, ok := r.(*StringObject)
 
@@ -297,6 +296,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 
 				rightValue := right.value
 
+				leftValue := receiver.(*StringObject).value
 				if leftValue < rightValue {
 					return t.vm.InitIntegerObject(-1)
 				}
@@ -320,7 +320,6 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			Name: "!=",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-				leftValue := receiver.(*StringObject).value
 				right, ok := args[0].(*StringObject)
 
 				if !ok {
@@ -329,6 +328,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 
 				rightValue := right.value
 
+				leftValue := receiver.(*StringObject).value
 				if leftValue != rightValue {
 					return TRUE
 				}
@@ -354,8 +354,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "[]",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				str := receiver.(*StringObject).value
@@ -429,19 +429,19 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "[]=",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 2 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 2, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
-
-				str := receiver.(*StringObject).value
+				
 				i := args[0]
 				index, ok := i.(*IntegerObject)
-
+				
 				if !ok {
 					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, i.Class().Name)
 				}
-
+				
 				indexValue := index.value
+				str := receiver.(*StringObject).value
 				strLength := utf8.RuneCountInString(str)
 
 				if strLength < indexValue {
@@ -529,11 +529,10 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "concat",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
-				str := receiver.(*StringObject).value
 				c := args[0]
 				concatStr, ok := c.(*StringObject)
 
@@ -541,6 +540,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
 				}
 
+				str := receiver.(*StringObject).value
 				return t.vm.InitStringObject(str + concatStr.value)
 
 			},
@@ -579,11 +579,10 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "delete",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
-				str := receiver.(*StringObject).value
 				d := args[0]
 				deleteStr, ok := d.(*StringObject)
 
@@ -591,6 +590,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, d.Class().Name)
 				}
 
+				str := receiver.(*StringObject).value
 				return t.vm.InitStringObject(strings.Replace(str, deleteStr.value, "", -1))
 
 			},
@@ -710,8 +710,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "each_line",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%d", len(args))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				if blockFrame == nil {
@@ -766,11 +766,10 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "end_with?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
-				str := receiver.(*StringObject).value
 				c := args[0]
 				compareStr, ok := c.(*StringObject)
 
@@ -780,6 +779,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 
 				compareStrValue := compareStr.value
 				compareStrLength := utf8.RuneCountInString(compareStrValue)
+				
+				str := receiver.(*StringObject).value
 				strLength := utf8.RuneCountInString(str)
 
 				if compareStrLength > strLength {
@@ -805,8 +806,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "eql?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				str := receiver.(*StringObject).value
@@ -832,11 +833,10 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Bool]
 			Name: "include?",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
-				str := receiver.(*StringObject).value
 				i := args[0]
 				includeStr, ok := i.(*StringObject)
 
@@ -844,6 +844,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, i.Class().Name)
 				}
 
+				str := receiver.(*StringObject).value
 				if strings.Contains(str, includeStr.value) {
 					return TRUE
 				}
@@ -871,11 +872,10 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "insert",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 2 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got=%d", len(args))
+				if e, aLen := 2, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
-				str := receiver.(*StringObject).value
 				i := args[0]
 				index, ok := i.(*IntegerObject)
 
@@ -890,6 +890,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 				if !ok {
 					return t.vm.InitErrorObject(errors.TypeError, sourceLine, "Expect insert string to be String. got: %s", ins.Class().Name)
 				}
+				
+				str := receiver.(*StringObject).value
 				strLength := utf8.RuneCountInString(str)
 
 				if indexValue < 0 {
@@ -949,11 +951,10 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "ljust",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 && len(args) != 2 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
+				aLen := len(args)
+				if l, u := 1, 2;l > aLen || u < aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, l, u, aLen)
 				}
-
-				str := receiver.(*StringObject).value
 
 				l := args[0]
 				strLength, ok := l.(*IntegerObject)
@@ -965,7 +966,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 				strLengthValue := strLength.value
 
 				var padStrValue string
-				if len(args) == 1 {
+				if aLen == 1 {
 					padStrValue = " "
 				} else {
 					p := args[1]
@@ -977,7 +978,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 
 					padStrValue = padStr.value
 				}
-
+				
+				str := receiver.(*StringObject).value
 				currentStrLength := utf8.RuneCountInString(str)
 				padStrLength := utf8.RuneCountInString(padStrValue)
 
@@ -1005,10 +1007,10 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [MatchData]
 			Name: "match",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
-
+				
 				arg := args[0]
 				regexpObj, ok := arg.(*RegexpObject)
 
@@ -1048,9 +1050,10 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "replace",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 2 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got=%v", len(args))
+				if e, aLen := 2, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
+				
 				r := args[1]
 				replacement, ok := r.(*StringObject)
 				if !ok {
@@ -1095,9 +1098,10 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "replace_once",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 2 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 2 arguments. got=%v", len(args))
+				if e, aLen := 2, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
+				
 				r := args[1]
 				replacement, ok := r.(*StringObject)
 				if !ok {
@@ -1168,8 +1172,9 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "rjust",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 && len(args) != 2 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1..2 arguments. got=%v", strconv.Itoa(len(args)))
+				aLen := len(args)
+				if l, u := 1, 2;l > aLen || u < aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentRange, l, u, aLen)
 				}
 
 				str := receiver.(*StringObject).value
@@ -1183,7 +1188,7 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 				strLengthValue := strLength.value
 
 				var padStrValue string
-				if len(args) == 1 {
+				if aLen == 1 {
 					padStrValue = " "
 				} else {
 					p := args[1]
@@ -1277,8 +1282,8 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "slice",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				str := receiver.(*StringObject).value
@@ -1355,19 +1360,18 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Array]
 			Name: "split",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				s := args[0]
-				seperator, ok := s.(*StringObject)
-
+				separator, ok := s.(*StringObject)
 				if !ok {
 					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, s.Class().Name)
 				}
 
 				str := receiver.(*StringObject).value
-				arr := strings.Split(str, seperator.value)
+				arr := strings.Split(str, separator.value)
 
 				var elements []Object
 				for i := 0; i < len(arr); i++ {
@@ -1391,20 +1395,21 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Boolean]
 			Name: "start_with",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				if len(args) != 1 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 1, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
-				str := receiver.(*StringObject).value
 				c := args[0]
 				compareStr, ok := c.(*StringObject)
-
+				
 				if !ok {
 					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, c.Class().Name)
 				}
-
+				
 				compareStrValue := compareStr.value
 				compareStrLength := utf8.RuneCountInString(compareStrValue)
+				
+				str := receiver.(*StringObject).value
 				strLength := utf8.RuneCountInString(str)
 
 				if compareStrLength > strLength {
@@ -1462,21 +1467,32 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_a",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				}
 
 				str := receiver.(*StringObject)
 				strLength := utf8.RuneCountInString(str.value)
-				elems := []Object{}
+				e := []Object{}
 
 				for i := 0; i < strLength; i++ {
-					elems = append(elems, t.vm.InitStringObject(string([]rune(str.value)[i])))
+					e = append(e, t.vm.InitStringObject(string([]rune(str.value)[i])))
 				}
 
-				return t.vm.InitArrayObject(elems)
+				return t.vm.InitArrayObject(e)
 
 			},
 		},
 		{
+			Name: "to_bytes",
+			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				r := receiver.(*StringObject)
+				return t.vm.initGoObject([]byte(r.value))
+			},
+		},
+		{
 			// Converts a string of decimal number to Decimal object.
+			// Returns an error when failed.
 			//
 			// ```ruby
 			// "3.14".to_d            # => 3.14
@@ -1487,16 +1503,15 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_d",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-
-				if len(args) != 0 {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got=%v", strconv.Itoa(len(args)))
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
 				}
 
 				str := receiver.(*StringObject).value
 
 				de, err := new(Decimal).SetString(str)
 				if err == false {
-					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Invalid numeric string. got=%v", str)
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Invalid numeric string. got: %s", str)
 				}
 
 				return t.vm.initDecimalObject(de)
@@ -1519,6 +1534,10 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Float]
 			Name: "to_f",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				}
+				
 				str := receiver.(*StringObject).value
 
 				for i, char := range str {
@@ -1551,6 +1570,9 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [Integer]
 			Name: "to_i",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				}
 
 				str := receiver.(*StringObject).value
 				parsedStr, err := strconv.ParseInt(str, 10, 0)
@@ -1589,6 +1611,9 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 			// @return [String]
 			Name: "to_s",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+				if e, aLen := 0, len(args); e != aLen {
+					return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, e, aLen)
+				}
 
 				str := receiver.(*StringObject).value
 
@@ -1610,13 +1635,6 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 
 				return t.vm.InitStringObject(strings.ToUpper(str))
 
-			},
-		},
-		{
-			Name: "to_bytes",
-			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				r := receiver.(*StringObject)
-				return t.vm.initGoObject([]byte(r.value))
 			},
 		},
 	}

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -22,6 +22,49 @@ func TestStringClassSuperclass(t *testing.T) {
 	}
 }
 
+func TestStringFmtMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`String.fmt("This is %s", "goby")`, "This is goby"},
+		{`String.fmt("This is %slang", "goby")`, "This is gobylang"},
+		{`String.fmt("This is %s %s", "goby", "ruby")`, "This is goby ruby"},
+		{` String.fmt("Hello! %s", 1)`, "Hello! 1"},
+		{` String.fmt("Hello! %s", 1.1)`, "Hello! 1.1"},
+		{` String.fmt("Hello! %s", "1.1".to_d)`, "Hello! 1.1"},
+		{` String.fmt("Hello! %s", "1.1".to_d.fraction)`, "Hello! 11/10"},
+		{` String.fmt("Hello! %s", :symbol)`, "Hello! symbol"},
+		{` String.fmt("Hello! %s", [:array])`, `Hello! ["array"]`},
+		{` String.fmt("Hello! %s", {key: :value})`, `Hello! { key: "value" }`},
+	}
+	
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		VerifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestStringFmtMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`String.fmt()`, "ArgumentError: Expect 1 or more argument(s). got: 0", 1},
+		{`String.fmt(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
+		{`String.fmt("Hello! %s Lang!")`, "ArgumentError: Expect 1 additional string(s) to insert. got: 0", 1},
+		{`String.fmt("Hello! %s Lang!", "Goby", "Ruby")`, "ArgumentError: Expect 1 additional string(s) to insert. got: 2", 1},
+	}
+	
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
 func TestEvalStringExpression(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -35,115 +78,6 @@ func TestEvalStringExpression(t *testing.T) {
 		{`'\'Alexius\''`, "'Alexius'"},
 		{`"Maxwell\nAlexius"`, "Maxwell\nAlexius"},
 		{`'Maxwell\nAlexius'`, "Maxwell\\nAlexius"},
-	}
-
-	for i, tt := range tests {
-		v := initTestVM()
-		evaluated := v.testEval(t, tt.input, getFilename())
-		VerifyExpected(t, i, evaluated, tt.expected)
-		v.checkCFP(t, i, 0)
-		v.checkSP(t, i, 1)
-	}
-}
-
-func TestStringConversion(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected interface{}
-	}{
-		{`"string".to_s`, "string"},
-		{`"Maxwell\nAlexius".to_s`, "Maxwell\nAlexius"},
-		{`'Maxwell\nAlexius'.to_s`, "Maxwell\\nAlexius"},
-		{`"\"Maxwell\"".to_s`, "\"Maxwell\""},
-		{`'\"Maxwell\"'.to_s`, "\\\"Maxwell\\\""},
-		{`"\'Maxwell\'".to_s`, "'Maxwell'"},
-		{`'\'Maxwell\''.to_s`, "'Maxwell'"},
-		{`"123".to_i`, 123},
-		{`"string".to_i`, 0},
-		{`" \t123".to_i`, 123},
-		{`"123string123".to_i`, 123},
-		{`"string123".to_i`, 0},
-		{`"123.5".to_f`, 123.5},
-		{`".5".to_f`, 0.5},
-		{`"  123.5".to_f`, 123.5},
-		{`"3.5e2".to_f`, 350.0},
-		{`"3.5ef".to_f`, 0.0},
-		{`
-		  arr = "Goby".to_a
-		  arr[0]
-		`, "G"},
-		{`
-		  arr = "Goby".to_a
-		  arr[1]
-		`, "o"},
-		{`
-		  arr = "Goby".to_a
-		  arr[2]
-		`, "b"},
-		{`
-		  arr = "Goby".to_a
-		  arr[3]
-		`, "y"},
-		{`
-		  arr = "🍣Goby🍺".to_a
-		  arr[0]
-		`, "🍣"},
-		{`
-		  arr = "🍣Goby🍺".to_a
-		  arr[5]
-		`, "🍺"},
-		{`
-		  arr = "Maxwell\nAlexius".to_a
-		  arr[7]
-		 `, "\n"},
-		{`
-		  arr = 'Maxwell\nAlexius'.to_a
-		  arr[7]
-		 `, "\\"},
-		{`
-		  arr = 'Maxwell\nAlexius'.to_a
-		  arr[8]
-		 `, "n"},
-		{`
-		  arr = "\"Maxwell\"".to_a
-		  arr[0]
-		 `, "\""},
-		{`
-		  arr = "\"Maxwell\"".to_a
-		  arr[-1]
-		 `, "\""},
-		{`
-		  arr = "\'Maxwell\'".to_a
-		  arr[0]
-		 `, "'"},
-		{`
-		  arr = "\'Maxwell\'".to_a
-		  arr[-1]
-		 `, "'"},
-		{`
-		  arr = '\"Maxwell\"'.to_a
-		  arr[0]
-		 `, "\\"},
-		{`
-		  arr = '\"Maxwell\"'.to_a
-		  arr[1]
-		 `, "\""},
-		{`
-		  arr = '\"Maxwell\"'.to_a
-		  arr[-1]
-		 `, "\""},
-		{`
-		  arr = '\"Maxwell\"'.to_a
-		  arr[-2]
-		 `, "\\"},
-		{`
-		  arr = '\'Maxwell\''.to_a
-		  arr[0]
-		 `, "'"},
-		{`
-		  arr = '\'Maxwell\''.to_a
-		  arr[-1]
-		 `, "'"},
 	}
 
 	for i, tt := range tests {
@@ -237,7 +171,7 @@ func TestStringMatchOperator(t *testing.T) {
 
 func TestStringMatchOperatorFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"abc" =~ *[1, 2]`, "ArgumentError: Expect 1 argument. got=2", 1},
+		{`"abc" =~ *[1, 2]`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 		{`"abc" =~ 'a'`, "TypeError: Expect argument to be Regexp. got: String", 1},
 	}
 	for i, tt := range testsFail {
@@ -308,7 +242,7 @@ func TestStringOperationFail(t *testing.T) {
 		{`"Taipei" * (-101)`, "ArgumentError: Second argument must be greater than or equal to 0. got=-101", 1},
 		{`"Taipei"[1] = 1`, "TypeError: Expect argument to be String. got: Integer", 1},
 		{`"Taipei"[1] = true`, "TypeError: Expect argument to be String. got: Boolean", 1},
-		{`"Taipei"[]`, "ArgumentError: Expect 1 argument. got=0", 1},
+		{`"Taipei"[]`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
 		{`"Taipei"[true] = 101`, "TypeError: Expect argument to be Integer. got: Boolean", 1},
 	}
 
@@ -386,8 +320,8 @@ func TestStringConcatenateMethod(t *testing.T) {
 
 func TestStringConcatenateMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"a".concat`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`"a".concat("Hello", "World")`, "ArgumentError: Expect 1 argument. got=2", 1},
+		{`"a".concat`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+		{`"a".concat("Hello", "World")`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 		{`"a".concat(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
 		{`"a".concat(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
 		{`"a".concat(nil)`, "TypeError: Expect argument to be String. got: Null", 1},
@@ -442,7 +376,7 @@ func TestStringDeleteMethod(t *testing.T) {
 
 func TestStringDeleteMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Hello hello HeLlo".delete`, "ArgumentError: Expect 1 argument. got=0", 1},
+		{`"Hello hello HeLlo".delete`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
 		{`"Hello hello HeLlo".delete(1)`, "TypeError: Expect argument to be String. got: Integer", 1},
 		{`"Hello hello HeLlo".delete(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
 		{`"Hello hello HeLlo".delete(nil)`, "TypeError: Expect argument to be String. got: Null", 1},
@@ -649,7 +583,7 @@ func TestStringEachLineMethodFail(t *testing.T) {
 		"Taipei".each_line(101) do |line|
 		  puts line
 		end
-		`, "ArgumentError: Expect 0 argument. got=1", 1},
+		`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
 		{`"Taipei".each_line`, "InternalError: Can't yield without a block", 1},
 	}
 
@@ -688,7 +622,7 @@ func TestStringEndWithMethod(t *testing.T) {
 
 func TestStringEndWithMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Taipei".end_with?("1", "0", "1")`, "ArgumentError: Expect 1 argument. got=3", 1},
+		{`"Taipei".end_with?("1", "0", "1")`, "ArgumentError: Expect 1 argument(s). got: 3", 1},
 		{`"Taipei".end_with?(101)`, "TypeError: Expect argument to be String. got: Integer", 1},
 		{`"Hello".end_with?(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
 		{`"Hello".end_with?(1..5)`, "TypeError: Expect argument to be String. got: Range", 1},
@@ -746,8 +680,8 @@ func TestStringEqualMethod(t *testing.T) {
 
 func TestStringEqualMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Hello".eql?`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`"Hello".eql?("Hello", "World")`, "ArgumentError: Expect 1 argument. got=2", 1},
+		{`"Hello".eql?`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+		{`"Hello".eql?("Hello", "World")`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -784,8 +718,8 @@ func TestStringIncludeMethod(t *testing.T) {
 
 func TestStringIncludeMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Goby".include?`, "ArgumentError: Expect 1 argument. got=0", 1},
-		{`"Goby".include?("Ruby", "Lang")`, "ArgumentError: Expect 1 argument. got=2", 1},
+		{`"Goby".include?`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
+		{`"Goby".include?("Ruby", "Lang")`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 		{`"Goby".include?(2)`, "TypeError: Expect argument to be String. got: Integer", 1},
 		{`"Goby".include?(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
 		{`"Goby".include?(nil)`, "TypeError: Expect argument to be String. got: Null", 1},
@@ -828,8 +762,8 @@ func TestStringInsertMethod(t *testing.T) {
 
 func TestStringInsertMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Goby Lang".insert`, "ArgumentError: Expect 2 arguments. got=0", 1},
-		{`"Taipei".insert(6, " ", "101")`, "ArgumentError: Expect 2 arguments. got=3", 1},
+		{`"Goby Lang".insert`, "ArgumentError: Expect 2 argument(s). got: 0", 1},
+		{`"Taipei".insert(6, " ", "101")`, "ArgumentError: Expect 2 argument(s). got: 3", 1},
 		{`"Taipei".insert("6", " 101")`, "TypeError: Expect argument to be Integer. got: String", 1},
 		{`"Taipei".insert(6, 101)`, "TypeError: Expect insert string to be String. got: Integer", 1},
 		{`"Taipei".insert(-8, "101")`, "ArgumentError: Index value out of range. got=-8", 1},
@@ -867,8 +801,8 @@ func TestStringLeftJustifyMethod(t *testing.T) {
 
 func TestStringLeftJustifyMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Hello".ljust`, "ArgumentError: Expect 1..2 arguments. got=0", 1},
-		{`"Hello".ljust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1..2 arguments. got=5", 1},
+		{`"Hello".ljust`, "ArgumentError: Expect 1 to 2 argument(s). got: 0", 1},
+		{`"Hello".ljust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1 to 2 argument(s). got: 5", 1},
 		{`"Hello".ljust(true)`, "TypeError: Expect justify width to be Integer. got: Boolean", 1},
 		{`"Hello".ljust("World")`, "TypeError: Expect justify width to be Integer. got: String", 1},
 		{`"Hello".ljust(2..5)`, "TypeError: Expect justify width to be Integer. got: Range", 1},
@@ -925,7 +859,7 @@ func TestStringMatch(t *testing.T) {
 
 func TestStringMatchFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`'a'.match(Regexp.new("abc"), 1)`, "ArgumentError: Expect 1 argument. got=2", 1},
+		{`'a'.match(Regexp.new("abc"), 1)`, "ArgumentError: Expect 1 argument(s). got: 2", 1},
 		{`'a'.match(1)`, "TypeError: Expect argument to be Regexp. got: Integer", 1},
 	}
 
@@ -959,9 +893,9 @@ func TestStringReplaceMethod(t *testing.T) {
 
 func TestStringReplaceMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Invalid".replace`, "ArgumentError: Expect 2 arguments. got=0", 1},
-		{`"Invalid".replace("string")`, "ArgumentError: Expect 2 arguments. got=1", 1},
-		{`"Invalid".replace("string", "replace", true)`, "ArgumentError: Expect 2 arguments. got=3", 1},
+		{`"Invalid".replace`, "ArgumentError: Expect 2 argument(s). got: 0", 1},
+		{`"Invalid".replace("string")`, "ArgumentError: Expect 2 argument(s). got: 1", 1},
+		{`"Invalid".replace("string", "replace", true)`, "ArgumentError: Expect 2 argument(s). got: 3", 1},
 		{`"Invalid".replace(true, "replacement")`, "TypeError: Expect pattern to be String or Regexp. got: Boolean", 1},
 		{`"Invalid".replace("pattern", true)`, "TypeError: Expect replacement to be String. got: Boolean", 1},
 	}
@@ -996,9 +930,9 @@ func TestStringReplaceOnceMethod(t *testing.T) {
 
 func TestStringReplaceOnceMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Invalid".replace_once`, "ArgumentError: Expect 2 arguments. got=0", 1},
-		{`"Invalid".replace_once("string")`, "ArgumentError: Expect 2 arguments. got=1", 1},
-		{`"Invalid".replace_once("string", "replace", true)`, "ArgumentError: Expect 2 arguments. got=3", 1},
+		{`"Invalid".replace_once`, "ArgumentError: Expect 2 argument(s). got: 0", 1},
+		{`"Invalid".replace_once("string")`, "ArgumentError: Expect 2 argument(s). got: 1", 1},
+		{`"Invalid".replace_once("string", "replace", true)`, "ArgumentError: Expect 2 argument(s). got: 3", 1},
 		{`"Invalid".replace_once(true, "replacement")`, "TypeError: Expect pattern to be String or Regexp. got: Boolean", 1},
 		{`"Invalid".replace_once("pattern", true)`, "TypeError: Expect replacement to be String. got: Boolean", 1},
 	}
@@ -1055,8 +989,8 @@ func TestStringRightJustifyMethod(t *testing.T) {
 
 func TestStringRightJustifyFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Hello".rjust`, "ArgumentError: Expect 1..2 arguments. got=0", 1},
-		{`"Hello".rjust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1..2 arguments. got=5", 1},
+		{`"Hello".rjust`, "ArgumentError: Expect 1 to 2 argument(s). got: 0", 1},
+		{`"Hello".rjust(1, 2, 3, 4, 5)`, "ArgumentError: Expect 1 to 2 argument(s). got: 5", 1},
 		{`"Hello".rjust(true)`, "TypeError: Expect justify width to be Integer. got: Boolean", 1},
 		{`"Hello".rjust("World")`, "TypeError: Expect justify width to be Integer. got: String", 1},
 		{`"Hello".rjust(2..5)`, "TypeError: Expect justify width to be Integer. got: Range", 1},
@@ -1142,7 +1076,7 @@ func TestStringSliceMethod(t *testing.T) {
 
 func TestStringSliceMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Goby Lang".slice`, "ArgumentError: Expect 1 argument. got=0", 1},
+		{`"Goby Lang".slice`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
 		{`"Goby Lang".slice("Hello")`, "TypeError: Expect slice range to be Range or Integer. got: String", 1},
 		{`"Goby Lang".slice(true)`, "TypeError: Expect slice range to be Range or Integer. got: Boolean", 1},
 	}
@@ -1238,7 +1172,7 @@ func TestStringSplitMethod(t *testing.T) {
 
 func TestStringSplitMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Hello World".split`, "ArgumentError: Expect 1 argument. got=0", 1},
+		{`"Hello World".split`, "ArgumentError: Expect 1 argument(s). got: 0", 1},
 		{`"Hello World".split(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
 		{`"Hello World".split(123)`, "TypeError: Expect argument to be String. got: Integer", 1},
 		{`"Hello World".split(1..2)`, "TypeError: Expect argument to be String. got: Range", 1},
@@ -1279,7 +1213,7 @@ func TestStringStartWithMethod(t *testing.T) {
 
 func TestStringStartWithMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
-		{`"Taipei".start_with("1", "0", "1")`, "ArgumentError: Expect 1 argument. got=3", 1},
+		{`"Taipei".start_with("1", "0", "1")`, "ArgumentError: Expect 1 argument(s). got: 3", 1},
 		{`"Taipei".start_with(101)`, "TypeError: Expect argument to be String. got: Integer", 1},
 		{`"Hello".start_with(true)`, "TypeError: Expect argument to be String. got: Boolean", 1},
 		{`"Hello".start_with(1..5)`, "TypeError: Expect argument to be String. got: Range", 1},
@@ -1312,6 +1246,135 @@ func TestStringStripMethod(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+
+func TestStringConversion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`"string".to_s`, "string"},
+		{`"Maxwell\nAlexius".to_s`, "Maxwell\nAlexius"},
+		{`'Maxwell\nAlexius'.to_s`, "Maxwell\\nAlexius"},
+		{`"\"Maxwell\"".to_s`, "\"Maxwell\""},
+		{`'\"Maxwell\"'.to_s`, "\\\"Maxwell\\\""},
+		{`"\'Maxwell\'".to_s`, "'Maxwell'"},
+		{`'\'Maxwell\''.to_s`, "'Maxwell'"},
+		{`"123".to_i`, 123},
+		{`"string".to_i`, 0},
+		{`" \t123".to_i`, 123},
+		{`"123string123".to_i`, 123},
+		{`"string123".to_i`, 0},
+		{`"123.5".to_f`, 123.5},
+		{`".5".to_f`, 0.5},
+		{`"  123.5".to_f`, 123.5},
+		{`"3.5e2".to_f`, 350.0},
+		{`"3.5ef".to_f`, 0.0},
+		{`
+		  arr = "Goby".to_a
+		  arr[0]
+		`, "G"},
+		{`
+		  arr = "Goby".to_a
+		  arr[1]
+		`, "o"},
+		{`
+		  arr = "Goby".to_a
+		  arr[2]
+		`, "b"},
+		{`
+		  arr = "Goby".to_a
+		  arr[3]
+		`, "y"},
+		{`
+		  arr = "🍣Goby🍺".to_a
+		  arr[0]
+		`, "🍣"},
+		{`
+		  arr = "🍣Goby🍺".to_a
+		  arr[5]
+		`, "🍺"},
+		{`
+		  arr = "Maxwell\nAlexius".to_a
+		  arr[7]
+		 `, "\n"},
+		{`
+		  arr = 'Maxwell\nAlexius'.to_a
+		  arr[7]
+		 `, "\\"},
+		{`
+		  arr = 'Maxwell\nAlexius'.to_a
+		  arr[8]
+		 `, "n"},
+		{`
+		  arr = "\"Maxwell\"".to_a
+		  arr[0]
+		 `, "\""},
+		{`
+		  arr = "\"Maxwell\"".to_a
+		  arr[-1]
+		 `, "\""},
+		{`
+		  arr = "\'Maxwell\'".to_a
+		  arr[0]
+		 `, "'"},
+		{`
+		  arr = "\'Maxwell\'".to_a
+		  arr[-1]
+		 `, "'"},
+		{`
+		  arr = '\"Maxwell\"'.to_a
+		  arr[0]
+		 `, "\\"},
+		{`
+		  arr = '\"Maxwell\"'.to_a
+		  arr[1]
+		 `, "\""},
+		{`
+		  arr = '\"Maxwell\"'.to_a
+		  arr[-1]
+		 `, "\""},
+		{`
+		  arr = '\"Maxwell\"'.to_a
+		  arr[-2]
+		 `, "\\"},
+		{`
+		  arr = '\'Maxwell\''.to_a
+		  arr[0]
+		 `, "'"},
+		{`
+		  arr = '\'Maxwell\''.to_a
+		  arr[-1]
+		 `, "'"},
+		{`"str".to_bytes.to_s.split(" ")[0]`, "<GoObject:"},
+	}
+	
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		VerifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestStringConversionFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`"str".to_a(1)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`"str".to_d(1)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`"str".to_i(1)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`"str".to_f(1)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+		{`"str".to_s(1)`, "ArgumentError: Expect 0 argument(s). got: 1", 1},
+	}
+	
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
 
 func TestStringUpcaseMethod(t *testing.T) {
 	tests := []struct {
@@ -1352,21 +1415,3 @@ func TestStringMethodChaining(t *testing.T) {
 	}
 }
 
-func TestFormattedString(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected interface{}
-	}{
-		{`String.fmt("This is %s", "goby")`, "This is goby"},
-		{`String.fmt("This is %slang", "goby")`, "This is gobylang"},
-		{`String.fmt("This is %s %s", "goby", "ruby")`, "This is goby ruby"},
-	}
-
-	for i, tt := range tests {
-		v := initTestVM()
-		evaluated := v.testEval(t, tt.input, getFilename())
-		VerifyExpected(t, i, evaluated, tt.expected)
-		v.checkCFP(t, i, 0)
-		v.checkSP(t, i, 1)
-	}
-}


### PR DESCRIPTION
Unifying the error messages for length checking in the rest of the classes.

```
benchmarking f54dc3e582496de9dd459c3858a38ff3844c3f54
benchmarking 3a8ae31e9ef7e1bed0007c9d15a7e4374625ab7e
x86_64-darwin17
benchmark                              old ns/op     new ns/op     delta
BenchmarkBasicMath/add-8               3239          3234          -0.15%
BenchmarkBasicMath/subtract-8          3158          3287          +4.08%
BenchmarkBasicMath/multiply-8          3250          3152          -3.02%
BenchmarkBasicMath/divide-8            3337          3175          -4.85%
BenchmarkConcurrency/concurrency-8     7862254       7397854       -5.91%

benchmark                              old allocs     new allocs     delta
BenchmarkBasicMath/add-8               33             33             +0.00%
BenchmarkBasicMath/subtract-8          33             33             +0.00%
BenchmarkBasicMath/multiply-8          33             33             +0.00%
BenchmarkBasicMath/divide-8            33             33             +0.00%
BenchmarkConcurrency/concurrency-8     53465          53516          +0.10%

benchmark                              old bytes     new bytes     delta
BenchmarkBasicMath/add-8               1568          1568          +0.00%
BenchmarkBasicMath/subtract-8          1568          1568          +0.00%
BenchmarkBasicMath/multiply-8          1568          1568          +0.00%
BenchmarkBasicMath/divide-8            1568          1568          +0.00%
BenchmarkConcurrency/concurrency-8     2725831       2729690       +0.14%
Switched to branch 'unify_argument_errors_cont'
```

If it is OK, I'll squash and merge them.