### PR TITLE
Improve case statement and REPL

### DIFF
--- a/compiler/parser/errors/errors.go
+++ b/compiler/parser/errors/errors.go
@@ -57,6 +57,11 @@ func (e *Error) IsUnexpectedWhen() bool {
 	return e.ErrType == UnexpectedTokenError && len(e.Message) >= 21 && e.Message[0:21] == "unexpected when Line:"
 }
 
+// IsUnexpectedEmptyLine checks if error is unexpected 'end' with empty line
+func (e *Error) IsUnexpectedEmptyLine(len int) bool {
+	return e.IsUnexpectedEnd() && len == 0
+}
+
 // InitError is a helper function for easily initializing error object
 func InitError(msg string, errType int) *Error {
 	return &Error{Message: msg, ErrType: errType}

--- a/compiler/parser/errors/errors.go
+++ b/compiler/parser/errors/errors.go
@@ -42,7 +42,7 @@ func (e *Error) IsUnexpectedEnd() bool {
 	return e.ErrType == UnexpectedEndError
 }
 
-// IsUnexpectedTok checks if error is unexpected token error
+// IsUnexpectedToken checks if error is unexpected token error
 func (e *Error) IsUnexpectedToken() bool {
 	return e.ErrType == UnexpectedTokenError
 }

--- a/compiler/parser/errors/errors.go
+++ b/compiler/parser/errors/errors.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+
 	"github.com/goby-lang/goby/compiler/parser/arguments"
 )
 
@@ -39,6 +40,21 @@ func (e *Error) IsEOF() bool {
 // IsUnexpectedEnd checks if error is unexpected "end" keyword error
 func (e *Error) IsUnexpectedEnd() bool {
 	return e.ErrType == UnexpectedEndError
+}
+
+// IsUnexpectedTok checks if error is unexpected token error
+func (e *Error) IsUnexpectedToken() bool {
+	return e.ErrType == UnexpectedTokenError
+}
+
+// IsUnexpectedCase checks if error is unexpected token error for 'case'atement
+func (e *Error) IsUnexpectedCase() bool {
+	return e.ErrType == UnexpectedTokenError && len(e.Message) >= 49 && e.Message[0:49] == "expected next token to be WHEN, got EOF() instead"
+}
+
+// IsUnexpectedWhen checks if error is unexpected token error for 'case'atement
+func (e *Error) IsUnexpectedWhen() bool {
+	return e.ErrType == UnexpectedTokenError && len(e.Message) >= 21 && e.Message[0:21] == "unexpected when Line:"
 }
 
 // InitError is a helper function for easily initializing error object

--- a/compiler/parser/errors/errors.go
+++ b/compiler/parser/errors/errors.go
@@ -47,17 +47,17 @@ func (e *Error) IsUnexpectedToken() bool {
 	return e.ErrType == UnexpectedTokenError
 }
 
-// IsUnexpectedCase checks if error is unexpected token error for 'case'atement
+// IsUnexpectedCase checks if error is a token error for 'case' statement
 func (e *Error) IsUnexpectedCase() bool {
 	return e.ErrType == UnexpectedTokenError && len(e.Message) >= 49 && e.Message[0:49] == "expected next token to be WHEN, got EOF() instead"
 }
 
-// IsUnexpectedWhen checks if error is unexpected token error for 'case'atement
+// IsUnexpectedWhen checks if error is a token error for 'case'atement
 func (e *Error) IsUnexpectedWhen() bool {
 	return e.ErrType == UnexpectedTokenError && len(e.Message) >= 21 && e.Message[0:21] == "unexpected when Line:"
 }
 
-// IsUnexpectedEmptyLine checks if error is unexpected 'end' with empty line
+// IsUnexpectedEmptyLine checks if error is an 'end' with empty line
 func (e *Error) IsUnexpectedEmptyLine(len int) bool {
 	return e.IsUnexpectedEnd() && len == 0
 }

--- a/compiler/parser/flow_control_parsing.go
+++ b/compiler/parser/flow_control_parsing.go
@@ -43,11 +43,16 @@ func (p *Parser) parseCaseExpression() ast.Expression {
 
 // case expression parsing helpers
 func (p *Parser) parseCaseConditionals() []*ast.ConditionalExpression {
-	p.nextToken()
-	base := p.parseExpression(precedence.Normal)
+	var ce []*ast.ConditionalExpression
+	var base ast.Expression
+	if p.peekTokenIs(token.When) {
+		base = &ast.BooleanExpression{BaseNode: &ast.BaseNode{Token: token.Token{Type: token.True, Literal: "true", Line: p.curToken.Line}}, Value: true}
+	} else {
+		p.nextToken()
+		base = p.parseExpression(precedence.Normal)
+	}
 
 	p.expectPeek(token.When)
-	ce := []*ast.ConditionalExpression{}
 
 	for p.curTokenIs(token.When) {
 		ce = append(ce, p.parseCaseConditional(base))

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -205,7 +205,7 @@ reset:
 				igb.tokenErr = true
 				continue
 			// To handle empty line
-			case pErr.IsUnexpectedEnd() && len(igb.cmds) == 0:
+			case pErr.IsUnexpectedEmptyLine(len(igb.cmds)):
 				// If igb.cmds is empty, it means that user just typed 'end' without corresponding statement/expression
 				println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
 				igb.indents = 0

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -2,7 +2,6 @@ package igb
 
 import (
 	"fmt"
-	parserErr "github.com/goby-lang/goby/compiler/parser/errors"
 	"io"
 	"log"
 	"math/rand"
@@ -16,6 +15,7 @@ import (
 	"github.com/goby-lang/goby/compiler/bytecode"
 	"github.com/goby-lang/goby/compiler/lexer"
 	"github.com/goby-lang/goby/compiler/parser"
+	parserErr "github.com/goby-lang/goby/compiler/parser/errors"
 	"github.com/goby-lang/goby/vm"
 	"github.com/looplab/fsm"
 	"github.com/mattn/go-colorable"
@@ -49,6 +49,8 @@ type iGb struct {
 	lines     string
 	cmds      []string
 	indents   int
+	tokenErr  bool
+	firstWhen bool
 }
 
 // iVM holds VM only for iGb.
@@ -126,6 +128,8 @@ reset:
 				igb.rl.SetPrompt(prompt1)
 				igb.sm.Event(waitExited)
 				igb.cmds = nil
+				igb.tokenErr = false
+				igb.firstWhen = false
 				println(" -- block cleared")
 				continue
 			}
@@ -152,12 +156,13 @@ reset:
 		}
 
 		ivm.p.Lexer = lexer.New(igb.lines)
-		program, perr := ivm.p.ParseProgram()
+		program, pErr := ivm.p.ParseProgram()
 
 		// Parse error handling
-		if perr != nil {
+		if pErr != nil {
 			switch {
-			case perr.IsEOF():
+			// To handle beginning of a block
+			case pErr.IsEOF():
 				if !igb.sm.Is(Waiting) {
 					igb.sm.Event(Waiting)
 				}
@@ -166,28 +171,78 @@ reset:
 				igb.rl.SetPrompt(prompt(igb.indents) + indent(igb.indents))
 				igb.cmds = append(igb.cmds, igb.lines)
 				continue
-			case perr.IsUnexpectedEnd() && len(igb.cmds) == 0:
+			// To handle 'case'
+			case pErr.IsUnexpectedCase():
+				println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
+				igb.sm.Event(Waiting)
+				igb.rl.SetPrompt(prompt2 + indent(igb.indents))
+				igb.cmds = append(igb.cmds, igb.lines)
+				igb.tokenErr = true
+				igb.firstWhen = true
+				continue
+			// To handle 'when'
+			case pErr.IsUnexpectedWhen():
+				if igb.firstWhen {
+					igb.firstWhen = false
+				} else {
+					igb.indents--
+				}
+				println(prompt2 + indent(igb.indents) + igb.lines)
+				igb.indents++
+				igb.sm.Event(Waiting)
+				igb.rl.SetPrompt(prompt2 + indent(igb.indents))
+				igb.cmds = append(igb.cmds, igb.lines)
+				igb.tokenErr = true
+				continue
+			// To handle such as 'else' or 'elsif'
+			case pErr.IsUnexpectedToken():
+				igb.indents--
+				println(prompt2 + indent(igb.indents) + igb.lines)
+				igb.indents++
+				igb.sm.Event(Waiting)
+				igb.rl.SetPrompt(prompt2 + indent(igb.indents))
+				igb.cmds = append(igb.cmds, igb.lines)
+				igb.tokenErr = true
+				continue
+			// To handle empty line
+			case pErr.IsUnexpectedEnd() && len(igb.cmds) == 0:
 				// If igb.cmds is empty, it means that user just typed 'end' without corresponding statement/expression
 				println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
 				igb.indents = 0
 				igb.rl.SetPrompt(prompt1)
-				fmt.Println(perr.Message)
+				fmt.Println(pErr.Message)
 				igb.cmds = nil
 				continue
-			case perr.IsUnexpectedEnd():
+			// To handle 'end'
+			case pErr.IsUnexpectedEnd():
 				if igb.indents > 1 {
 					igb.indents--
 					println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
+					if igb.tokenErr {
+						igb.indents++
+					}
 					igb.sm.Event(Waiting)
 					igb.rl.SetPrompt(prompt(igb.indents) + indent(igb.indents))
 					igb.cmds = append(igb.cmds, igb.lines)
+					igb.tokenErr = false
+					igb.firstWhen = false
 					continue
 				}
 				igb.indents = 0
 				igb.sm.Event(waitEnded)
 				igb.rl.SetPrompt(prompt(igb.indents) + indent(igb.indents))
 				igb.cmds = append(igb.cmds, igb.lines)
+				igb.tokenErr = false
+				igb.firstWhen = false
 			}
+		}
+
+		if igb.sm.Is(Waiting) && igb.tokenErr {
+			igb.tokenErr = false
+			println(prompt2 + indent(igb.indents) + igb.lines)
+			igb.rl.SetPrompt(prompt2 + indent(igb.indents))
+			igb.cmds = append(igb.cmds, igb.lines)
+			continue
 		}
 
 		if igb.sm.Is(Waiting) && igb.indents > 0 {
@@ -201,10 +256,10 @@ reset:
 			ivm.p.Lexer = lexer.New(string(strings.Join(igb.cmds, "\n")))
 
 			// Test if current input can be properly parsed.
-			program, perr = ivm.p.ParseProgram()
+			program, pErr = ivm.p.ParseProgram()
 
-			if perr != nil {
-				handleParserError(perr, igb)
+			if pErr != nil {
+				handleParserError(pErr, igb)
 				igb.cmds = nil
 				igb.sm.Event(readyToExec)
 				continue
@@ -218,8 +273,8 @@ reset:
 		if igb.sm.Is(readyToExec) {
 			println(prompt(igb.indents) + igb.lines)
 
-			if perr != nil {
-				handleParserError(perr, igb)
+			if pErr != nil {
+				handleParserError(pErr, igb)
 				continue
 			}
 
@@ -276,6 +331,8 @@ func newIgb() *iGb {
 			readline.PcItem(help),
 			readline.PcItem(reset),
 		),
+		tokenErr:  false,
+		firstWhen: false,
 	}
 }
 

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -379,6 +379,49 @@ func TestCaseExpressionEvaluation(t *testing.T) {
 			end
 `, 1,
 		},
+		{
+			`
+    case
+    when 1
+      99
+    when 2
+      if true
+        88
+      elsif false
+        77
+      else
+       66
+      end
+    when 3
+      case
+      when 1
+        2
+      when 3
+        4
+      when 5
+        if true
+          3
+        else
+          4
+        end
+      else
+        222
+      end
+    when 99
+      88
+    else
+      0
+    end
+    case
+    when 7
+      55
+    when 8
+      44
+    else
+      33
+    end
+`, 33,
+		},
 	}
 
 	for i, tt := range tests {

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -369,6 +369,16 @@ func TestCaseExpressionEvaluation(t *testing.T) {
 			`,
 			3,
 		},
+		{
+			`
+			case
+			when 1 > 2
+				-1
+			when 1 < 2
+				1
+			end
+`, 1,
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
I realized that Ruby's `case` permits empty conditions:

```ruby
[1] pry(main)> case
[1] pry(main)* when 1
[1] pry(main)*   1
[1] pry(main)* when 2
[1] pry(main)*   2
[1] pry(main)* end
=> 1
```

Thus I have made the change to be like above:

```ruby
Goby 0.1.10 😌 👺 😻
» class Foo
¤   def bar
¤     case
¤     when 1
¤       99
¤     when 2
¤       if true
¤         88
¤       elsif false
¤         77
¤       else
¤         66
¤       end
¤     end
¤     case
¤     when 7
¤       55
¤     when 8
¤       44
¤     when 9
¤       33
¤     end
¤   end
» end
#»
```

Actually, previous REPL had an issue that it cannot handle `case` sentences well. I also fixed this and now works fine as above. 