### PR TITLE
Move ArgSet to arguments package/replace too simple functions to references

### DIFF
--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -187,8 +187,8 @@ func (g *Generator) compileAssignExpression(is *InstructionSet, exp *ast.AssignE
 
 func (g *Generator) compileBlockArgExpression(index int, exp *ast.CallExpression, scope *scope, table *localTable) {
 	is := &InstructionSet{}
-	is.name = fmt.Sprint(index)
-	is.isType = Block
+	is.Name = fmt.Sprint(index)
+	is.InstType = Block
 
 	for i := 0; i < len(exp.BlockArguments); i++ {
 		table.set(exp.BlockArguments[i].Value)

--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -2,6 +2,7 @@ package bytecode
 
 import (
 	"fmt"
+
 	"github.com/goby-lang/goby/compiler/ast"
 )
 
@@ -94,8 +95,8 @@ func (g *Generator) compileGetBlockExpression(is *InstructionSet, exp *ast.GetBl
 func (g *Generator) compileCallExpression(is *InstructionSet, exp *ast.CallExpression, scope *scope, table *localTable) {
 	var blockInfo string
 	argSet := &ArgSet{
-		names: make([]string, len(exp.Arguments)),
-		types: make([]uint8, len(exp.Arguments)),
+		Names: make([]string, len(exp.Arguments)),
+		Types: make([]uint8, len(exp.Arguments)),
 	}
 
 	// Compile receiver

--- a/compiler/bytecode/generator.go
+++ b/compiler/bytecode/generator.go
@@ -57,7 +57,7 @@ func (g *Generator) compileCodeBlock(is *InstructionSet, stmt *ast.BlockStatemen
 }
 
 func (g *Generator) endInstructions(is *InstructionSet, sourceLine int) {
-	if g.REPL && is.name == Program {
+	if g.REPL && is.Name == Program {
 		return
 	}
 	is.define(Leave, sourceLine)

--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -134,11 +134,11 @@ type ArgSet arguments.ArgSet
 
 // InstructionSet contains a set of Instructions and some metadata
 type InstructionSet struct {
-	name         string
-	isType       string
+	Name         string
+	InstType     string
 	Instructions []*Instruction
 	count        int
-	argTypes     *ArgSet
+	ArgSet       *ArgSet
 }
 
 func (as *ArgSet) FindIndex(name string) int {
@@ -154,21 +154,6 @@ func (as *ArgSet) FindIndex(name string) int {
 func (as *ArgSet) setArg(index int, name string, argType uint8) {
 	as.Names[index] = name
 	as.Types[index] = argType
-}
-
-// ArgTypes returns enums that represents each argument's type
-func (is *InstructionSet) ArgTypes() *ArgSet {
-	return is.argTypes
-}
-
-// Name returns instruction set's name
-func (is *InstructionSet) Name() string {
-	return is.name
-}
-
-// SetType returns instruction's type
-func (is *InstructionSet) Type() string {
-	return is.isType
 }
 
 func (is *InstructionSet) define(action uint8, sourceLine int, params ...interface{}) *Instruction {

--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -130,6 +130,7 @@ type anchor struct {
 	line int
 }
 
+// ArgSet struct comes from arguments package.
 type ArgSet arguments.ArgSet
 
 // InstructionSet contains a set of Instructions and some metadata

--- a/compiler/bytecode/instruction.go
+++ b/compiler/bytecode/instruction.go
@@ -3,6 +3,8 @@ package bytecode
 import (
 	"fmt"
 	"strings"
+
+	"github.com/goby-lang/goby/compiler/parser/arguments"
 )
 
 // instruction set types
@@ -15,7 +17,7 @@ const (
 
 // instruction actions
 const (
-	GetLocal            uint8 = iota
+	GetLocal uint8 = iota
 	GetConstant
 	GetInstanceVariable
 	SetLocal
@@ -46,7 +48,6 @@ const (
 	Dup
 	Leave
 )
-
 
 // InstructionNameTable is the table the maps instruction's op code with its readable name
 var InstructionNameTable = []string{
@@ -129,6 +130,8 @@ type anchor struct {
 	line int
 }
 
+type ArgSet arguments.ArgSet
+
 // InstructionSet contains a set of Instructions and some metadata
 type InstructionSet struct {
 	name         string
@@ -138,24 +141,8 @@ type InstructionSet struct {
 	argTypes     *ArgSet
 }
 
-// ArgSet stores the metadata of a method definition's parameters.
-type ArgSet struct {
-	names []string
-	types []uint8
-}
-
-// Types are the getter method of *ArgSet's types attribute
-func (as *ArgSet) Types() []uint8 {
-	return as.types
-}
-
-// Names are the getter method of *ArgSet's names attribute
-func (as *ArgSet) Names() []string {
-	return as.names
-}
-
 func (as *ArgSet) FindIndex(name string) int {
-	for i, n := range as.names {
+	for i, n := range as.Names {
 		if n == name {
 			return i
 		}
@@ -165,8 +152,8 @@ func (as *ArgSet) FindIndex(name string) int {
 }
 
 func (as *ArgSet) setArg(index int, name string, argType uint8) {
-	as.names[index] = name
-	as.types[index] = argType
+	as.Names[index] = name
+	as.Types[index] = argType
 }
 
 // ArgTypes returns enums that represents each argument's type
@@ -185,7 +172,7 @@ func (is *InstructionSet) Type() string {
 }
 
 func (is *InstructionSet) define(action uint8, sourceLine int, params ...interface{}) *Instruction {
-	i := &Instruction{Opcode: action, Params: params, line: is.count, sourceLine: sourceLine+1}
+	i := &Instruction{Opcode: action, Params: params, line: is.count, sourceLine: sourceLine + 1}
 	for _, param := range params {
 		a, ok := param.(*anchor)
 

--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -188,8 +188,8 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 		name:   stmt.Name.Value,
 		isType: MethodDef,
 		argTypes: &ArgSet{
-			names: make([]string, len(stmt.Parameters)),
-			types: make([]uint8, len(stmt.Parameters)),
+			Names: make([]string, len(stmt.Parameters)),
+			Types: make([]uint8, len(stmt.Parameters)),
 		},
 	}
 

--- a/compiler/bytecode/statement_generation.go
+++ b/compiler/bytecode/statement_generation.go
@@ -16,7 +16,7 @@ const (
 )
 
 func (g *Generator) compileStatements(stmts []ast.Statement, scope *scope, table *localTable) {
-	is := &InstructionSet{isType: Program, name: Program}
+	is := &InstructionSet{InstType: Program, Name: Program}
 
 	for _, statement := range stmts {
 		g.compileStatement(is, statement, scope, table)
@@ -120,7 +120,7 @@ func (g *Generator) compileBreakStatement(is *InstructionSet, stmt ast.Statement
 
 			y # 12
 		*/
-		if is.isType == Block {
+		if is.InstType == Block {
 			is.define(Break, stmt.Line())
 		}
 		jp := is.define(Jump, stmt.Line(), scope.anchors["break"])
@@ -146,8 +146,8 @@ func (g *Generator) compileClassStmt(is *InstructionSet, stmt *ast.ClassStatemen
 
 	// compile class's content
 	newIS := &InstructionSet{}
-	newIS.name = stmt.Name.Value
-	newIS.isType = ClassDef
+	newIS.Name = stmt.Name.Value
+	newIS.InstType = ClassDef
 
 	g.compileCodeBlock(newIS, stmt.Body, scope, scope.localTable)
 	newIS.define(Leave, stmt.Line())
@@ -161,8 +161,8 @@ func (g *Generator) compileModuleStmt(is *InstructionSet, stmt *ast.ModuleStatem
 
 	scope = newScope()
 	newIS := &InstructionSet{}
-	newIS.name = stmt.Name.Value
-	newIS.isType = ClassDef
+	newIS.Name = stmt.Name.Value
+	newIS.InstType = ClassDef
 
 	g.compileCodeBlock(newIS, stmt.Body, scope, scope.localTable)
 	newIS.define(Leave, stmt.Line())
@@ -185,9 +185,9 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 
 	// compile method definition's content
 	newIS := &InstructionSet{
-		name:   stmt.Name.Value,
-		isType: MethodDef,
-		argTypes: &ArgSet{
+		Name:     stmt.Name.Value,
+		InstType: MethodDef,
+		ArgSet: &ArgSet{
 			Names: make([]string, len(stmt.Parameters)),
 			Types: make([]uint8, len(stmt.Parameters)),
 		},
@@ -198,7 +198,7 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 		case *ast.Identifier:
 			scope.localTable.setLCL(exp.Value, scope.localTable.depth)
 
-			newIS.argTypes.setArg(i, exp.Value, NormalArg)
+			newIS.ArgSet.setArg(i, exp.Value, NormalArg)
 		case *ast.AssignExpression:
 			exp.Optioned = 1
 
@@ -206,7 +206,7 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 			varName := v.(*ast.Identifier)
 			g.compileAssignExpression(newIS, exp, scope, scope.localTable)
 
-			newIS.argTypes.setArg(i, varName.Value, OptionedArg)
+			newIS.ArgSet.setArg(i, varName.Value, OptionedArg)
 		case *ast.PrefixExpression:
 			if exp.Operator != "*" {
 				continue
@@ -219,7 +219,7 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 			newIS.define(NewArray, exp.Line(), 0)
 			newIS.define(SetLocal, exp.Line(), depth, index, 1)
 
-			newIS.argTypes.setArg(i, ident.Value, SplatArg)
+			newIS.ArgSet.setArg(i, ident.Value, SplatArg)
 		case *ast.ArgumentPairExpression:
 			key := exp.Key.(*ast.Identifier)
 			index, depth := scope.localTable.setLCL(key.Value, scope.localTable.depth)
@@ -227,9 +227,9 @@ func (g *Generator) compileDefStmt(is *InstructionSet, stmt *ast.DefStatement, s
 			if exp.Value != nil {
 				g.compileExpression(newIS, exp.Value, scope, scope.localTable)
 				newIS.define(SetLocal, exp.Line(), depth, index, 1)
-				newIS.argTypes.setArg(i, key.Value, OptionalKeywordArg)
+				newIS.ArgSet.setArg(i, key.Value, OptionalKeywordArg)
 			} else {
-				newIS.argTypes.setArg(i, key.Value, RequiredKeywordArg)
+				newIS.ArgSet.setArg(i, key.Value, RequiredKeywordArg)
 			}
 		}
 	}

--- a/compiler/parser/arguments/arguments.go
+++ b/compiler/parser/arguments/arguments.go
@@ -20,6 +20,12 @@ var Types = map[int]string{
 	SplatArg:           "Splat argument",
 }
 
+// ArgSet stores the metadata of a method definition's parameters.
+type ArgSet struct {
+	Names []string
+	Types []uint8
+}
+
 // Tokens marks token types that can be used as method call arguments
 var Tokens = map[token.Type]bool{
 	token.Int:              true,

--- a/native/ripper/ripper.go
+++ b/native/ripper/ripper.go
@@ -209,10 +209,10 @@ func convertToTuple(instSet []*bytecode.InstructionSet, v *VM) *ArrayObject {
 	ary := []Object{}
 	for _, instruction := range instSet {
 		hashInstLevel1 := make(map[string]Object)
-		hashInstLevel1["name"] = v.InitStringObject(instruction.Name())
-		hashInstLevel1["type"] = v.InitStringObject(instruction.Type())
-		if instruction.ArgTypes() != nil {
-			hashInstLevel1["arg_types"] = getArgNameType(instruction.ArgTypes(), v)
+		hashInstLevel1["name"] = v.InitStringObject(instruction.Name)
+		hashInstLevel1["type"] = v.InitStringObject(instruction.InstType)
+		if instruction.ArgSet != nil {
+			hashInstLevel1["arg_types"] = getArgNameType(instruction.ArgSet, v)
 		}
 		ary = append(ary, v.InitHashObject(hashInstLevel1))
 

--- a/native/ripper/ripper.go
+++ b/native/ripper/ripper.go
@@ -1,6 +1,9 @@
 package ripper
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/goby-lang/goby/compiler"
 	"github.com/goby-lang/goby/compiler/bytecode"
 	"github.com/goby-lang/goby/compiler/lexer"
@@ -9,8 +12,6 @@ import (
 	"github.com/goby-lang/goby/vm"
 	"github.com/goby-lang/goby/vm/classes"
 	"github.com/goby-lang/goby/vm/errors"
-	"strings"
-	"fmt"
 )
 
 // Ripper is a loadable library and has abilities to parse/lex/tokenize/get instructions of Goby codes from String.
@@ -60,14 +61,14 @@ func instruction(receiver Object, sourceLine int, t *Thread, args []Object) Obje
 	if len(args) != 1 {
 		return t.VM().InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
 	}
-	
+
 	arg, ok := args[0].(*StringObject)
 	if !ok {
 		return t.VM().InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 	}
-		
+
 	i, _ := compiler.CompileToInstructions(arg.Value().(string), parser.NormalMode)
-	
+
 	return convertToTuple(i, t.VM())
 }
 
@@ -84,16 +85,16 @@ func instruction(receiver Object, sourceLine int, t *Thread, args []Object) Obje
 //
 // @param Goby code [String]
 // @return [Array]
-func lex(receiver Object, sourceLine int, t *Thread, args []Object) Object  {
+func lex(receiver Object, sourceLine int, t *Thread, args []Object) Object {
 	if len(args) != 1 {
 		return t.VM().InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
 	}
-		
+
 	arg, ok := args[0].(*StringObject)
 	if !ok {
 		return t.VM().InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 	}
-		
+
 	l := lexer.New(arg.Value().(string))
 	array := t.VM().InitArrayObject([]Object{})
 	var elements []Object
@@ -136,16 +137,16 @@ func parse(receiver Object, sourceLine int, t *Thread, args []Object) Object {
 	if len(args) != 1 {
 		return t.VM().InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
 	}
-		
+
 	arg, ok := args[0].(*StringObject)
 	if !ok {
 		return t.VM().InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 	}
-		
+
 	l := lexer.New(arg.Value().(string))
 	p := parser.New(l)
 	program, _ := p.ParseProgram()
-		
+
 	return t.VM().InitStringObject(program.String())
 }
 
@@ -166,12 +167,12 @@ func tokenize(receiver Object, sourceLine int, t *Thread, args []Object) Object 
 	if len(args) != 1 {
 		return t.VM().InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got=%d", len(args))
 	}
-		
+
 	arg, ok := args[0].(*StringObject)
 	if !ok {
 		return t.VM().InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
 	}
-		
+
 	l := lexer.New(arg.Value().(string))
 	el := []Object{}
 	var nt token.Token
@@ -193,7 +194,7 @@ func init() {
 		map[string]vm.Method{
 			"instruction": instruction,
 			"lex":         lex,
-			"new": 				 new,
+			"new":         new,
 			"parse":       parse,
 			"tokenize":    tokenize,
 		},
@@ -214,7 +215,7 @@ func convertToTuple(instSet []*bytecode.InstructionSet, v *VM) *ArrayObject {
 			hashInstLevel1["arg_types"] = getArgNameType(instruction.ArgTypes(), v)
 		}
 		ary = append(ary, v.InitHashObject(hashInstLevel1))
-		
+
 		arrayInst := []Object{}
 		for _, ins := range instruction.Instructions {
 			hashInstLevel2 := make(map[string]Object)
@@ -223,20 +224,20 @@ func convertToTuple(instSet []*bytecode.InstructionSet, v *VM) *ArrayObject {
 			hashInstLevel2["source_line"] = v.InitIntegerObject(ins.SourceLine())
 			anchor := ins.AnchorLine()
 			hashInstLevel2["anchor"] = v.InitIntegerObject(anchor)
-			
+
 			arrayParams := []Object{}
 			for _, param := range ins.Params {
 				arrayParams = append(arrayParams, v.InitStringObject(covertTypesToString(param)))
 			}
 			hashInstLevel2["params"] = v.InitArrayObject(arrayParams)
-			
+
 			if ins.Opcode == bytecode.Send {
 				hashInstLevel1["arg_set"] = getArgNameType(ins.Params[3].(*bytecode.ArgSet), v)
 			}
-			
+
 			arrayInst = append(arrayInst, v.InitHashObject(hashInstLevel2))
 		}
-		
+
 		hashInstLevel1["instructions"] = v.InitArrayObject(arrayInst)
 		ary = append(ary, v.InitHashObject(hashInstLevel1))
 	}
@@ -245,18 +246,18 @@ func convertToTuple(instSet []*bytecode.InstructionSet, v *VM) *ArrayObject {
 
 func getArgNameType(argSet *bytecode.ArgSet, v *VM) *HashObject {
 	h := make(map[string]Object)
-	
+
 	aName := []Object{}
-	for _, argname := range argSet.Names() {
+	for _, argname := range argSet.Names {
 		aName = append(aName, v.InitStringObject(argname))
 	}
 	h["names"] = v.InitArrayObject(aName)
-	
+
 	aType := []Object{}
-	for _, argtype := range argSet.Types() {
+	for _, argtype := range argSet.Types {
 		aType = append(aType, v.InitIntegerObject(int(argtype)))
 	}
-	
+
 	h["types"] = v.InitArrayObject(aType)
 	return v.InitHashObject(h)
 }
@@ -336,7 +337,7 @@ func convertLex(t token.Type) string {
 	default:
 		s = strings.ToLower(string(t))
 	}
-	
+
 	return "on_" + s
 }
 

--- a/vm/call_object.go
+++ b/vm/call_object.go
@@ -51,7 +51,7 @@ func (co *callObject) argPosition() int {
 }
 
 func (co *callObject) assignNormalArguments(stack []*Pointer) {
-	for i, paramType := range co.method.instructionSet.paramTypes.Types {
+	for i, paramType := range co.method.instructionSet.ArgSet.Types {
 		if paramType == bytecode.NormalArg {
 			co.callFrame.insertLCL(i, 0, stack[co.argPosition()].Target)
 			co.argIndex++
@@ -104,7 +104,7 @@ func (co *callObject) assignKeywordArguments(stack []*Pointer) (err error) {
 }
 
 func (co *callObject) assignSplatArgument(stack []*Pointer, arr *ArrayObject) {
-	index := len(co.method.instructionSet.paramTypes.Types) - 1
+	index := len(co.method.instructionSet.ArgSet.Types) - 1
 
 	for co.argIndex < co.argCount {
 		arr.Elements = append(arr.Elements, stack[co.argPosition()].Target)
@@ -115,8 +115,8 @@ func (co *callObject) assignSplatArgument(stack []*Pointer, arr *ArrayObject) {
 }
 
 func (co *callObject) hasKeywordParam(name string) (index int, result bool) {
-	for paramIndex, paramType := range co.method.instructionSet.paramTypes.Types {
-		paramName := co.method.instructionSet.paramTypes.Names[paramIndex]
+	for paramIndex, paramType := range co.method.instructionSet.ArgSet.Types {
+		paramName := co.method.instructionSet.ArgSet.Names[paramIndex]
 
 		if paramName == name && (paramType == bytecode.RequiredKeywordArg || paramType == bytecode.OptionalKeywordArg) {
 			index = paramIndex
@@ -143,7 +143,7 @@ func (co *callObject) hasKeywordArgument(name string) (index int, result bool) {
 }
 
 func (co *callObject) normalParamsCount() (n int) {
-	for _, at := range co.method.instructionSet.paramTypes.Types {
+	for _, at := range co.method.instructionSet.ArgSet.Types {
 		if at == bytecode.NormalArg {
 			n++
 		}

--- a/vm/call_object.go
+++ b/vm/call_object.go
@@ -34,16 +34,12 @@ func newCallObject(receiver Object, method *MethodObject, receiverPtr, argCount 
 	}
 }
 
-func (co *callObject) instructionSet() *instructionSet {
-	return co.method.instructionSet
-}
-
 func (co *callObject) paramTypes() []uint8 {
-	return co.instructionSet().paramTypes.Types
+	return co.method.instructionSet.paramTypes.Types
 }
 
 func (co *callObject) paramNames() []string {
-	return co.instructionSet().paramTypes.Names
+	return co.method.instructionSet.paramTypes.Names
 }
 
 func (co *callObject) methodName() string {

--- a/vm/call_object.go
+++ b/vm/call_object.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"fmt"
+
 	"github.com/goby-lang/goby/compiler/bytecode"
 )
 
@@ -38,11 +39,11 @@ func (co *callObject) instructionSet() *instructionSet {
 }
 
 func (co *callObject) paramTypes() []uint8 {
-	return co.instructionSet().paramTypes.Types()
+	return co.instructionSet().paramTypes.Types
 }
 
 func (co *callObject) paramNames() []string {
-	return co.instructionSet().paramTypes.Names()
+	return co.instructionSet().paramTypes.Names
 }
 
 func (co *callObject) methodName() string {
@@ -54,7 +55,7 @@ func (co *callObject) argTypes() []uint8 {
 		return []uint8{}
 	}
 
-	return co.argSet.Types()
+	return co.argSet.Types
 }
 
 func (co *callObject) argPtr() int {
@@ -104,7 +105,7 @@ func (co *callObject) assignNormalAndOptionedArguments(paramIndex int, stack []*
 func (co *callObject) assignKeywordArguments(stack []*Pointer) (err error) {
 	for argIndex, argType := range co.argTypes() {
 		if argType == bytecode.RequiredKeywordArg || argType == bytecode.OptionalKeywordArg {
-			argName := co.argSet.Names()[argIndex]
+			argName := co.argSet.Names[argIndex]
 			paramIndex, ok := co.hasKeywordParam(argName)
 
 			if ok {
@@ -145,7 +146,7 @@ func (co *callObject) hasKeywordParam(name string) (index int, result bool) {
 
 func (co *callObject) hasKeywordArgument(name string) (index int, result bool) {
 	for argIndex, argType := range co.argTypes() {
-		argName := co.argSet.Names()[argIndex]
+		argName := co.argSet.Names[argIndex]
 
 		if argName == name && (argType == bytecode.RequiredKeywordArg || argType == bytecode.OptionalKeywordArg) {
 			index = argIndex

--- a/vm/call_object.go
+++ b/vm/call_object.go
@@ -34,10 +34,6 @@ func newCallObject(receiver Object, method *MethodObject, receiverPtr, argCount 
 	}
 }
 
-func (co *callObject) paramNames() []string {
-	return co.method.instructionSet.paramTypes.Names
-}
-
 func (co *callObject) argTypes() []uint8 {
 	if co.argSet == nil {
 		return []uint8{}
@@ -120,7 +116,7 @@ func (co *callObject) assignSplatArgument(stack []*Pointer, arr *ArrayObject) {
 
 func (co *callObject) hasKeywordParam(name string) (index int, result bool) {
 	for paramIndex, paramType := range co.method.instructionSet.paramTypes.Types {
-		paramName := co.paramNames()[paramIndex]
+		paramName := co.method.instructionSet.paramTypes.Names[paramIndex]
 
 		if paramName == name && (paramType == bytecode.RequiredKeywordArg || paramType == bytecode.OptionalKeywordArg) {
 			index = paramIndex

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -19,7 +19,7 @@ type instructionSet struct {
 	name         string
 	instructions []*bytecode.Instruction
 	filename     filename
-	paramTypes   *bytecode.ArgSet
+	ArgSet       *bytecode.ArgSet
 }
 
 var operations map[operationType]operation

--- a/vm/instruction_translator.go
+++ b/vm/instruction_translator.go
@@ -45,7 +45,7 @@ func (it *instructionTranslator) transferInstructionSets(sets []*bytecode.Instru
 	for _, set := range sets {
 		is := &instructionSet{filename: it.filename}
 		is.instructions = set.Instructions
-		is.paramTypes = set.ArgSet
+		is.ArgSet = set.ArgSet
 		it.setMetadata(is, set)
 	}
 }

--- a/vm/instruction_translator.go
+++ b/vm/instruction_translator.go
@@ -26,8 +26,8 @@ func newInstructionTranslator(file filename) *instructionTranslator {
 }
 
 func (it *instructionTranslator) setMetadata(is *instructionSet, set *bytecode.InstructionSet) {
-	t := set.Type()
-	n := set.Name()
+	t := set.InstType
+	n := set.Name
 
 	is.name = n
 
@@ -45,7 +45,7 @@ func (it *instructionTranslator) transferInstructionSets(sets []*bytecode.Instru
 	for _, set := range sets {
 		is := &instructionSet{filename: it.filename}
 		is.instructions = set.Instructions
-		is.paramTypes = set.ArgTypes()
+		is.paramTypes = set.ArgSet
 		it.setMetadata(is, set)
 	}
 }

--- a/vm/method.go
+++ b/vm/method.go
@@ -44,7 +44,7 @@ func (m *MethodObject) Value() interface{} {
 }
 
 func (m *MethodObject) paramTypes() []uint8 {
-	return m.instructionSet.paramTypes.Types()
+	return m.instructionSet.paramTypes.Types
 }
 
 func (m *MethodObject) isSplatArgIncluded() bool {

--- a/vm/method.go
+++ b/vm/method.go
@@ -44,7 +44,7 @@ func (m *MethodObject) Value() interface{} {
 }
 
 func (m *MethodObject) paramTypes() []uint8 {
-	return m.instructionSet.paramTypes.Types
+	return m.instructionSet.ArgSet.Types
 }
 
 func (m *MethodObject) isSplatArgIncluded() bool {

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -382,8 +382,8 @@ func (t *Thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject,
 // TODO: Move instruction into call object
 func (t *Thread) evalMethodObject(call *callObject) {
 	normalParamsCount := call.normalParamsCount()
-	paramTypes := call.method.instructionSet.paramTypes.Types
-	paramsCount := len(call.method.instructionSet.paramTypes.Types)
+	paramTypes := call.method.instructionSet.ArgSet.Types
+	paramsCount := len(call.method.instructionSet.ArgSet.Types)
 	stack := t.Stack.data
 	sourceLine := call.sourceLine
 
@@ -399,7 +399,7 @@ func (t *Thread) evalMethodObject(call *callObject) {
 	for paramIndex, paramType := range paramTypes {
 		switch paramType {
 		case bytecode.RequiredKeywordArg:
-			paramName := call.method.instructionSet.paramTypes.Names[paramIndex]
+			paramName := call.method.instructionSet.ArgSet.Names[paramIndex]
 			if _, ok := call.hasKeywordArgument(paramName); !ok {
 				t.setErrorObject(call.receiverPtr, call.argPtr(), errors.ArgumentError, sourceLine, "Method %s requires key argument %s", call.method.Name, paramName)
 			}

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -399,7 +399,7 @@ func (t *Thread) evalMethodObject(call *callObject) {
 	for paramIndex, paramType := range paramTypes {
 		switch paramType {
 		case bytecode.RequiredKeywordArg:
-			paramName := call.paramNames()[paramIndex]
+			paramName := call.method.instructionSet.paramTypes.Names[paramIndex]
 			if _, ok := call.hasKeywordArgument(paramName); !ok {
 				t.setErrorObject(call.receiverPtr, call.argPtr(), errors.ArgumentError, sourceLine, "Method %s requires key argument %s", call.method.Name, paramName)
 			}

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -382,17 +382,17 @@ func (t *Thread) evalBuiltinMethod(receiver Object, method *BuiltinMethodObject,
 // TODO: Move instruction into call object
 func (t *Thread) evalMethodObject(call *callObject) {
 	normalParamsCount := call.normalParamsCount()
-	paramTypes := call.paramTypes()
-	paramsCount := len(call.paramTypes())
+	paramTypes := call.method.instructionSet.paramTypes.Types
+	paramsCount := len(call.method.instructionSet.paramTypes.Types)
 	stack := t.Stack.data
 	sourceLine := call.sourceLine
 
 	if call.argCount > paramsCount && !call.method.isSplatArgIncluded() {
-		t.reportArgumentError(sourceLine, paramsCount, call.methodName(), call.argCount, call.receiverPtr)
+		t.reportArgumentError(sourceLine, paramsCount, call.method.Name, call.argCount, call.receiverPtr)
 	}
 
 	if normalParamsCount > call.argCount {
-		t.reportArgumentError(sourceLine, normalParamsCount, call.methodName(), call.argCount, call.receiverPtr)
+		t.reportArgumentError(sourceLine, normalParamsCount, call.method.Name, call.argCount, call.receiverPtr)
 	}
 
 	// Check if arguments include all the required keys before assign keyword arguments
@@ -401,7 +401,7 @@ func (t *Thread) evalMethodObject(call *callObject) {
 		case bytecode.RequiredKeywordArg:
 			paramName := call.paramNames()[paramIndex]
 			if _, ok := call.hasKeywordArgument(paramName); !ok {
-				t.setErrorObject(call.receiverPtr, call.argPtr(), errors.ArgumentError, sourceLine, "Method %s requires key argument %s", call.methodName(), paramName)
+				t.setErrorObject(call.receiverPtr, call.argPtr(), errors.ArgumentError, sourceLine, "Method %s requires key argument %s", call.method.Name, paramName)
 			}
 		}
 	}


### PR DESCRIPTION
Moved `ArgSet` structs to arguments.go.

I found some too simple functions just to return the value from deep structs, so replaced them.

```
benchmarking f54dc3e582496de9dd459c3858a38ff3844c3f54
benchmarking 08a436e3cf4f70a845ea3114428b42ada0d27700
x86_64-darwin17
benchmark                              old ns/op     new ns/op     delta
BenchmarkBasicMath/add-8               3298          3165          -4.03%
BenchmarkBasicMath/subtract-8          3266          3182          -2.57%
BenchmarkBasicMath/multiply-8          3308          3205          -3.11%
BenchmarkBasicMath/divide-8            3294          3213          -2.46%
BenchmarkConcurrency/concurrency-8     8511839       7654885       -10.07%

benchmark                              old allocs     new allocs     delta
BenchmarkBasicMath/add-8               33             33             +0.00%
BenchmarkBasicMath/subtract-8          33             33             +0.00%
BenchmarkBasicMath/multiply-8          33             33             +0.00%
BenchmarkBasicMath/divide-8            33             33             +0.00%
BenchmarkConcurrency/concurrency-8     53524          53520          -0.01%

benchmark                              old bytes     new bytes     delta
BenchmarkBasicMath/add-8               1568          1568          +0.00%
BenchmarkBasicMath/subtract-8          1568          1568          +0.00%
BenchmarkBasicMath/multiply-8          1568          1568          +0.00%
BenchmarkBasicMath/divide-8            1568          1568          +0.00%
BenchmarkConcurrency/concurrency-8     2729965       2729851       -0.00%
```