### PR TITLE
Fixes by go vet checks

### DIFF
--- a/vm/concurrent_hash.go
+++ b/vm/concurrent_hash.go
@@ -29,7 +29,7 @@ import (
 //
 type ConcurrentHashObject struct {
 	*BaseObj
-	internalMap sync.Map
+	internalMap *sync.Map
 }
 
 // Class methods --------------------------------------------------------
@@ -306,7 +306,7 @@ func (vm *VM) initConcurrentHashObject(pairs map[string]Object) *ConcurrentHashO
 
 	return &ConcurrentHashObject{
 		BaseObj:     &BaseObj{class: hash},
-		internalMap: internalMap,
+		internalMap: &internalMap,
 	}
 }
 

--- a/vm/concurrent_rw_lock.go
+++ b/vm/concurrent_rw_lock.go
@@ -24,7 +24,7 @@ import (
 //
 type ConcurrentRWLockObject struct {
 	*BaseObj
-	mutex sync.RWMutex
+	mutex *sync.RWMutex
 }
 
 // Class methods --------------------------------------------------------
@@ -228,7 +228,7 @@ func (vm *VM) initConcurrentRWLockObject() *ConcurrentRWLockObject {
 
 	return &ConcurrentRWLockObject{
 		BaseObj: &BaseObj{class: lockClass},
-		mutex:   sync.RWMutex{},
+		mutex:   &sync.RWMutex{},
 	}
 }
 

--- a/vm/error.go
+++ b/vm/error.go
@@ -37,7 +37,7 @@ func (vm *VM) InitNoMethodError(sourceLine int, methodName string, receiver Obje
 func (vm *VM) InitErrorObject(errorType string, sourceLine int, format string, args ...interface{}) *Error {
 	errClass := vm.objectClass.getClassConstant(errorType)
 
-	t := vm.mainThread
+	t := &vm.mainThread
 	cf := t.callFrameStack.top()
 
 	switch cf := cf.(type) {

--- a/vm/issue_vm.go
+++ b/vm/issue_vm.go
@@ -36,7 +36,7 @@ func PrintError(v *VM) {
 	fmt.Printf("### GOPATH\n%s\n", os.Getenv("GOPATH"))
 	fmt.Printf("### Operating system\n%s\n", runtime.GOOS)
 
-	t := v.mainThread
+	t := &v.mainThread
 	cf := t.callFrameStack.top()
 
 	file := cf.FileName()

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -202,15 +202,14 @@ func (t *Thread) reportErrorAndStop(e interface{}) {
 			err.storedTraces = true
 		}
 
-		panic(err)
-
 		if t.vm.mode == NormalMode {
 
 			if t.isMainThread() {
 				os.Exit(1)
 			}
 		}
-	// Otherwise it's a Go panic that needs to be raise
+		panic(err)
+		// Otherwise it's a Go panic that needs to be raise
 	default:
 		panic(e)
 	}


### PR DESCRIPTION
The go vet tools pointed out the following hidden issues so I fixed them:

```bash
$ go tool vet vm
vm/concurrent_hash.go:310: literal copies lock value from internalMap: sync.Map contains sync.Mutex
vm/concurrent_hash.go:328: return copies lock value: sync.Map contains sync.Mutex
vm/concurrent_rw_lock.go:249: return copies lock value: sync.RWMutex
vm/error.go:40: assignment copies lock value to t: vm.Thread contains vm.Stack
vm/issue_vm.go:39: assignment copies lock value to t: vm.Thread contains vm.Stack
vm/thread.go:207: unreachable code
```