### PR TITLE
vm: use type switch var binding to avoid redundant type assertions

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -528,20 +528,17 @@ func builtinArrayInstanceMethods() []*BuiltinMethodObject {
 
 				for i := 0; i < len(arr.Elements); i++ {
 					el := arr.Elements[i]
-					switch el.(type) {
+					switch el := el.(type) {
 					case *IntegerObject:
-						elInt := el.(*IntegerObject)
-						if findIsInt && findInt.equal(elInt) {
+						if findIsInt && findInt.equal(el) {
 							count++
 						}
 					case *StringObject:
-						elString := el.(*StringObject)
-						if findIsString && findString.equal(elString) {
+						if findIsString && findString.equal(el) {
 							count++
 						}
 					case *BooleanObject:
-						elBoolean := el.(*BooleanObject)
-						if findIsBoolean && findBoolean.equal(elBoolean) {
+						if findIsBoolean && findBoolean.equal(el) {
 							count++
 						}
 					}

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -296,10 +296,10 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 				rightObject := args[0]
 
-				switch rightObject.(type) {
+				switch rightObject := rightObject.(type) {
 				case *IntegerObject:
 					leftValue := receiver.(*IntegerObject).value
-					rightValue := rightObject.(*IntegerObject).value
+					rightValue := rightObject.value
 
 					if leftValue < rightValue {
 						return t.vm.InitIntegerObject(-1)
@@ -311,7 +311,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 					return t.vm.InitIntegerObject(0)
 				case *FloatObject:
 					leftValue := float64(receiver.(*IntegerObject).value)
-					rightValue := rightObject.(*FloatObject).value
+					rightValue := rightObject.value
 
 					if leftValue < rightValue {
 						return t.vm.InitIntegerObject(-1)
@@ -699,10 +699,10 @@ func (i *IntegerObject) arithmeticOperation(
 	sourceLine int,
 	division bool,
 ) Object {
-	switch rightObject.(type) {
+	switch rightObject := rightObject.(type) {
 	case *IntegerObject:
 		leftValue := i.value
-		rightValue := rightObject.(*IntegerObject).value
+		rightValue := rightObject.value
 		if division && rightValue == 0 {
 			return t.vm.InitErrorObject(errors.ZeroDivisionError, sourceLine, errors.DividedByZero)
 		}
@@ -712,7 +712,7 @@ func (i *IntegerObject) arithmeticOperation(
 		return t.vm.InitIntegerObject(result)
 	case *FloatObject:
 		leftValue := float64(i.value)
-		rightValue := rightObject.(*FloatObject).value
+		rightValue := rightObject.value
 
 		if division && rightValue == 0 {
 			return t.vm.InitErrorObject(errors.ZeroDivisionError, sourceLine, errors.DividedByZero)
@@ -730,15 +730,15 @@ func (i *IntegerObject) arithmeticOperation(
 // and false otherwise.
 // See comment on numericComparison().
 func (i *IntegerObject) equalityTest(rightObject Object) bool {
-	switch rightObject.(type) {
+	switch rightObject := rightObject.(type) {
 	case *IntegerObject:
 		leftValue := i.value
-		rightValue := rightObject.(*IntegerObject).value
+		rightValue := rightObject.value
 
 		return leftValue == rightValue
 	case *FloatObject:
 		leftValue := i.floatValue()
-		rightValue := rightObject.(*FloatObject).value
+		rightValue := rightObject.value
 
 		return leftValue == rightValue
 	default:
@@ -755,17 +755,17 @@ func (i *IntegerObject) numericComparison(
 	intComparison func(leftValue int, rightValue int) bool,
 	floatComparison func(leftValue float64, rightValue float64) bool,
 ) bool {
-	switch rightObject.(type) {
+	switch rightObject := rightObject.(type) {
 	case *IntegerObject:
 		leftValue := i.value
-		rightValue := rightObject.(*IntegerObject).value
+		rightValue := rightObject.value
 
 		result := intComparison(leftValue, rightValue)
 
 		return result
 	case *FloatObject:
 		leftValue := i.floatValue()
-		rightValue := rightObject.(*FloatObject).value
+		rightValue := rightObject.value
 
 		result := floatComparison(leftValue, rightValue)
 

--- a/vm/string.go
+++ b/vm/string.go
@@ -1044,12 +1044,10 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 				var result string
 				var err error
 				target := receiver.(*StringObject).value
-				switch args[0].(type) {
+				switch pattern := args[0].(type) {
 				case *StringObject:
-					pattern := args[0].(*StringObject)
 					result = strings.Replace(target, pattern.value, replacement.value, -1)
 				case *RegexpObject:
-					pattern := args[0].(*RegexpObject)
 					result, err = pattern.regexp.Replace(target, replacement.value, 0, -1)
 					if err != nil {
 						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.RegexpFailure, args[0].Class().Name)
@@ -1091,12 +1089,10 @@ func builtinStringInstanceMethods() []*BuiltinMethodObject {
 				var result string
 				var err error
 				target := receiver.(*StringObject).value
-				switch args[0].(type) {
+				switch pattern := args[0].(type) {
 				case *StringObject:
-					pattern := args[0].(*StringObject)
 					result = strings.Replace(target, pattern.value, replacement.value, 1)
 				case *RegexpObject:
-					pattern := args[0].(*RegexpObject)
 					result, err = pattern.regexp.Replace(target, replacement.value, 0, 1)
 					if err != nil {
 						return t.vm.InitErrorObject(errors.InternalError, sourceLine, errors.RegexpFailure, args[0].Class().Name)


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#typeSwitchVar-ref