### PR TITLE
vm: remove unnecessary lambda wrappers

### DIFF
--- a/vm/float.go
+++ b/vm/float.go
@@ -66,10 +66,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Float]
 			Name: "%",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				operation := func(leftValue float64, rightValue float64) float64 {
-					return math.Mod(leftValue, rightValue)
-				}
-
+				operation := math.Mod
 				return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, true)
 
 			},
@@ -117,10 +114,7 @@ func builtinFloatInstanceMethods() []*BuiltinMethodObject {
 			// @return [Float]
 			Name: "**",
 			Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-				operation := func(leftValue float64, rightValue float64) float64 {
-					return math.Pow(leftValue, rightValue)
-				}
-
+				operation := math.Pow
 				return receiver.(*FloatObject).arithmeticOperation(t, args[0], operation, sourceLine, false)
 
 			},

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -91,9 +91,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 				intOperation := func(leftValue int, rightValue int) int {
 					return leftValue % rightValue
 				}
-				floatOperation := func(leftValue float64, rightValue float64) float64 {
-					return math.Mod(leftValue, rightValue)
-				}
+				floatOperation := math.Mod
 
 				return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, true)
 
@@ -151,9 +149,7 @@ func builtinIntegerInstanceMethods() []*BuiltinMethodObject {
 				intOperation := func(leftValue int, rightValue int) int {
 					return int(math.Pow(float64(leftValue), float64(rightValue)))
 				}
-				floatOperation := func(leftValue float64, rightValue float64) float64 {
-					return math.Pow(leftValue, rightValue)
-				}
+				floatOperation := math.Pow
 
 				return receiver.(*IntegerObject).arithmeticOperation(t, args[0], intOperation, floatOperation, sourceLine, false)
 


### PR DESCRIPTION
Use function value directly.

Found using https://go-critic.github.io/overview#unlambda-ref