### PR TITLE
vm,cmd/binder,igb,compiler/parser: simplify `x = x <op> y` to `x <op> = y`

### DIFF
--- a/cmd/binder/main.go
+++ b/cmd/binder/main.go
@@ -174,7 +174,7 @@ func (b *Binding) body(receiver *Statement, f *File, d *ast.FuncDecl) {
 		if i == 0 {
 			continue
 		}
-		i = i - 1
+		i--
 		c := List(Id(fmt.Sprintf("arg%d", i)), Id("ok")).Op(":=").Id("args").Index(Lit(i)).Assert(Id(a.kind))
 		c = c.Line()
 		c = c.If(Op("!").Id("ok")).Block(

--- a/compiler/parser/method_call_parsing.go
+++ b/compiler/parser/method_call_parsing.go
@@ -65,7 +65,7 @@ func (p *Parser) parseCallExpressionWithReceiver(receiver ast.Expression) ast.Ex
 			p.nextToken()
 			exp.Arguments = p.parseCallArgumentsWithParens()
 		case token.Assign: // Setter method call like: p.foo = x
-			exp.Method = exp.Method + "="
+			exp.Method += "="
 			p.nextToken()
 			p.nextToken()
 			exp.Arguments = append(exp.Arguments, p.parseExpression(precedence.Normal))

--- a/compiler/parser/statement_parsing.go
+++ b/compiler/parser/statement_parsing.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+
 	"github.com/goby-lang/goby/compiler/ast"
 	"github.com/goby-lang/goby/compiler/parser/arguments"
 	"github.com/goby-lang/goby/compiler/parser/errors"
@@ -82,7 +83,7 @@ func (p *Parser) parseDefMethodStatement() *ast.DefStatement {
 
 	// Setter method def foo=()
 	if p.peekTokenIs(token.Assign) {
-		stmt.Name.Value = stmt.Name.Value + "="
+		stmt.Name.Value += "="
 		p.nextToken()
 	}
 

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -2,7 +2,6 @@ package igb
 
 import (
 	"fmt"
-	parserErr "github.com/goby-lang/goby/compiler/parser/errors"
 	"io"
 	"log"
 	"math/rand"
@@ -11,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	parserErr "github.com/goby-lang/goby/compiler/parser/errors"
 
 	"github.com/chzyer/readline"
 	"github.com/goby-lang/goby/compiler/bytecode"
@@ -335,7 +336,7 @@ func usage(w io.Writer, c *readline.PrefixCompleter) {
 func indent(c int) string {
 	var s string
 	for i := 0; i < c; i++ {
-		s = s + pad
+		s += pad
 	}
 	return s
 }

--- a/vm/class.go
+++ b/vm/class.go
@@ -1363,7 +1363,7 @@ func builtinClassCommonInstanceMethods() []*BuiltinMethodObject {
 					callerDir := path.Dir(t.vm.currentFilePath())
 					filePath := args[0].(*StringObject).value
 					filePath = path.Join(callerDir, filePath)
-					filePath = filePath + ".gb"
+					filePath += ".gb"
 
 					if t.execFile(filePath) != nil {
 						return t.vm.InitErrorObject(errors.IOError, sourceLine, errors.CantLoadFile, args[0].(*StringObject).value)

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -290,7 +290,7 @@ func (t *Thread) sendMethod(methodName string, argCount int, blockFrame *normalC
 		// Pop array
 		t.Stack.Pop()
 		// Can't count array self, only the number of array elements
-		argCount = argCount + len(arr.Elements)
+		argCount += len(arr.Elements)
 		for _, elem := range arr.Elements {
 			t.Stack.Push(&Pointer{Target: elem})
 		}


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#assignOp-ref