### PR TITLE
Remove an unnecessary from classes.go

### DIFF
--- a/vm/classes/classes.go
+++ b/vm/classes/classes.go
@@ -22,5 +22,4 @@ const (
 	GoMapClass     = "GoMap"
 	DecimalClass   = "Decimal"
 	BlockClass     = "Block"
-	RipperClass    = "Ripper"
 )


### PR DESCRIPTION
Just now I found that the entry for RipperClass in classes.go is unnecessary.