### PR TITLE
Support multiple line quotation on REPL

### DIFF
--- a/igb/manual_test.md
+++ b/igb/manual_test.md
@@ -49,7 +49,7 @@ Currently we are unable to perform automated tests against REPL. Follow the step
     Bye!
     ```
 
-### 2. trailing `;` feature for supressing echo back
+### 2. trailing `;` feature for suppressing echo back
 
 1. type a statement with a trailing `;`
     * expect: echo back is suppressed:
@@ -246,4 +246,37 @@ Currently we are unable to perform automated tests against REPL. Follow the step
     » x + y
     #» 19
     »
+    ```
+
+### 7. Handling multiple line quotation
+
+    * expect: treats multiple line double quotation including single quotes 
+    ```ruby
+    » if true
+    ¤   if true
+    ¤     puts "a", "a
+    ¤ b's
+    ¤ c"
+    ¤   end
+    » end
+    a
+    a
+    b
+    c
+    #»
+    ```
+
+    * expect: treats multiple line single quotation including double quotes 
+    ```ruby
+    » if true
+    ¤   if true
+    ¤     puts 'a', 'a
+    ¤ b "c"
+    ¤ c'
+    ¤   end
+    » end
+    a
+    b
+    c
+    #»
     ```

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -39,12 +39,20 @@ const (
 	waitEnded   = "waitEnded"
 	waitExited  = "waitExited"
 
+	NoMultiLineQuote          = "NoMultiLineQuote"
+	MultiLineDoubleQuote      = "MultiLineDoubleQuote"
+	MultiLineDoubleQuoteEnded = "MultiLineDoubleQuoteEnded"
+	MultiLineSingleQuote      = "MultiLineSingleQuote"
+	MultiLineSingleQuoteEnded = "MultiLineSingleQuoteEnded"
+	MultiLineQuoteExited      = "MultiLineQuoteExited"
+
 	emojis = "😀😁😂🤣😃😄😅😆😉😊😋😎😍😘😗😙😚🙂🤗🤔😐😑😶🙄😏😮😪😴😌😛😜😝🤤🙃🤑😲😭😳🤧😇🤠🤡🤥🤓😈👿👹👺💀👻👽🤖💩😺😸😹😻😼😽"
 )
 
 // iGb holds internal states of iGb.
 type iGb struct {
 	sm        *fsm.FSM
+	qsm       *fsm.FSM
 	rl        *readline.Instance
 	completer *readline.PrefixCompleter
 	lines     string
@@ -341,6 +349,17 @@ func newIgb() *iGb {
 				{Name: waitEnded, Src: []string{Waiting}, Dst: waitEnded},
 				{Name: waitExited, Src: []string{Waiting, waitEnded}, Dst: readyToExec},
 				{Name: readyToExec, Src: []string{waitEnded, readyToExec}, Dst: readyToExec},
+			},
+			fsm.Callbacks{},
+		),
+		qsm: fsm.NewFSM(
+			NoMultiLineQuote,
+			fsm.Events{
+				{Name: MultiLineDoubleQuote, Src: []string{NoMultiLineQuote}, Dst: MultiLineDoubleQuote},
+				{Name: MultiLineDoubleQuoteEnded, Src: []string{MultiLineDoubleQuote}, Dst: MultiLineDoubleQuoteEnded},
+				{Name: MultiLineSingleQuote, Src: []string{NoMultiLineQuote}, Dst: MultiLineSingleQuote},
+				{Name: MultiLineSingleQuoteEnded, Src: []string{MultiLineSingleQuote}, Dst: MultiLineSingleQuoteEnded},
+				{Name: MultiLineQuoteExited, Src: []string{MultiLineDoubleQuoteEnded, MultiLineSingleQuoteEnded}, Dst: NoMultiLineQuote},
 			},
 			fsm.Callbacks{},
 		),

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -231,6 +231,7 @@ reset:
 				println(prompt2 + indent(igb.indents) + igb.lines)
 				igb.indents++
 				igb.cmds = append(igb.cmds, igb.lines)
+				igb.rl.SetPrompt(prompt2 + indent(igb.indents))
 				igb.sm.Event(Waiting)
 				igb.caseBlock = true
 				continue
@@ -361,10 +362,11 @@ func handleParserError(e *parserErr.Error, igb *iGb) {
 func (igb *iGb) continueMultiLineQuote(cdq bool) bool {
 	if cdq { // end multi-line double quote
 		igb.qsm.Event(NoMultiLineQuote)
-		if igb.nqsm.Is(NestedQuote) { // end nested-quote and continue
-			igb.cmds = append(igb.cmds, igb.lines)
-			println(prompt2 + igb.lines)
+		if igb.nqsm.Is(NestedQuote) { // end nested-quote
 			igb.nqsm.Event(NoNestedQuote)
+			igb.cmds = append(igb.cmds, igb.lines)
+			println(prompt(igb.indents) + igb.lines)
+			igb.rl.SetPrompt(prompt2 + indent(igb.indents))
 			return true
 		} else { // exit multi-line double quote
 			igb.cmds = append(igb.cmds, igb.lines)

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -89,9 +89,9 @@ func println(s ...string) {
 // StartIgb starts goby's REPL.
 func StartIgb(version string) {
 	openDoubleQuote, _ := regexp2.Compile("(?<!\"[^\"]*?\")\"[^\"]+?$", 0)
-	closedDoubleQuote, _ := regexp2.Compile("^[^\"]*?\"(?!\"[^\"]*?\")", 0)
+	closedDoubleQuote, _ := regexp2.Compile("^[^\"\n]*\"([^\"\n]*\"[^\"\n]*\"[^\"\n]*)*$", 0)
 	openSingleQuote, _ := regexp2.Compile("(?<!'[^']*?')'[^']+?$", 0)
-	closedSingleQuote, _ := regexp2.Compile("^[^']*?'(?!'[^']*?')", 0)
+	closedSingleQuote, _ := regexp2.Compile("^[^'\n]*'([^'\n]*'[^'\n]*'[^'\n]*)*$", 0)
 
 reset:
 	var err error


### PR DESCRIPTION
Fixes https://github.com/goby-lang/goby/issues/378.
The commit supports multiple lines of double quotation as well as single quotation.

* expect: treats multiple line double quotation including single quotes 

```ruby
» if true
¤   if true
¤     puts "a", "a
¤ b's
¤ c"
¤   end
» end
a
a
b's
c
#»
 ```

* expect: treats multiple line single quotation including double quotes 

```ruby
» if true
¤   if true
¤     puts 'a', 'a
¤ b "c"
¤ c'
¤   end
» end
a
a
b "c"
c
#»
```