### PR TITLE
Fix #378: handle multiple double single quotation on igb REPL

### DIFF
--- a/igb/manual_test.md
+++ b/igb/manual_test.md
@@ -250,7 +250,7 @@ Currently we are unable to perform automated tests against REPL. Follow the step
 
 ### 7. Handling multiple line quotation
 
-    * expect: treats multiple line double quotation including single quotes 
+    * expect: treats multiple line double quotation including single quotes
     ```ruby
     » if true
     ¤   if true
@@ -261,12 +261,39 @@ Currently we are unable to perform automated tests against REPL. Follow the step
     » end
     a
     a
-    b
+    b's
     c
     #»
     ```
 
-    * expect: treats multiple line single quotation including double quotes 
+    * expect: treats multiple line double quotation including an open single quotes
+    ```ruby
+    » puts "a", "b'
+    ¤ c
+    ¤ d'
+    ¤ e'
+    » f"
+    a
+    b'
+    c
+    d'
+    e'
+    f
+    #»
+
+    » puts "a", "'b
+    ¤ d
+    ¤ b'
+    » e"
+    a
+    'b
+    d
+    b'
+    e
+    #»
+    ```
+
+    * expect: treats multiple line single quotation including double quotes
     ```ruby
     » if true
     ¤   if true
@@ -276,7 +303,30 @@ Currently we are unable to perform automated tests against REPL. Follow the step
     ¤   end
     » end
     a
-    b
+    a
+    b "c"
     c
+    #»
+    ```
+
+    * expect: treats multiple line single quotation including an open double quote
+    ```ruby
+    » puts 'a
+    ¤ b"
+    » c'
+    a
+    b"
+    c
+    #»
+
+    » puts 'b', '"c
+    ¤ d
+    ¤ e"
+    » d'
+    b
+    "c
+    d
+    e"
+    d
     #»
     ```

--- a/igb/manual_test.md
+++ b/igb/manual_test.md
@@ -49,7 +49,7 @@ Currently we are unable to perform automated tests against REPL. Follow the step
     Bye!
     ```
 
-### 2. trailing `;` feature for supressing echo back
+### 2. trailing `;` feature for suppressing echo back
 
 1. type a statement with a trailing `;`
     * expect: echo back is suppressed:
@@ -246,4 +246,37 @@ Currently we are unable to perform automated tests against REPL. Follow the step
     » x + y
     #» 19
     »
+    ```
+
+### 7. Handling multiple line quotation
+
+    * expect: treats multiple line double quotation including single quotes 
+    ```ruby
+    » if true
+    ¤   if true
+    ¤     puts "a", "a
+    ¤ b's
+    ¤ c"
+    ¤   end
+    » end
+    a
+    a
+    b
+    c
+    #»
+    ```
+
+    * expect: treats multiple line single quotation including double quotes 
+    ```ruby
+    » if true
+    ¤   if true
+    ¤     puts 'a', 'a
+    ¤ b "c"
+    ¤ c'
+    ¤   end
+    » end
+    a
+    b
+    c
+    #»
     ```

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -36,16 +36,16 @@ const (
 	reset     = "reset"
 
 	readyToExec = "readyToExec"
-	Waiting     = "waiting"
+	waiting     = "waiting"
 	waitEnded   = "waitEnded"
 	waitExited  = "waitExited"
 
-	NoMultiLineQuote     = "NoMultiLineQuote"
-	MultiLineDoubleQuote = "MultiLineDoubleQuote"
-	MultiLineSingleQuote = "MultiLineSingleQuote"
+	noMultiLineQuote     = "noMultiLineQuote"
+	multiLineDoubleQuote = "multiLineDoubleQuote"
+	multiLineSingleQuote = "multiLineSingleQuote"
 
-	NoNestedQuote = "NoNestedQuote"
-	NestedQuote   = "NestedQuote"
+	noNestedQuote = "noNestedQuote"
+	nestedQuote   = "nestedQuote"
 
 	emojis = "😀😁😂🤣😃😄😅😆😉😊😋😎😍😘😗😙😚🙂🤗🤔😐😑😶🙄😏😮😪😴😌😛😜😝🤤🙃🤑😲😭😳🤧😇🤠🤡🤥🤓😈👿👹👺💀👻👽🤖💩😺😸😹😻😼😽"
 )
@@ -147,24 +147,24 @@ reset:
 		sq := checkSingleQuoteOpen(igb.lines)
 
 		switch {
-		case igb.qsm.Is(NoMultiLineQuote):
+		case igb.qsm.Is(noMultiLineQuote):
 			switch {
 			case dq: // start multi-line double quote
-				igb.qsm.Event(MultiLineDoubleQuote)
+				igb.qsm.Event(multiLineDoubleQuote)
 				igb.startMultiLineQuote()
 				continue
 			case sq: // start multi-line single quote
-				igb.qsm.Event(MultiLineSingleQuote)
+				igb.qsm.Event(multiLineSingleQuote)
 				igb.startMultiLineQuote()
 				continue
 			}
 
-		case igb.qsm.Is(MultiLineDoubleQuote):
+		case igb.qsm.Is(multiLineDoubleQuote):
 			if igb.continueMultiLineQuote(dq) {
 				continue
 			}
 
-		case igb.qsm.Is(MultiLineSingleQuote):
+		case igb.qsm.Is(multiLineSingleQuote):
 			if igb.continueMultiLineQuote(sq) {
 				continue
 			}
@@ -199,8 +199,8 @@ reset:
 
 			// To handle beginning of a block
 			case pErr.IsEOF():
-				if !igb.sm.Is(Waiting) {
-					igb.sm.Event(Waiting)
+				if !igb.sm.Is(waiting) {
+					igb.sm.Event(waiting)
 				}
 				igb.printLineAndIndentRight()
 				continue
@@ -210,7 +210,7 @@ reset:
 				println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
 				igb.rl.SetPrompt(prompt2 + indent(igb.indents))
 				igb.cmds = append(igb.cmds, igb.lines)
-				igb.sm.Event(Waiting)
+				igb.sm.Event(waiting)
 				igb.caseBlock = true
 				igb.firstWhen = true
 				continue
@@ -226,7 +226,7 @@ reset:
 				igb.indents++
 				igb.cmds = append(igb.cmds, igb.lines)
 				igb.rl.SetPrompt(prompt2 + indent(igb.indents))
-				igb.sm.Event(Waiting)
+				igb.sm.Event(waiting)
 				igb.caseBlock = true
 				continue
 
@@ -235,7 +235,7 @@ reset:
 				println(prompt2 + indent(igb.indents-1) + igb.lines)
 				igb.rl.SetPrompt(prompt2 + indent(igb.indents))
 				igb.cmds = append(igb.cmds, igb.lines)
-				igb.sm.Event(Waiting)
+				igb.sm.Event(waiting)
 				continue
 
 			// To handle empty line
@@ -258,7 +258,7 @@ reset:
 					}
 					igb.rl.SetPrompt(prompt(igb.indents) + indent(igb.indents))
 					igb.cmds = append(igb.cmds, igb.lines)
-					igb.sm.Event(Waiting)
+					igb.sm.Event(waiting)
 					igb.caseBlock = false
 					igb.firstWhen = false
 					continue
@@ -274,7 +274,7 @@ reset:
 			}
 		}
 
-		if igb.sm.Is(Waiting) {
+		if igb.sm.Is(waiting) {
 			// Indent = 0 but not ended
 			if igb.caseBlock {
 				igb.caseBlock = false
@@ -355,9 +355,9 @@ func handleParserError(e *parserErr.Error, igb *iGb) {
 // Returns true if indentation continues.
 func (igb *iGb) continueMultiLineQuote(cdq bool) bool {
 	if cdq { // end multi-line double quote
-		igb.qsm.Event(NoMultiLineQuote)
-		if igb.nqsm.Is(NestedQuote) { // end nested-quote
-			igb.nqsm.Event(NoNestedQuote)
+		igb.qsm.Event(noMultiLineQuote)
+		if igb.nqsm.Is(nestedQuote) { // end nested-quote
+			igb.nqsm.Event(noNestedQuote)
 			igb.cmds = append(igb.cmds, igb.lines)
 			println(prompt(igb.indents) + igb.lines)
 			igb.rl.SetPrompt(prompt2 + indent(igb.indents))
@@ -380,7 +380,7 @@ func (igb *iGb) eraseBuffer() {
 	igb.indents = 0
 	igb.rl.SetPrompt(prompt1)
 	igb.sm.Event(waitExited)
-	igb.qsm.Event(NoMultiLineQuote)
+	igb.qsm.Event(noMultiLineQuote)
 	igb.cmds = nil
 	igb.caseBlock = false
 	igb.firstWhen = false
@@ -396,10 +396,10 @@ func (igb *iGb) printLineAndIndentRight() {
 
 // Starts multiple line quotation.
 func (igb *iGb) startMultiLineQuote() {
-	if igb.sm.Is(Waiting) {
-		igb.nqsm.Event(NestedQuote)
+	if igb.sm.Is(waiting) {
+		igb.nqsm.Event(nestedQuote)
 	} else {
-		igb.sm.Event(Waiting)
+		igb.sm.Event(waiting)
 	}
 	igb.cmds = append(igb.cmds, igb.lines)
 	println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
@@ -447,9 +447,9 @@ func newIgb() *iGb {
 		sm: fsm.NewFSM(
 			readyToExec,
 			fsm.Events{
-				{Name: Waiting, Src: []string{waitEnded, readyToExec}, Dst: Waiting},
-				{Name: waitEnded, Src: []string{Waiting}, Dst: waitEnded},
-				{Name: waitExited, Src: []string{Waiting, waitEnded}, Dst: readyToExec},
+				{Name: waiting, Src: []string{waitEnded, readyToExec}, Dst: waiting},
+				{Name: waitEnded, Src: []string{waiting}, Dst: waitEnded},
+				{Name: waitExited, Src: []string{waiting, waitEnded}, Dst: readyToExec},
 				{Name: readyToExec, Src: []string{waitEnded, readyToExec}, Dst: readyToExec},
 			},
 			fsm.Callbacks{},
@@ -457,20 +457,20 @@ func newIgb() *iGb {
 		// qsm is for controlling the status of multi-line quotation.
 		// Note that double and single multi-line quotations are exclusive and do not coexist.
 		qsm: fsm.NewFSM(
-			NoMultiLineQuote,
+			noMultiLineQuote,
 			fsm.Events{
-				{Name: NoMultiLineQuote, Src: []string{MultiLineDoubleQuote, MultiLineSingleQuote}, Dst: NoMultiLineQuote},
-				{Name: MultiLineDoubleQuote, Src: []string{NoMultiLineQuote}, Dst: MultiLineDoubleQuote},
-				{Name: MultiLineSingleQuote, Src: []string{NoMultiLineQuote}, Dst: MultiLineSingleQuote},
+				{Name: noMultiLineQuote, Src: []string{multiLineDoubleQuote, multiLineSingleQuote}, Dst: noMultiLineQuote},
+				{Name: multiLineDoubleQuote, Src: []string{noMultiLineQuote}, Dst: multiLineDoubleQuote},
+				{Name: multiLineSingleQuote, Src: []string{noMultiLineQuote}, Dst: multiLineSingleQuote},
 			},
 			fsm.Callbacks{},
 		),
-		// nqsm is for controlling the status if the multi-line quotation is nested within other "Waiting" statement.
+		// nqsm is for controlling the status if the multi-line quotation is nested within other "waiting" statement.
 		nqsm: fsm.NewFSM(
-			NoNestedQuote,
+			noNestedQuote,
 			fsm.Events{
-				{Name: NoNestedQuote, Src: []string{NestedQuote}, Dst: NoNestedQuote},
-				{Name: NestedQuote, Src: []string{NoNestedQuote}, Dst: NestedQuote},
+				{Name: noNestedQuote, Src: []string{nestedQuote}, Dst: noNestedQuote},
+				{Name: nestedQuote, Src: []string{noNestedQuote}, Dst: nestedQuote},
 			},
 			fsm.Callbacks{},
 		),

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -410,8 +410,7 @@ func (igb *iGb) startMultiLineQuote() {
 
 // filterInput just ignores Ctrl-z.
 func filterInput(r rune) (rune, bool) {
-	switch r {
-	case readline.CharCtrlZ:
+	if r == readline.CharCtrlZ {
 		return r, false
 	}
 	return r, true

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -173,20 +173,20 @@ reset:
 		// Command handling
 		switch {
 		case strings.HasPrefix(igb.lines, "#"):
-			println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
+			println(switchPrompt(igb.indents) + indent(igb.indents) + igb.lines)
 			continue
 		case igb.lines == help:
-			println(prompt(igb.indents) + igb.lines)
+			println(switchPrompt(igb.indents) + igb.lines)
 			usage(igb.rl.Stderr(), igb.completer)
 			continue
 		case igb.lines == reset:
 			igb.rl = nil
 			igb.cmds = nil
-			println(prompt(igb.indents) + igb.lines)
+			println(switchPrompt(igb.indents) + igb.lines)
 			println("Restarting iGb...")
 			goto reset
 		case igb.lines == "":
-			println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
+			println(switchPrompt(igb.indents) + indent(igb.indents) + igb.lines)
 			continue
 		}
 
@@ -207,7 +207,7 @@ reset:
 
 			// To handle 'case'
 			case pErr.IsUnexpectedCase():
-				println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
+				println(switchPrompt(igb.indents) + indent(igb.indents) + igb.lines)
 				igb.rl.SetPrompt(prompt2 + indent(igb.indents))
 				igb.cmds = append(igb.cmds, igb.lines)
 				igb.sm.Event(waiting)
@@ -242,7 +242,7 @@ reset:
 			case pErr.IsUnexpectedEmptyLine(len(igb.cmds)):
 				// If igb.cmds is empty, it means that user just typed 'end' without corresponding statement/expression
 				println("exceptEmptyLine")
-				println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
+				println(switchPrompt(igb.indents) + indent(igb.indents) + igb.lines)
 				igb.rl.SetPrompt(prompt1)
 				fmt.Println(pErr.Message)
 				igb.eraseBuffer()
@@ -252,11 +252,11 @@ reset:
 			case pErr.IsUnexpectedEnd():
 				if igb.indents > 1 {
 					igb.indents--
-					println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
+					println(switchPrompt(igb.indents) + indent(igb.indents) + igb.lines)
 					if igb.caseBlock {
 						igb.indents++
 					}
-					igb.rl.SetPrompt(prompt(igb.indents) + indent(igb.indents))
+					igb.rl.SetPrompt(switchPrompt(igb.indents) + indent(igb.indents))
 					igb.cmds = append(igb.cmds, igb.lines)
 					igb.sm.Event(waiting)
 					igb.caseBlock = false
@@ -266,7 +266,7 @@ reset:
 
 				// Exiting error handling
 				igb.indents = 0
-				igb.rl.SetPrompt(prompt(igb.indents) + indent(igb.indents))
+				igb.rl.SetPrompt(switchPrompt(igb.indents) + indent(igb.indents))
 				igb.cmds = append(igb.cmds, igb.lines)
 				igb.sm.Event(waitEnded)
 				igb.caseBlock = false
@@ -286,8 +286,8 @@ reset:
 
 			// Still indented
 			if igb.indents > 0 {
-				println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
-				igb.rl.SetPrompt(prompt(igb.indents) + indent(igb.indents))
+				println(switchPrompt(igb.indents) + indent(igb.indents) + igb.lines)
+				igb.rl.SetPrompt(switchPrompt(igb.indents) + indent(igb.indents))
 				igb.cmds = append(igb.cmds, igb.lines)
 				continue
 			}
@@ -307,13 +307,13 @@ reset:
 			}
 
 			// If everything goes well, reset state and statements buffer
-			igb.rl.SetPrompt(prompt(igb.indents))
+			igb.rl.SetPrompt(switchPrompt(igb.indents))
 			igb.sm.Event(readyToExec)
 		}
 
 		// Execute the lines
 		if igb.sm.Is(readyToExec) {
-			println(prompt(igb.indents) + igb.lines)
+			println(switchPrompt(igb.indents) + igb.lines)
 
 			if pErr != nil {
 				handleParserError(pErr, igb)
@@ -346,7 +346,7 @@ func handleParserError(e *parserErr.Error, igb *iGb) {
 		if !e.IsEOF() {
 			fmt.Println(e.Message)
 		}
-		println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
+		println(switchPrompt(igb.indents) + indent(igb.indents) + igb.lines)
 	}
 }
 
@@ -359,7 +359,7 @@ func (igb *iGb) continueMultiLineQuote(cdq bool) bool {
 		if igb.nqsm.Is(nestedQuote) { // end nested-quote
 			igb.nqsm.Event(noNestedQuote)
 			igb.cmds = append(igb.cmds, igb.lines)
-			println(prompt(igb.indents) + igb.lines)
+			println(switchPrompt(igb.indents) + igb.lines)
 			igb.rl.SetPrompt(prompt2 + indent(igb.indents))
 			return true
 		}
@@ -388,9 +388,9 @@ func (igb *iGb) eraseBuffer() {
 
 // Prints and add an indent.
 func (igb *iGb) printLineAndIndentRight() {
-	println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
+	println(switchPrompt(igb.indents) + indent(igb.indents) + igb.lines)
 	igb.indents++
-	igb.rl.SetPrompt(prompt(igb.indents) + indent(igb.indents))
+	igb.rl.SetPrompt(switchPrompt(igb.indents) + indent(igb.indents))
 	igb.cmds = append(igb.cmds, igb.lines)
 }
 
@@ -402,7 +402,7 @@ func (igb *iGb) startMultiLineQuote() {
 		igb.sm.Event(waiting)
 	}
 	igb.cmds = append(igb.cmds, igb.lines)
-	println(prompt(igb.indents) + indent(igb.indents) + igb.lines)
+	println(switchPrompt(igb.indents) + indent(igb.indents) + igb.lines)
 	igb.rl.SetPrompt(prompt2)
 }
 
@@ -511,8 +511,7 @@ func newIVM() (ivm iVM, err error) {
 func checkDoubleQuoteOpen(s string) bool {
 	openDoubleQuote, _ := regexp2.Compile(`^[^']*"`, 0)
 
-	s = strings.Replace(s, "\\\"", "", -1)
-	s = strings.Replace(s, "\\'", "", -1)
+	s = removeEscapedQuotes(s)
 	od, _ := openDoubleQuote.MatchString(s)
 	if strings.Count(s, "\"")%2 == 1 && od {
 		return true
@@ -524,8 +523,7 @@ func checkDoubleQuoteOpen(s string) bool {
 func checkSingleQuoteOpen(s string) bool {
 	openSingleQuote, _ := regexp2.Compile(`^[^"]*'`, 0)
 
-	s = strings.Replace(s, "\\\"", "", -1)
-	s = strings.Replace(s, "\\'", "", -1)
+	s = removeEscapedQuotes(s)
 	sd, _ := openSingleQuote.MatchString(s)
 	if strings.Count(s, "'")%2 == 1 && sd {
 		return true
@@ -533,8 +531,14 @@ func checkSingleQuoteOpen(s string) bool {
 	return false
 }
 
-// prompt switches prompt sign.
-func prompt(s int) string {
+func removeEscapedQuotes(s string) string {
+	s = strings.Replace(s, "\\\"", "", -1)
+	s = strings.Replace(s, "\\'", "", -1)
+	return s
+}
+
+// switchPrompt switches the prompt sign.
+func switchPrompt(s int) string {
 	if s > 0 {
 		return prompt2
 	}

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -39,12 +39,20 @@ const (
 	waitEnded   = "waitEnded"
 	waitExited  = "waitExited"
 
+	NoMultiLineQuote          = "NoMultiLineQuote"
+	MultiLineDoubleQuote      = "MultiLineDoubleQuote"
+	MultiLineDoubleQuoteEnded = "MultiLineDoubleQuoteEnded"
+	MultiLineSingleQuote      = "MultiLineSingleQuote"
+	MultiLineSingleQuoteEnded = "MultiLineSingleQuoteEnded"
+	MultiLineQuoteExited      = "MultiLineQuoteExited"
+
 	emojis = "😀😁😂🤣😃😄😅😆😉😊😋😎😍😘😗😙😚🙂🤗🤔😐😑😶🙄😏😮😪😴😌😛😜😝🤤🙃🤑😲😭😳🤧😇🤠🤡🤥🤓😈👿👹👺💀👻👽🤖💩😺😸😹😻😼😽"
 )
 
 // iGb holds internal states of iGb.
 type iGb struct {
 	sm        *fsm.FSM
+	qsm       *fsm.FSM
 	rl        *readline.Instance
 	completer *readline.PrefixCompleter
 	lines     string
@@ -341,6 +349,17 @@ func newIgb() *iGb {
 				{Name: waitEnded, Src: []string{Waiting}, Dst: waitEnded},
 				{Name: waitExited, Src: []string{Waiting, waitEnded}, Dst: readyToExec},
 				{Name: readyToExec, Src: []string{waitEnded, readyToExec}, Dst: readyToExec},
+			},
+			fsm.Callbacks{},
+		),
+		qsm: fsm.NewFSM(
+			NoMultiLineQuote,
+			fsm.Events{
+				{Name: MultiLineDoubleQuote, Src: []string{NoMultiLineQuote}, Dst: MultiLineDoubleQuote},
+				{Name: MultiLineDoubleQuoteEnded, Src: []string{MultiLineDoubleQuote}, Dst: MultiLineDoubleQuoteEnded},
+				{Name: MultiLineSingleQuote, Src: []string{NoMultiLineQuote}, Dst: MultiLineSingleQuote},
+				{Name: MultiLineSingleQuoteEnded, Src: []string{MultiLineSingleQuote}, Dst: MultiLineSingleQuoteEnded},
+				{Name: MultiLineQuoteExited, Src: []string{MultiLineDoubleQuoteEnded, MultiLineSingleQuoteEnded}, Dst: NoMultiLineQuote},
 			},
 			fsm.Callbacks{},
 		),

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -2,6 +2,7 @@ package igb
 
 import (
 	"fmt"
+	"github.com/dlclark/regexp2"
 	"io"
 	"log"
 	"math/rand"
@@ -508,8 +509,12 @@ func newIVM() (ivm iVM, err error) {
 
 // Returns true if double quotation in the string is open.
 func checkDoubleQuoteOpen(s string) bool {
+	openDoubleQuote, _ := regexp2.Compile(`^[^']*"`, 0)
+
 	s = strings.Replace(s, "\\\"", "", -1)
-	if strings.Count(s, "\"")%2 == 1 {
+	s = strings.Replace(s, "\\'", "", -1)
+	od, _ := openDoubleQuote.MatchString(s)
+	if strings.Count(s, "\"")%2 == 1 && od {
 		return true
 	}
 	return false
@@ -517,8 +522,12 @@ func checkDoubleQuoteOpen(s string) bool {
 
 // Returns true if single quotation in the string is open.
 func checkSingleQuoteOpen(s string) bool {
+	openSingleQuote, _ := regexp2.Compile(`^[^"]*'`, 0)
+
+	s = strings.Replace(s, "\\\"", "", -1)
 	s = strings.Replace(s, "\\'", "", -1)
-	if strings.Count(s, "'")%2 == 1 {
+	sd, _ := openSingleQuote.MatchString(s)
+	if strings.Count(s, "'")%2 == 1 && sd {
 		return true
 	}
 	return false

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -231,6 +231,7 @@ reset:
 				println(prompt2 + indent(igb.indents) + igb.lines)
 				igb.indents++
 				igb.cmds = append(igb.cmds, igb.lines)
+				igb.rl.SetPrompt(prompt2 + indent(igb.indents))
 				igb.sm.Event(Waiting)
 				igb.caseBlock = true
 				continue
@@ -361,10 +362,11 @@ func handleParserError(e *parserErr.Error, igb *iGb) {
 func (igb *iGb) continueMultiLineQuote(cdq bool) bool {
 	if cdq { // end multi-line double quote
 		igb.qsm.Event(NoMultiLineQuote)
-		if igb.nqsm.Is(NestedQuote) { // end nested-quote and continue
-			igb.cmds = append(igb.cmds, igb.lines)
-			println(prompt2 + igb.lines)
+		if igb.nqsm.Is(NestedQuote) { // end nested-quote
 			igb.nqsm.Event(NoNestedQuote)
+			igb.cmds = append(igb.cmds, igb.lines)
+			println(prompt(igb.indents) + igb.lines)
+			igb.rl.SetPrompt(prompt2 + indent(igb.indents))
 			return true
 		} else { // exit multi-line double quote
 			igb.cmds = append(igb.cmds, igb.lines)

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -143,8 +143,8 @@ reset:
 		}
 
 		// Multi-line quotation handling
-		dq := checkDoubleQuoteOpen(igb.lines)
-		sq := checkSingleQuoteOpen(igb.lines)
+		dq := checkOpenQuotes(igb.lines, `"`, `'`)
+		sq := checkOpenQuotes(igb.lines, `'`, `"`)
 
 		switch {
 		case igb.qsm.Is(noMultiLineQuote):
@@ -507,34 +507,17 @@ func newIVM() (ivm iVM, err error) {
 	return ivm, nil
 }
 
-// Returns true if double quotation in the string is open.
-func checkDoubleQuoteOpen(s string) bool {
-	openDoubleQuote, _ := regexp2.Compile(`^[^']*"`, 0)
+// Returns true if the specified quotation in the string is open.
+func checkOpenQuotes(s, open, ignore string) bool {
+	s = strings.Replace(s, `\\"`, "", -1)
+	s = strings.Replace(s, `\\'`, "", -1)
 
-	s = removeEscapedQuotes(s)
-	od, _ := openDoubleQuote.MatchString(s)
-	if strings.Count(s, "\"")%2 == 1 && od {
+	rq, _ := regexp2.Compile(`^[^`+ignore+`]*`+open, 0)
+	isOpen, _ := rq.MatchString(s)
+	if strings.Count(s, open)%2 == 1 && isOpen {
 		return true
 	}
 	return false
-}
-
-// Returns true if single quotation in the string is open.
-func checkSingleQuoteOpen(s string) bool {
-	openSingleQuote, _ := regexp2.Compile(`^[^"]*'`, 0)
-
-	s = removeEscapedQuotes(s)
-	sd, _ := openSingleQuote.MatchString(s)
-	if strings.Count(s, "'")%2 == 1 && sd {
-		return true
-	}
-	return false
-}
-
-func removeEscapedQuotes(s string) string {
-	s = strings.Replace(s, "\\\"", "", -1)
-	s = strings.Replace(s, "\\'", "", -1)
-	return s
 }
 
 // switchPrompt switches the prompt sign.

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -89,9 +89,9 @@ func println(s ...string) {
 // StartIgb starts goby's REPL.
 func StartIgb(version string) {
 	openDoubleQuote, _ := regexp2.Compile("(?<!\"[^\"]*?\")\"[^\"]+?$", 0)
-	closedDoubleQuote, _ := regexp2.Compile("^[^\"]*?\"(?!\"[^\"]*?\")", 0)
+	closedDoubleQuote, _ := regexp2.Compile("^[^\"\n]*\"([^\"\n]*\"[^\"\n]*\"[^\"\n]*)*$", 0)
 	openSingleQuote, _ := regexp2.Compile("(?<!'[^']*?')'[^']+?$", 0)
-	closedSingleQuote, _ := regexp2.Compile("^[^']*?'(?!'[^']*?')", 0)
+	closedSingleQuote, _ := regexp2.Compile("^[^'\n]*'([^'\n]*'[^'\n]*'[^'\n]*)*$", 0)
 
 reset:
 	var err error

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -231,6 +231,7 @@ reset:
 				continue
 
 			// To handle such as 'else' or 'elsif'
+			// The prompt should be `¤` even on the top level indentation when the line is `else` or `elif` or like that
 			case pErr.IsUnexpectedToken():
 				println(prompt2 + indent(igb.indents-1) + igb.lines)
 				igb.rl.SetPrompt(prompt2 + indent(igb.indents))

--- a/igb/repl.go
+++ b/igb/repl.go
@@ -362,11 +362,6 @@ func (igb *iGb) continueMultiLineQuote(cdq bool) bool {
 			println(prompt(igb.indents) + igb.lines)
 			igb.rl.SetPrompt(prompt2 + indent(igb.indents))
 			return true
-		} else { // exit multi-line double quote
-			igb.cmds = append(igb.cmds, igb.lines)
-			igb.rl.SetPrompt(prompt1)
-			igb.sm.Event(waitEnded)
-			return false
 		}
 	} else { // continue multi-line double quote
 		println(prompt2 + igb.lines)
@@ -374,6 +369,11 @@ func (igb *iGb) continueMultiLineQuote(cdq bool) bool {
 		igb.cmds = append(igb.cmds, igb.lines)
 		return true
 	}
+	// exit multi-line double quote
+	igb.cmds = append(igb.cmds, igb.lines)
+	igb.rl.SetPrompt(prompt1)
+	igb.sm.Event(waitEnded)
+	return false
 }
 
 func (igb *iGb) eraseBuffer() {


### PR DESCRIPTION
Fixes #378.

Finally fixed the bug when multiple double/single quotations are in one line on igb REPL. Sorry for the delay🙇 @st0012 

   * expect: treats multiple line double quotation including single quotes

    ```ruby
    » if true
    ¤   if true
    ¤     puts "a", "a
    ¤ b's
    ¤ c"
    ¤   end
    » end
    a
    a
    b's
    c
    #»
    ```

* expect: treats multiple line double quotation including an open single quotes

    ```ruby
    » puts "a", "b'
    ¤ c
    ¤ d'
    ¤ e'
    » f"
    a
    b'
    c
    d'
    e'
    f
    #»

    » puts "a", "'b
    ¤ d
    ¤ b'
    » e"
    a
    'b
    d
    b'
    e
    #»
    ```

* expect: treats multiple line single quotation including double quotes

    ```ruby
    » if true
    ¤   if true
    ¤     puts 'a', 'a
    ¤ b "c"
    ¤ c'
    ¤   end
    » end
    a
    a
    b "c"
    c
    #»
    ```

* expect: treats multiple line single quotation including an open double quote

    ```ruby
    » puts 'a
    ¤ b"
    » c'
    a
    b"
    c
    #»

    » puts 'b', '"c
    ¤ d
    ¤ e"
    » d'
    b
    "c
    d
    e"
    d
    #»
    ```