### PR TITLE
Add xenial to matrix of Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
+
 language: go
 
-go:
-  - "1.10.x"
-  - "1.11.x"
+matrix:
+  include:
+    - go: 1.10.x
+      dist: trusty
+    - go: 1.10.x
+      dist: xenial
+    - go: 1.11.x
+      # trusty builds with 1.11 are [currently broken](https://github.com/golang/go/issues/31293)
+      dist: xenial
 
 services:
   - postgresql


### PR DESCRIPTION
With the current setup, the Trusty+1.11 build breaks, so it's excluded.