### PR TITLE
Replace fmt.Sprintf with strconv

### DIFF
--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -2,7 +2,6 @@ package ast
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 )
 
@@ -118,10 +117,10 @@ func (ape *ArgumentPairExpression) TokenLiteral() string {
 // String .....
 func (ape *ArgumentPairExpression) String() string {
 	if ape.Value == nil {
-		return fmt.Sprintf("%s:", ape.Key.String())
+		return ape.Key.String() + ":"
 	}
 
-	return fmt.Sprintf("%s: %s", ape.Key.String(), ape.Value.String())
+	return ape.Key.String() + ": " + ape.Value.String()
 }
 
 // HashExpression defines the hash expression literal which contains the node expression and its value
@@ -143,7 +142,7 @@ func (he *HashExpression) String() string {
 	var pairs []string
 
 	for key, value := range he.Data {
-		pairs = append(pairs, fmt.Sprintf("%s: %s", key, value.String()))
+		pairs = append(pairs, "%s: %s", key + ": " + value.String())
 	}
 
 	out.WriteString("{ ")

--- a/compiler/bytecode/expression_generation.go
+++ b/compiler/bytecode/expression_generation.go
@@ -3,6 +3,7 @@ package bytecode
 import (
 	"fmt"
 	"github.com/goby-lang/goby/compiler/ast"
+	"strconv"
 )
 
 func (g *Generator) compileExpression(is *InstructionSet, exp ast.Expression, scope *scope, table *localTable) {
@@ -135,7 +136,7 @@ func (g *Generator) compileCallExpression(is *InstructionSet, exp *ast.CallExpre
 		newTable := newLocalTable(table.depth + 1)
 		newTable.upper = table
 		blockIndex := g.blockCounter
-		blockInfo = fmt.Sprintf("block:%d", blockIndex)
+		blockInfo = "block:" + strconv.Itoa(blockIndex)
 		g.blockCounter++
 		g.compileBlockArgExpression(blockIndex, exp, scope, newTable)
 	}

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -2,7 +2,6 @@ package vm
 
 import (
 	"bytes"
-	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -1237,7 +1236,7 @@ func (h *HashObject) ToString() string {
 	var pairs []string
 
 	for _, key := range h.sortedKeys() {
-		pairs = append(pairs, fmt.Sprintf("%s: %s", key, h.Pairs[key].Inspect()))
+		pairs = append(pairs, key + ": " + h.Pairs[key].Inspect())
 	}
 
 	out.WriteString("{ ")


### PR DESCRIPTION
This is a PR for testing an optimization technic.

According to [this article](https://stephen.sh/posts/quick-go-performance-improvements), `fmt.Sprintf` is less performant than `strconv`.

```
🍎 strfmt → go test -bench=. -benchmem
goos: darwin
goarch: amd64
pkg: github.com/sjwhitworth/perfblog/strfmt
BenchmarkStrconv-8      30000000            39.5 ns/op        32 B/op          1 allocs/op
BenchmarkFmt-8          10000000           143 ns/op          72 B/op          3 allocs/op
```

So I changed some hotspots' `fmt.Sprintf` usages with more low level operations. (We actually use `fmt.Sprintf` a lot but most for inspection methods, but I think there's no need to change them.)
