### PR TITLE
Return error when found invalid assignment value (currently ignore)

### DIFF
--- a/compiler/ast/expressions.go
+++ b/compiler/ast/expressions.go
@@ -146,9 +146,9 @@ func (he *HashExpression) String() string {
 		pairs = append(pairs, fmt.Sprintf("%s: %s", key, value.String()))
 	}
 
-	out.WriteString("{ ")
+	out.WriteString("{")
 	out.WriteString(strings.Join(pairs, ", "))
-	out.WriteString(" }")
+	out.WriteString("}")
 
 	return out.String()
 }

--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -57,6 +57,9 @@ func (p *Parser) parseAssignExpression(v ast.Expression) ast.Expression {
 
 		errMsg := fmt.Sprintf("Can't assign value to %s. Line: %d", v.String(), p.curToken.Line)
 		p.error = errors.InitError(errMsg, errors.InvalidAssignmentError)
+	default:
+		errMsg := fmt.Sprintf("Can't assign value to %s. Line: %d", v.String(), p.curToken.Line)
+		p.error = errors.InitError(errMsg, errors.InvalidAssignmentError)
 	}
 
 	if len(exp.Variables) == 1 {

--- a/compiler/parser/expression_parsing_test.go
+++ b/compiler/parser/expression_parsing_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"github.com/goby-lang/goby/compiler/ast"
 	"github.com/goby-lang/goby/compiler/lexer"
 	"testing"
@@ -165,6 +166,30 @@ func TestAssignExpressionWithLiteralValue(t *testing.T) {
 			assignExp.TestableValue().IsStringLiteral(t).ShouldEqualTo(v)
 		case bool:
 			assignExp.TestableValue().IsBooleanExpression(t).ShouldEqualTo(v)
+		}
+	}
+}
+
+func TestAssignExpressionWithInvalidValue(t *testing.T) {
+	tests := []struct {
+		input         string
+		expectedError string
+	}{
+		{"123 = []", "Can't assign value to 123. Line: 0"},
+		{"[] = []", "Can't assign value to []. Line: 0"},
+		{"{} = []", "Can't assign value to {}. Line: 0"},
+	}
+
+	for _, tt := range tests {
+		l := lexer.New(tt.input)
+		p := New(l)
+
+		_, err := p.ParseProgram()
+
+		if err == nil {
+			t.Fatal(fmt.Sprintf("Expect %s to cause parser error", tt.input))
+		} else if err.Message != tt.expectedError {
+			t.Fatal(fmt.Sprintf("Expect error message to be '%s', got '%s'", tt.expectedError, err.Message))
 		}
 	}
 }


### PR DESCRIPTION
This fixes certain invalid syntaxes reported in #783 like

```
123 = []
[] = []
{} = []
```

But cases like `123foo = []` are caused by lexer's whitespace-insensitive. Which means that it doesn't consider whitespace while reading characters. So in this case, it'll tokenize the code into `Int, Ident, Eq, LBracket and RBracket` instead of `Illegal, Eq, LBracket and RBracket`.

To make the lexer whitespace-sensetive, we need to do some refactoring or even redesign for our lexer. So I choose to pick the low hanging fruits first and address that in other PR.