### PR TITLE
Implement dup

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -618,6 +618,18 @@ var builtinArrayInstanceMethods = []*BuiltinMethodObject{
 		},
 	},
 	{
+		Name: "dup",
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			arr, _ := receiver.(*ArrayObject)
+			newArr := make([]Object, len(arr.Elements))
+			copy(newArr, arr.Elements)
+			newObj := t.vm.InitArrayObject(newArr)
+			newObj.setInstanceVariables(arr.instanceVariables().copy())
+
+			return newObj
+		},
+	},
+	{
 		// Loops through each element in the array, with the given block.
 		// Returns self.
 		// A block literal is required.
@@ -1490,7 +1502,7 @@ var builtinArrayInstanceMethods = []*BuiltinMethodObject{
 // InitArrayObject returns a new object with the given elemnts
 func (vm *VM) InitArrayObject(elements []Object) *ArrayObject {
 	return &ArrayObject{
-		BaseObj:  &BaseObj{class: vm.TopLevelClass(classes.ArrayClass)},
+		BaseObj:  &BaseObj{class: vm.TopLevelClass(classes.ArrayClass), InstanceVariables: newEnvironment()},
 		Elements: elements,
 	}
 }

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -2245,3 +2245,28 @@ func TestArrayValuesAtMethodFail(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+
+func TestArrayDupMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`[1,2,3].dup`, []interface{}{1, 2, 3}},
+
+		{`
+a = [1,2,3]
+b = a.dup
+a[0] = 10
+b
+`, []interface{}{1, 2, 3}},
+	}
+
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		VerifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/boolean_test.go
+++ b/vm/boolean_test.go
@@ -214,3 +214,22 @@ func TestInitializeBoolean(t *testing.T) {
 		t.Errorf("expected 'false'. got=%t", FALSE.value)
 	}
 }
+
+func TestBooleanDupMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`true.dup`, true},
+		{`false.dup`, false},
+	}
+
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		VerifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/class.go
+++ b/vm/class.go
@@ -874,6 +874,20 @@ var builtinClassCommonInstanceMethods = []*BuiltinMethodObject{
 
 		},
 	},
+	{
+		Name: "dup",
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			switch receiver.(type) {
+			case *RObject:
+				newObj := receiver.Class().initializeInstance()
+				newObj.setInstanceVariables(receiver.instanceVariables().copy())
+
+				return newObj
+			default:
+				return t.vm.InitErrorObject(errors.NotImplementedError, sourceLine, errors.NativeNotImplementedErrorFormat, "dup", receiver.Class().Name)
+			}
+		},
+	},
 	// Exits from the interpreter, returning the specified exit code (if any).
 	//
 	// The method itself formally returns nil, although it's not usable.

--- a/vm/class.go
+++ b/vm/class.go
@@ -884,7 +884,7 @@ var builtinClassCommonInstanceMethods = []*BuiltinMethodObject{
 
 				return newObj
 			default:
-				return t.vm.InitErrorObject(errors.NotImplementedError, sourceLine, errors.NativeNotImplementedErrorFormat, "dup", receiver.Class().Name)
+				return receiver
 			}
 		},
 	},

--- a/vm/decimal_test.go
+++ b/vm/decimal_test.go
@@ -481,3 +481,20 @@ func TestDecimalMinusZero(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+
+func TestDecimalDupMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`"1.1".to_d.dup == "1.1".to_d`, true},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		VerifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/environment.go
+++ b/vm/environment.go
@@ -29,3 +29,11 @@ func (e *environment) names() []string {
 	sort.Strings(keys)
 	return keys
 }
+
+func (e *environment) copy() *environment {
+	newEnv := make(map[string]Object)
+	for key, value := range e.store {
+		newEnv[key] = value
+	}
+	return &environment{store: newEnv}
+}

--- a/vm/error.go
+++ b/vm/error.go
@@ -59,7 +59,7 @@ func (vm *VM) InitErrorObject(errorType string, sourceLine int, format string, a
 }
 
 func (vm *VM) initErrorClasses() {
-	errTypes := []string{errors.InternalError, errors.IOError, errors.ArgumentError, errors.NameError, errors.StopIteration, errors.TypeError, errors.NoMethodError, errors.ConstantAlreadyInitializedError, errors.HTTPError, errors.ZeroDivisionError, errors.ChannelCloseError}
+	errTypes := []string{errors.InternalError, errors.IOError, errors.ArgumentError, errors.NameError, errors.StopIteration, errors.TypeError, errors.NoMethodError, errors.ConstantAlreadyInitializedError, errors.HTTPError, errors.ZeroDivisionError, errors.ChannelCloseError, errors.NotImplementedError}
 
 	for _, errType := range errTypes {
 		c := vm.initializeClass(errType)

--- a/vm/errors/error.go
+++ b/vm/errors/error.go
@@ -23,30 +23,33 @@ const (
 	ZeroDivisionError = "ZeroDivisionError"
 	// ChannelCloseError is for accessing to the closed channel
 	ChannelCloseError = "ChannelCloseError"
+
+	NotImplementedError = "NotImplementedError"
 )
 
 /*
 	Here defines different error message formats for different types of errors
 */
 const (
-	WrongNumberOfArgument       = "Expect %d argument(s). got: %d"
-	WrongNumberOfArgumentMore   = "Expect %d or more argument(s). got: %d"
-	WrongNumberOfArgumentLess   = "Expect %d or less argument(s). got: %d"
-	WrongNumberOfArgumentRange  = "Expect %d to %d argument(s). got: %d"
-	WrongArgumentTypeFormat     = "Expect argument to be %s. got: %s"
-	WrongArgumentTypeFormatNum  = "Expect argument #%d to be %s. got: %s"
-	InvalidChmodNumber          = "Invalid chmod number. got: %d"
-	InvalidNumericString        = "Invalid numeric string. got: %s"
-	CantLoadFile                = "Can't load \"%s\""
-	CantRequireNonString        = "Can't require \"%s\": Pass a string instead"
-	CantYieldWithoutBlockFormat = "Can't yield without a block"
-	NotDiggable                 = "Expect target to be Diggable, got %s"
-	DividedByZero               = "Divided by 0"
-	ChannelIsClosed             = "The channel is already closed."
-	TooSmallIndexValue          = "Index value %d too small for array. minimum: %d"
-	IndexOutOfRange             = "Index value out of range. got: %v"
-	RegexpFailure               = "Replacement failure with the Regexp. got: %s"
-	NegativeValue               = "Expect argument to be positive value. got: %d"
-	NegativeSecondValue         = "Expect second argument to be positive value. got: %d"
-	UndefinedMethod             = "Undefined Method '%+v' for %+v"
+	WrongNumberOfArgument           = "Expect %d argument(s). got: %d"
+	WrongNumberOfArgumentMore       = "Expect %d or more argument(s). got: %d"
+	WrongNumberOfArgumentLess       = "Expect %d or less argument(s). got: %d"
+	WrongNumberOfArgumentRange      = "Expect %d to %d argument(s). got: %d"
+	WrongArgumentTypeFormat         = "Expect argument to be %s. got: %s"
+	WrongArgumentTypeFormatNum      = "Expect argument #%d to be %s. got: %s"
+	InvalidChmodNumber              = "Invalid chmod number. got: %d"
+	InvalidNumericString            = "Invalid numeric string. got: %s"
+	CantLoadFile                    = "Can't load \"%s\""
+	CantRequireNonString            = "Can't require \"%s\": Pass a string instead"
+	CantYieldWithoutBlockFormat     = "Can't yield without a block"
+	NotDiggable                     = "Expect target to be Diggable, got %s"
+	DividedByZero                   = "Divided by 0"
+	ChannelIsClosed                 = "The channel is already closed."
+	TooSmallIndexValue              = "Index value %d too small for array. minimum: %d"
+	IndexOutOfRange                 = "Index value out of range. got: %v"
+	RegexpFailure                   = "Replacement failure with the Regexp. got: %s"
+	NegativeValue                   = "Expect argument to be positive value. got: %d"
+	NegativeSecondValue             = "Expect second argument to be positive value. got: %d"
+	NativeNotImplementedErrorFormat = "'%s' should be implemented on %s but haven't be done yet. Looking forward to see your PR for it ;-)"
+	UndefinedMethod                 = "Undefined Method '%+v' for %+v"
 )

--- a/vm/float_test.go
+++ b/vm/float_test.go
@@ -368,3 +368,20 @@ func TestFloatMinusZero(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+
+func TestFloatDupMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`1.1.dup == 1.1`, true},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		VerifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -427,6 +427,12 @@ var builtinHashInstanceMethods = []*BuiltinMethodObject{
 		},
 	},
 	{
+		Name: "dup",
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			return receiver.(*HashObject).copy()
+		},
+	},
+	{
 		// Calls block once for each key in the hash (in sorted key order), passing the
 		// key-value pair as parameters.
 		// Returns `self`.
@@ -1292,7 +1298,7 @@ func (h *HashObject) copy() Object {
 	}
 
 	newHash := &HashObject{
-		BaseObj: &BaseObj{class: h.class},
+		BaseObj: &BaseObj{class: h.class, InstanceVariables: newEnvironment()},
 		Pairs:   elems,
 	}
 

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -1949,3 +1949,28 @@ func TestHashInspectCallsChildElementToString(t *testing.T) {
 	vm.checkCFP(t, i, 0)
 	vm.checkSP(t, i, 1)
 }
+
+func TestHashDupMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected map[string]interface{}
+	}{
+		{`{foo: "bar"}.dup`, map[string]interface{}{"foo": "bar"}},
+
+		{`
+a = {foo: "bar"}
+b = a.dup
+a["foo"] = 10
+b
+`, map[string]interface{}{"foo": "bar"}},
+	}
+
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		verifyHashObject(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -383,6 +383,12 @@ var builtinIntegerInstanceMethods = []*BuiltinMethodObject{
 
 		},
 	},
+	{
+		Name: "dup",
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			return receiver
+		},
+	},
 	// Returns the `Decimal` conversion of self.
 	//
 	// ```Ruby

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -383,12 +383,6 @@ var builtinIntegerInstanceMethods = []*BuiltinMethodObject{
 
 		},
 	},
-	{
-		Name: "dup",
-		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-			return receiver
-		},
-	},
 	// Returns the `Decimal` conversion of self.
 	//
 	// ```Ruby

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -361,3 +361,22 @@ func TestIntegerZeroDivisionFail(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+
+
+func TestIntegerDupMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`1.dup`, 1},
+	}
+
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		VerifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/object.go
+++ b/vm/object.go
@@ -21,6 +21,8 @@ type Object interface {
 	id() int
 	InstanceVariableGet(string) (Object, bool)
 	InstanceVariableSet(string, Object) Object
+	instanceVariables() *environment
+	setInstanceVariables(*environment)
 	isTruthy() bool
 }
 
@@ -73,6 +75,14 @@ func (b *BaseObj) InstanceVariableSet(name string, value Object) Object {
 	b.InstanceVariables.set(name, value)
 
 	return value
+}
+
+func (b *BaseObj) instanceVariables() *environment {
+	return b.InstanceVariables
+}
+
+func (b *BaseObj) setInstanceVariables(e *environment) {
+	b.InstanceVariables = e
 }
 
 func (b *BaseObj) findMethod(methodName string) (method Object) {

--- a/vm/range_test.go
+++ b/vm/range_test.go
@@ -655,3 +655,20 @@ func TestRangeToEnumMethod(t *testing.T) {
 	v.checkCFP(t, i, 0)
 	v.checkSP(t, i, 1)
 }
+
+func TestRangeDupMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`(1..2).dup == (1..2)`, true},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		VerifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/regexp_test.go
+++ b/vm/regexp_test.go
@@ -197,3 +197,21 @@ func TestRegexpMatchMethodFail(t *testing.T) {
 		v.checkSP(t, i, 1)
 	}
 }
+
+
+func TestRegexpDupMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{`Regexp.new("abc").dup == Regexp.new("abc")`, true},
+	}
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		VerifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}

--- a/vm/string.go
+++ b/vm/string.go
@@ -596,6 +596,16 @@ var builtinStringInstanceMethods = []*BuiltinMethodObject{
 		},
 	},
 	{
+		Name: "dup",
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			str, _ := receiver.(*StringObject)
+			newObj := t.vm.InitStringObject(str.value)
+			newObj.setInstanceVariables(str.instanceVariables().copy())
+
+			return newObj
+		},
+	},
+	{
 		// Split and loop through the string byte.
 		//
 		// ```ruby
@@ -1651,7 +1661,7 @@ var builtinStringInstanceMethods = []*BuiltinMethodObject{
 
 func (vm *VM) InitStringObject(value string) *StringObject {
 	return &StringObject{
-		BaseObj: &BaseObj{class: vm.TopLevelClass(classes.StringClass)},
+		BaseObj: &BaseObj{class: vm.TopLevelClass(classes.StringClass), InstanceVariables: newEnvironment()},
 		value:   value,
 	}
 }

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -1490,3 +1490,28 @@ func TestStringInspectEvaluatesToOriginalString(t *testing.T) {
 		v.checkSP(t, i, 3)
 	}
 }
+
+func TestStringDupMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			`"Stan".dup`, "Stan"},
+		{`
+s = "Stan"
+ds = "Stan".dup
+ds += " Lo"
+[s, ds]
+`, []interface{}{"Stan", "Stan Lo"}},
+	}
+
+
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		VerifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}


### PR DESCRIPTION
The default `dup` method returns the receiver object. Mutable data structures like `Object`, `Array`, `String` and `Hash` have their own implementation to override the default behavior for real duplication.