### PR TITLE
Add apidocs to #tap and #dup

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -618,6 +618,35 @@ var builtinArrayInstanceMethods = []*BuiltinMethodObject{
 		},
 	},
 	{
+		// Performs a 'shallow' copy of the array and returns it.
+		// Any arguments are ignored.
+		// The object_id of the returned object is different from the one of the receiver.
+
+		// Note that any elements of the array are NOT copied.
+		//
+		// See also `Object#dup`, `String#dup`, `Hash#dup`.
+		//
+		// ```ruby
+		// a = ["s", "t", "r"]
+		// a.object_id  #» 824635637568
+		// a.each do |i|
+		//   puts i.object_id
+		// end
+		// #» 824635637248
+		// #» 824635637344
+		// #» 824635637440
+		//
+		// b = a.dup
+		// b.each do |i|
+		//   puts i.object_id
+		// end
+		// #» 824635637248
+		// #» 824635637344
+		// #» 824635637440
+		// b.object_id  #» 824637392704
+		// ```
+		//
+		// @return [Array]
 		Name: "dup",
 		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 			arr, _ := receiver.(*ArrayObject)

--- a/vm/class.go
+++ b/vm/class.go
@@ -875,6 +875,33 @@ var builtinClassCommonInstanceMethods = []*BuiltinMethodObject{
 		},
 	},
 	{
+		// Performs a 'shallow' copy of the receiver object and returns it.
+		// Any arguments are just ignored.
+		// The object_id of the returned object is different from the one of the receiver.
+		// Note that `#tap` just returns self without copying if the receiver is an immutable object
+		// such as Integer, Decimal, Float or Regexp.
+		// Note that the internal statuses(instance variables) of the objects
+		// are also copied.
+		//
+		// See also `Array#dup`, `String#dup`, `Hash#dup`.
+		//
+		// ```ruby
+		// a = "string"
+		// a.object_id  #» 824637261824
+		// b = a.dup
+		// b.object_id  #» 824637263168
+		//
+		// class Foo
+		//   attr_accessor :foo
+		// end
+		// a = Foo.new     #» #<Foo:824634338592 >
+		// a.foo = 3.14
+		// a.inspect       #» #<Foo:824634338592 @foo=3.14 >
+		// b = a.dup
+		// b.inspect       #» #<Foo:824635635168 @foo=3.14 >
+		// ```
+		//
+		// @return [Object] Same type as the receiver
 		Name: "dup",
 		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 			switch receiver.(type) {
@@ -1550,6 +1577,33 @@ var builtinClassCommonInstanceMethods = []*BuiltinMethodObject{
 
 		},
 	},
+	// Just evaluates a given block with the receiver and returns the receiver.
+	// #tap method literally "taps into" the method chain and
+	// good for inspecting method chains.
+	// Any arguments to the method are just ignored.
+	//
+	// ```ruby
+	// (1..10).tap do |x|
+	//   print "original: "
+	//   puts x
+	// end.to_a.tap do |x|
+	//   print "array: "
+	//   puts x
+	// end.select do |x|
+	//   x.even?
+	// end.tap do |x|
+	//   print "evens: "
+	//   puts x
+	// end.map do |x|
+	//   x*x
+	// end.tap do |x|
+	//   print "squares:"
+	//   puts x
+	// end
+	// ```
+	//
+	// @param block literal
+	// @return [Object] singleton class
 	{
 		Name: "tap",
 		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
@@ -1592,9 +1646,9 @@ var builtinClassCommonInstanceMethods = []*BuiltinMethodObject{
 			return t.vm.InitStringObject(receiver.ToString())
 
 		},
-  },
-  {
-		
+	},
+	{
+
 		// Returns object's inspect representation.
 		// @param n/a []
 		// @return [String] Object's inspect representation.
@@ -1603,7 +1657,6 @@ var builtinClassCommonInstanceMethods = []*BuiltinMethodObject{
 			return t.vm.InitStringObject(receiver.Inspect())
 		},
 	},
-
 }
 
 // Internal functions ===================================================

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -427,6 +427,49 @@ var builtinHashInstanceMethods = []*BuiltinMethodObject{
 		},
 	},
 	{
+		// Performs a 'shallow' copy of the hash and returns it.
+		// Any arguments are ignored.
+		// The object_id of the returned object is different from the one of the receiver.
+
+		// Caveat: any keys of hash ARE also copied with different object ids for now.
+		// This comes from the fact that the string objects are NOT frozen in current Goby.
+		// TBD: Perhaps the `Hash#dup` will not copy keys when we change the implementation of string objects as frozen.
+		//
+		// See also `Object#dup`, `String#dup`, `Array#dup`.
+		//
+		// ```ruby
+		// h = { k1: :key1, k2: :key2 }
+		// h.object_id           #» 824633779744
+		// h.each do |k, v|
+		//   print "key:   "
+		//   puts k.object_id
+		//   print "value: "
+		//   puts v.object_id
+		// end
+		// #» key:   824635631488
+		// #» value: 824633779648
+		// #» key:   824635632288
+		// #» value: 824633779264
+		// #» key:   824635633728
+		// #» value: 824633779456
+		//
+		// b = h.dup
+		// b.object_id           #» 824633779904
+		// b.each do |k, v|
+		//   print "key:   "
+		//   puts k.object_id
+		//   print "value: "
+		//   puts v.object_id
+		// end
+		// #» key:   824633783360
+		// #» value: 824633779648
+		// #» key:   824633784256
+		// #» value: 824633779264
+		// #» key:   824633785056
+		// #» value: 824633779456
+		// ```
+		//
+		// @return [Hash]
 		Name: "dup",
 		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 			return receiver.(*HashObject).copy()

--- a/vm/string.go
+++ b/vm/string.go
@@ -596,6 +596,20 @@ var builtinStringInstanceMethods = []*BuiltinMethodObject{
 		},
 	},
 	{
+		// Performs a 'shallow' copy of the string and returns it.
+		// Any arguments are ignored.
+		// The object_id of the returned object is different from the one of the receiver.
+		//
+		// See also `Object#dup`, `Array#dup`, `Hash#dup`.
+		//
+		// ```ruby
+		// a = "string"
+		// a.object_id  #» 824637261824
+		// b = a.dup
+		// b.object_id  #» 824637263168
+		// ```
+		//
+		// @return [String]
 		Name: "dup",
 		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 			str, _ := receiver.(*StringObject)
@@ -1619,22 +1633,22 @@ var builtinStringInstanceMethods = []*BuiltinMethodObject{
 
 			return t.vm.InitStringObject(str)
 		},
-  },
+	},
 	{
 		// Returns a new String which would evaluate to self value
-    //
-    // ```ruby
-    // "string".inspect # => "\"string\""
-    // ```
-    //
-    // @return [String]
-    Name: "inspect",
-    Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+		//
+		// ```ruby
+		// "string".inspect # => "\"string\""
+		// ```
+		//
+		// @return [String]
+		Name: "inspect",
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-      str := receiver.(*StringObject)
+			str := receiver.(*StringObject)
 
-      return t.vm.InitStringObject(str.Inspect())
-    },
+			return t.vm.InitStringObject(str.Inspect())
+		},
 	},
 	{
 		// Returns a new String with all characters is upcase.


### PR DESCRIPTION
Added the api documents to `#tap` and `#dup`.

Ref: #788 and #791 

I hope my understanding is correct, especially on `Hash#dup`.