### PR TITLE
[Refactor] Use Token Factory Method

### DIFF
--- a/compiler/parser/expression_parsing.go
+++ b/compiler/parser/expression_parsing.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+
 	"github.com/goby-lang/goby/compiler/ast"
 	"github.com/goby-lang/goby/compiler/parser/arguments"
 	"github.com/goby-lang/goby/compiler/parser/errors"
@@ -63,7 +64,7 @@ func (p *Parser) parseAssignExpression(v ast.Expression) ast.Expression {
 	}
 
 	if len(exp.Variables) == 1 {
-		tok = token.Token{Type: token.Assign, Literal: "=", Line: p.curToken.Line}
+		tok = token.CreateOperator("=", p.curToken.Line)
 		value = p.expandAssignmentValue(v)
 	} else {
 		tok = p.curToken
@@ -405,17 +406,15 @@ func (p *Parser) expandAssignmentValue(value ast.Expression) ast.Expression {
 		return p.parseExpression(precedence)
 	case token.MinusEq, token.PlusEq, token.OrEq:
 		// Syntax Surgar: Assignment with operator case
-		infixOperator := token.Token{Line: p.curToken.Line}
+		var infixOperator token.Token
+
 		switch p.curToken.Type {
 		case token.PlusEq:
-			infixOperator.Type = token.Plus
-			infixOperator.Literal = "+"
+			infixOperator = token.CreateOperator("+", p.curToken.Line)
 		case token.MinusEq:
-			infixOperator.Type = token.Minus
-			infixOperator.Literal = "-"
+			infixOperator = token.CreateOperator("-", p.curToken.Line)
 		case token.OrEq:
-			infixOperator.Type = token.Or
-			infixOperator.Literal = "||"
+			infixOperator = token.CreateOperator("||", p.curToken.Line)
 		}
 
 		p.nextToken()

--- a/compiler/token/token.go
+++ b/compiler/token/token.go
@@ -108,10 +108,78 @@ var keywords = map[string]Type{
 	"get_block": GetBlock,
 }
 
+var operators = map[string]Type{
+	"=":   Assign,
+	"+":   Plus,
+	"+=":  PlusEq,
+	"-":   Minus,
+	"-=":  MinusEq,
+	"!":   Bang,
+	"*":   Asterisk,
+	"**":  Pow,
+	"/":   Slash,
+	".":   Dot,
+	"&&":  And,
+	"||":  Or,
+	"||=": OrEq,
+	"%":   Modulo,
+
+	"=~":  Match,
+	"<":   LT,
+	"<=":  LTE,
+	">":   GT,
+	">=":  GTE,
+	"<=>": COMP,
+
+	"==": Eq,
+	"!=": NotEq,
+	"..": Range,
+
+	"::": ResolutionOperator,
+}
+
+var separators = map[string]Type{
+	",": Comma,
+	";": Semicolon,
+	":": Colon,
+	"|": Bar,
+
+	"(": LParen,
+	")": RParen,
+	"{": LBrace,
+	"}": RBrace,
+	"[": LBracket,
+	"]": RBracket,
+}
+
 // LookupIdent is used for keyword identification
 func LookupIdent(ident string) Type {
 	if tok, ok := keywords[ident]; ok {
 		return tok
 	}
 	return Ident
+}
+
+func getOperatorType(literal string) Type {
+	if t, ok := operators[literal]; ok {
+		return t
+	}
+	return Ident
+}
+
+func getSeparatorType(literal string) Type {
+	if t, ok := separators[literal]; ok {
+		return t
+	}
+	return Ident
+}
+
+// CreateOperator - Factory method for creating operator types token from literal string
+func CreateOperator(literal string, line int) Token {
+	return Token{Type: getOperatorType(literal), Literal: literal, Line: line}
+}
+
+// CreateSeparator - Factory method for creating separator types token from literal string
+func CreateSeparator(literal string, line int) Token {
+	return Token{Type: getSeparatorType(literal), Literal: literal, Line: line}
 }

--- a/compiler/token/token_test.go
+++ b/compiler/token/token_test.go
@@ -37,3 +37,97 @@ func TestLookupIdentTrue(t *testing.T) {
 		}
 	}
 }
+
+func TestCreateOperatorIdentFalse(t *testing.T) {
+	line := 123
+	token := CreateOperator("nonexist", line)
+	if token.Type != Ident {
+		t.Fatalf("Expect token type %s, got: %s", Ident, token.Type)
+	}
+	if token.Line != line {
+		t.Fatalf("Expect token line %v, got: %v", line, token.Line)
+	}
+}
+
+func TestCreateOperatorIdentTrue(t *testing.T) {
+	var operators = map[string]Type{
+		"=":   Assign,
+		"+":   Plus,
+		"+=":  PlusEq,
+		"-":   Minus,
+		"-=":  MinusEq,
+		"!":   Bang,
+		"*":   Asterisk,
+		"**":  Pow,
+		"/":   Slash,
+		".":   Dot,
+		"&&":  And,
+		"||":  Or,
+		"||=": OrEq,
+		"%":   Modulo,
+
+		"=~":  Match,
+		"<":   LT,
+		"<=":  LTE,
+		">":   GT,
+		">=":  GTE,
+		"<=>": COMP,
+
+		"==": Eq,
+		"!=": NotEq,
+		"..": Range,
+
+		"::": ResolutionOperator,
+	}
+
+	line := 123
+
+	for name, tokenType := range operators {
+		tok := CreateOperator(name, line)
+		if tok.Type != tokenType {
+			t.Fatalf("Expect token type %s, got: %s", tokenType, tok.Type)
+		}
+		if tok.Line != line {
+			t.Fatalf("Expect token line %v, got: %v", line, tok.Line)
+		}
+	}
+}
+
+func TestCreateSeparatorIdentFalse(t *testing.T) {
+	line := 123
+	token := CreateSeparator("nonexist", line)
+	if token.Type != Ident {
+		t.Fatalf("Expect token type %s, got: %s", Ident, token.Type)
+	}
+	if token.Line != line {
+		t.Fatalf("Expect token line %v, got: %v", line, token.Line)
+	}
+}
+
+func TestCreateSeparatorIdentTrue(t *testing.T) {
+	var separators = map[string]Type{
+		",": Comma,
+		";": Semicolon,
+		":": Colon,
+		"|": Bar,
+
+		"(": LParen,
+		")": RParen,
+		"{": LBrace,
+		"}": RBrace,
+		"[": LBracket,
+		"]": RBracket,
+	}
+
+	line := 123
+
+	for name, tokenType := range separators {
+		tok := CreateSeparator(name, line)
+		if tok.Type != tokenType {
+			t.Fatalf("Expect token type %s, got: %s", tokenType, tok.Type)
+		}
+		if tok.Line != line {
+			t.Fatalf("Expect token line %v, got: %v", line, tok.Line)
+		}
+	}
+}


### PR DESCRIPTION
While inspecting the code in lexer, I noticed that the `newToken` method in lexer file violates the DRY rule. Thus, I come up with a way to change the token creation logic back to the token declaration file.

I'm not sure if there is a better approach, but overall, I hope this PR can help:
- Improve readability, follow DRY principle
- Token creation logic should be placed to where tokens are declared