### PR TITLE
Use equalTo() as a interface for equality comparison

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -1797,23 +1797,23 @@ func (a *ArrayObject) copy() Object {
 }
 
 func (a *ArrayObject) equalTo(compared Object) bool {
-	 c, ok := compared.(*ArrayObject)
+	c, ok := compared.(*ArrayObject)
 
-	 if !ok {
-	 	return false
-	 }
+	if !ok {
+		return false
+	}
 
-	 if len(a.Elements) != len(c.Elements) {
-	 	return false
-	 }
+	if len(a.Elements) != len(c.Elements) {
+		return false
+	}
 
-	 for i, e := range a.Elements {
-	 	if !e.equalTo(c.Elements[i]) {
-	 		return false
+	for i, e := range a.Elements {
+		if !e.equalTo(c.Elements[i]) {
+			return false
 		}
-	 }
+	}
 
-	 return true
+	return true
 }
 
 // unshift inserts an element in the first position of the array

--- a/vm/array.go
+++ b/vm/array.go
@@ -1796,6 +1796,26 @@ func (a *ArrayObject) copy() Object {
 	return newArr
 }
 
+func (a *ArrayObject) equalTo(compared Object) bool {
+	 c, ok := compared.(*ArrayObject)
+
+	 if !ok {
+	 	return false
+	 }
+
+	 if len(a.Elements) != len(c.Elements) {
+	 	return false
+	 }
+
+	 for i, e := range a.Elements {
+	 	if !e.equalTo(c.Elements[i]) {
+	 		return false
+		}
+	 }
+
+	 return true
+}
+
 // unshift inserts an element in the first position of the array
 func (a *ArrayObject) unshift(objs []Object) *ArrayObject {
 	a.Elements = append(objs, a.Elements...)

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -2261,7 +2261,6 @@ b
 `, []interface{}{1, 2, 3}},
 	}
 
-
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -84,6 +84,16 @@ func (b *BooleanObject) isTruthy() bool {
 	return b.value
 }
 
+func (b *BooleanObject) equalTo(with Object) bool {
+	bool, ok := with.(*BooleanObject)
+
+	if !ok {
+		return false
+	}
+
+	return b.value == bool.value
+}
+
 // equal returns true if the Boolean values between receiver and parameter are equal
 func (b *BooleanObject) equal(e *BooleanObject) bool {
 	return b.value == e.value

--- a/vm/boolean_test.go
+++ b/vm/boolean_test.go
@@ -224,7 +224,6 @@ func TestBooleanDupMethod(t *testing.T) {
 		{`false.dup`, false},
 	}
 
-
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())

--- a/vm/call_object.go
+++ b/vm/call_object.go
@@ -93,7 +93,7 @@ func (co *callObject) assignNormalAndOptionedArguments(paramIndex int, stack []*
 		if co.lastArgIndex < argIndex && (at == bytecode.NormalArg || at == bytecode.OptionedArg) {
 			co.callFrame.insertLCL(paramIndex, 0, stack[co.argPtr()+argIndex].Target)
 
-			// Store latest index value (and compare them to current argument index)
+			// Store latest index value (and equalTo them to current argument index)
 			// This is to make sure we won't get same argument's index twice.
 			co.lastArgIndex = argIndex
 			break

--- a/vm/concurrent_array.go
+++ b/vm/concurrent_array.go
@@ -137,6 +137,16 @@ func (cac *ConcurrentArrayObject) Value() interface{} {
 	return cac.InternalArray.Elements
 }
 
+func (cao *ConcurrentArrayObject) equalTo(compared Object) bool {
+	 c, ok := compared.(*ConcurrentArrayObject)
+
+	 if !ok {
+	 	return false
+	 }
+
+	 return cao.InternalArray.equalTo(c.InternalArray)
+}
+
 // Helper functions -----------------------------------------------------
 
 func DefineForwardedConcurrentArrayMethod(methodName string, requireWriteLock bool) *BuiltinMethodObject {

--- a/vm/concurrent_array.go
+++ b/vm/concurrent_array.go
@@ -138,13 +138,13 @@ func (cac *ConcurrentArrayObject) Value() interface{} {
 }
 
 func (cao *ConcurrentArrayObject) equalTo(compared Object) bool {
-	 c, ok := compared.(*ConcurrentArrayObject)
+	c, ok := compared.(*ConcurrentArrayObject)
 
-	 if !ok {
-	 	return false
-	 }
+	if !ok {
+		return false
+	}
 
-	 return cao.InternalArray.equalTo(c.InternalArray)
+	return cao.InternalArray.equalTo(c.InternalArray)
 }
 
 // Helper functions -----------------------------------------------------

--- a/vm/decimal.go
+++ b/vm/decimal.go
@@ -324,66 +324,7 @@ var builtinDecimalInstanceMethods = []*BuiltinMethodObject{
 
 		},
 	},
-	{
-		// Returns if self is equal to an Object.
-		// If the second term is integer or float, they are converted into decimal and then perform calculation.
-		// If the Object is not a Numeric the result is always false.
-		//
-		// ```Ruby
-		// "1.0".to_d == 3           # => false
-		// "1.0".to_d == 1           # => true
-		// "1.0".to_d == "1".to_d    # => true
-		// "1.0".to_d == "1".to_f    # => false
-		// "1.0".to_d == "1.0".to_f  # => false
-		// "1.0".to_d == 'str'       # => false
-		// "1.0".to_d == Array       # => false
-		// ```
-		//
-		// @return [Boolean]
-		Name: "==",
-		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-			decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
-				if leftValue.Cmp(rightValue) == 0 {
-					return true
-				}
 
-				return false
-			}
-
-			return receiver.(*DecimalObject).equalityTest(t, args[0], decimalOperation, true, sourceLine)
-
-		},
-	},
-	{
-		// Returns if self is not equal to an Object.
-		// If the second term is integer or float, they are converted into decimal and then perform calculation.
-		// If the Object is not a Numeric the result is always false.
-		//
-		// ```Ruby
-		// "1.0".to_d != 3           # => false
-		// "1.0".to_d != 1           # => true
-		// "1.0".to_d != "1".to_d    # => true
-		// "1.0".to_d != "1".to_f    # => false
-		// "1.0".to_d != "1.0".to_f  # => false
-		// "1.0".to_d != 'str'       # => false
-		// "1.0".to_d != Array       # => false
-		// ```
-		//
-		// @return [Boolean]
-		Name: "!=",
-		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-			decimalOperation := func(leftValue *Decimal, rightValue *Decimal) bool {
-				if leftValue.Cmp(rightValue) != 0 {
-					return true
-				}
-
-				return false
-			}
-
-			return receiver.(*DecimalObject).equalityTest(t, args[0], decimalOperation, false, sourceLine)
-
-		},
-	},
 	{
 		// Returns a string with fraction format of the decimal.
 		// If the denominator is 1, '/1` is omitted.
@@ -613,28 +554,17 @@ func (d *DecimalObject) arithmeticOperation(
 	return t.vm.initDecimalObject(&result)
 }
 
-// Apply an equality test, returning true if the objects are considered equal,
-// and false otherwise.
-func (d *DecimalObject) equalityTest(
-	t *Thread,
-	rightObject Object,
-	decimalOperation func(leftValue *Decimal, rightValue *Decimal) bool,
-	nonInverse bool,
-	sourceLine int,
-) Object {
-	var rightValue *Decimal
-	var result bool
+func (d *DecimalObject) equalTo(with Object) bool {
+	w, ok := with.(*DecimalObject)
 
-	switch rightObject.(type) {
-	case *DecimalObject:
-		rightValue = rightObject.(*DecimalObject).value
-	default:
-		return toBooleanObject(nonInverse == false)
+	if !ok {
+		return false
 	}
 
-	leftValue := d.value
-	result = decimalOperation(leftValue, rightValue)
-	return toBooleanObject(result)
+	if d.value.Cmp(w.value) == 0 {
+		return true
+	}
+	return false
 }
 
 // Apply the passed numeric comparison, while performing type conversion.

--- a/vm/float.go
+++ b/vm/float.go
@@ -268,46 +268,6 @@ var builtinFloatInstanceMethods = []*BuiltinMethodObject{
 		},
 	},
 	{
-		// Returns if self is equal to an Object.
-		// If the Object is a Numeric, a comparison is performed, otherwise, the
-		// result is always false.
-		//
-		// ```Ruby
-		// 1.0 == 3     # => false
-		// 1.0 == 1     # => true
-		// 1.0 == '1.0' # => false
-		// ```
-		//
-		// @return [Boolean]
-		Name: "==",
-		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-			result := receiver.(*FloatObject).equalityTest(args[0])
-
-			return toBooleanObject(result)
-
-		},
-	},
-	{
-		// Returns if self is not equal to an Object.
-		// If the Object is a Numeric, a comparison is performed, otherwise, the
-		// result is always true.
-		//
-		// ```Ruby
-		// 1.0 != 3     # => true
-		// 1.0 != 1     # => false
-		// 1.0 != '1.0' # => true
-		// ```
-		//
-		// @return [Boolean]
-		Name: "!=",
-		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-			result := !receiver.(*FloatObject).equalityTest(args[0])
-
-			return toBooleanObject(result)
-
-		},
-	},
-	{
 		// Converts the Integer object into Decimal object and returns it.
 		// Each digit of the float is literally transferred to the corresponding digit
 		// of the Decimal, via a string representation of the float.
@@ -415,17 +375,14 @@ func (f *FloatObject) arithmeticOperation(t *Thread, rightObject Object, operati
 
 // Apply an equality test, returning true if the objects are considered equal,
 // and false otherwise.
-func (f *FloatObject) equalityTest(rightObject Object) bool {
+func (f *FloatObject) equalTo(rightObject Object) bool {
 	rightNumeric, ok := rightObject.(Numeric)
 
 	if !ok {
 		return false
 	}
 
-	leftValue := f.value
-	rightValue := rightNumeric.floatValue()
-
-	return leftValue == rightValue
+	return f.value == rightNumeric.floatValue()
 }
 
 // TODO: Remove instruction argument

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -1334,6 +1334,20 @@ func (h *HashObject) dig(t *Thread, keys []Object, sourceLine int) Object {
 	return diggableCurrentValue.dig(t, nextKeys, sourceLine)
 }
 
+func (h *HashObject) equalTo(with Object) bool {
+	w, ok := with.(*HashObject)
+
+	if !ok {
+		return false
+	}
+
+	if len(h.Pairs) != len(w.Pairs) {
+		return false
+	}
+
+	return reflect.DeepEqual(h.Pairs, w.Pairs)
+}
+
 // Other helper functions ----------------------------------------------
 
 // Return the JSON style strings of the Hash object

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -1965,7 +1965,6 @@ b
 `, map[string]interface{}{"foo": "bar"}},
 	}
 
-
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())

--- a/vm/hash_test.go
+++ b/vm/hash_test.go
@@ -1900,7 +1900,7 @@ func JSONBytesEqual(a, b []byte) (bool, error) {
 	return reflect.DeepEqual(j2, j), nil
 }
 
-// We can't compare string directly because the key/value's order might change and we can't control it.
+// We can't equalTo string directly because the key/value's order might change and we can't control it.
 func compareJSONResult(t *testing.T, evaluated Object, exp interface{}) {
 	expected, err := json.Marshal(exp)
 

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -321,44 +321,6 @@ var builtinIntegerInstanceMethods = []*BuiltinMethodObject{
 		},
 	},
 	{
-		// Returns if self is equal to an Object.
-		// If the Object is a Numeric, a comparison is performed, otherwise, the
-		// result is always false.
-		//
-		// ```Ruby
-		// 1 == 3   # => false
-		// 1 == 1   # => true
-		// 1 == '1' # => false
-		// ```
-		// @return [Boolean]
-		Name: "==",
-		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-			result := receiver.(*IntegerObject).equalityTest(args[0])
-
-			return toBooleanObject(result)
-
-		},
-	},
-	{
-		// Returns if self is not equal to an Object.
-		// If the Object is a Numeric, a comparison is performed, otherwise, the
-		// result is always true.
-		//
-		// ```Ruby
-		// 1 != 3   # => true
-		// 1 != 1   # => false
-		// 1 != '1' # => true
-		// ```
-		// @return [Boolean]
-		Name: "!=",
-		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-			result := !receiver.(*IntegerObject).equalityTest(args[0])
-
-			return toBooleanObject(result)
-
-		},
-	},
-	{
 		// Returns if self is even.
 		//
 		// ```Ruby
@@ -806,7 +768,7 @@ func (i *IntegerObject) arithmeticOperation(
 // Apply an equality test, returning true if the objects are considered equal,
 // and false otherwise.
 // See comment on numericComparison().
-func (i *IntegerObject) equalityTest(rightObject Object) bool {
+func (i *IntegerObject) equalTo(rightObject Object) bool {
 	switch rightObject := rightObject.(type) {
 	case *IntegerObject:
 		leftValue := i.value

--- a/vm/integer_test.go
+++ b/vm/integer_test.go
@@ -362,7 +362,6 @@ func TestIntegerZeroDivisionFail(t *testing.T) {
 	}
 }
 
-
 func TestIntegerDupMethod(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -370,7 +369,6 @@ func TestIntegerDupMethod(t *testing.T) {
 	}{
 		{`1.dup`, 1},
 	}
-
 
 	for i, tt := range tests {
 		v := initTestVM()

--- a/vm/null.go
+++ b/vm/null.go
@@ -81,27 +81,6 @@ var builtinNullInstanceMethods = []*BuiltinMethodObject{
 		},
 	},
 	{
-		// Returns true because it is nil. (See the main implementation of nil? method in vm/class.go)
-		//
-		// ```ruby
-		// a = nil
-		// a == nil
-		// # => true
-		// ```
-		Name: "==",
-		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-			if len(args) != 1 {
-				return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 1 argument. got: %d", len(args))
-			}
-
-			if _, ok := args[0].(*NullObject); ok {
-				return TRUE
-			}
-			return FALSE
-
-		},
-	},
-	{
 		// Returns true: the flipped boolean value of nil object.
 		//
 		// ```ruby
@@ -177,4 +156,8 @@ func (n *NullObject) Inspect() string {
 
 func (n *NullObject) isTruthy() bool {
 	return false
+}
+
+func (n *NullObject) equalTo(compared Object) bool {
+	return n == compared
 }

--- a/vm/null.go
+++ b/vm/null.go
@@ -67,17 +67,17 @@ var builtinNullInstanceMethods = []*BuiltinMethodObject{
 			n := receiver.(*NullObject)
 			return t.vm.InitStringObject(n.ToString())
 		},
-  },
+	},
 	{
 		Name: "inspect",
 
-    Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-      if len(args) != 0 {
-        return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
-      }
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			if len(args) != 0 {
+				return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "Expect 0 argument. got: %d", len(args))
+			}
 
-      n := receiver.(*NullObject)
-      return t.vm.InitStringObject(n.Inspect())
+			n := receiver.(*NullObject)
+			return t.vm.InitStringObject(n.Inspect())
 		},
 	},
 	{

--- a/vm/object.go
+++ b/vm/object.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/goby-lang/goby/compiler/bytecode"
+	"reflect"
 )
 
 // Object represents all objects in Goby, including Array, Integer or even Method and Error.
@@ -24,6 +25,7 @@ type Object interface {
 	instanceVariables() *environment
 	setInstanceVariables(*environment)
 	isTruthy() bool
+	equalTo(Object) bool
 }
 
 // BaseObj ==============================================================
@@ -125,6 +127,16 @@ func (b *BaseObj) id() int {
 
 func (b *BaseObj) isTruthy() bool {
 	return true
+}
+
+func (b *BaseObj) equalTo(with Object) bool {
+	className := b.Class().Name
+	compareClassName := with.Class().Name
+
+	if className == compareClassName && reflect.DeepEqual(b, with) {
+		return true
+	}
+	return false
 }
 
 // Pointer ==============================================================

--- a/vm/object_test.go
+++ b/vm/object_test.go
@@ -105,7 +105,7 @@ dup.name = "Jane"
 
 [stan.name, dup.name]
 `, []interface{}{"Stan", "Jane"}},
-{
+		{
 			`
 stan = Student.new("Stan")
 jane = Student.new("Stan")
@@ -119,7 +119,7 @@ s2.inspect
 
 	for i, tt := range tests {
 		v := initTestVM()
-		evaluated := v.testEval(t, setup + tt.input, getFilename())
+		evaluated := v.testEval(t, setup+tt.input, getFilename())
 		VerifyExpected(t, i, evaluated, tt.expected)
 		v.checkCFP(t, i, 0)
 		v.checkSP(t, i, 1)

--- a/vm/range.go
+++ b/vm/range.go
@@ -47,60 +47,6 @@ var builtinRangeClassMethods = []*BuiltinMethodObject{
 // Instance methods -----------------------------------------------------
 var builtinRangeInstanceMethods = []*BuiltinMethodObject{
 	{
-		// Returns a Boolean of compared two ranges
-		//
-		// ```ruby
-		// (1..5) == (1..5) # => true
-		// (1..5) == (1..6) # => false
-		// ```
-		//
-		// @return [Boolean]
-		Name: "==",
-		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-
-			left := receiver.(*RangeObject)
-			r := args[0]
-			right, ok := r.(*RangeObject)
-
-			if !ok {
-				return FALSE
-			}
-
-			if left.Start == right.Start && left.End == right.End {
-				return TRUE
-			}
-
-			return FALSE
-
-		},
-	},
-	{
-		// Returns a Boolean of compared two ranges
-		//
-		// ```ruby
-		// (1..5) != (1..5) # => false
-		// (1..5) != (1..6) # => true
-		// ```
-		//
-		// @return [Boolean]
-		Name: "!=",
-		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-
-			right, ok := args[0].(*RangeObject)
-			if !ok {
-				return TRUE
-			}
-
-			left := receiver.(*RangeObject)
-			if left.Start == right.Start && left.End == right.End {
-				return FALSE
-			}
-
-			return TRUE
-
-		},
-	},
-	{
 		// By using binary search, finds a value in range which meets the given condition in O(log n)
 		// where n is the size of the range.
 		//
@@ -568,4 +514,18 @@ func (ro *RangeObject) each(f func(int) error) (err error) {
 	}
 
 	return
+}
+
+func (ro *RangeObject) equalTo(with Object) bool {
+	right, ok := with.(*RangeObject)
+
+	if !ok {
+		return false
+	}
+
+	if ro.Start == right.Start && ro.End == right.End {
+		return true
+	}
+
+	return false
 }

--- a/vm/regexp.go
+++ b/vm/regexp.go
@@ -67,41 +67,6 @@ var builtInRegexpClassMethods = []*BuiltinMethodObject{
 // Instance methods -----------------------------------------------------
 var builtinRegexpInstanceMethods = []*BuiltinMethodObject{
 	{
-		// Returns true if the two regexp patterns are exactly the same, or returns false if not.
-		// If comparing with non Regexp class, just returns false.
-		//
-		// ```ruby
-		// r1 = Regexp.new("goby[0-9]+")
-		// r2 = Regexp.new("goby[0-9]+")
-		// r3 = Regexp.new("Goby[0-9]+")
-		//
-		// r1 == r2   # => true
-		// r1 == r2   # => false
-		// ```
-		//
-		// @param regexp [Regexp]
-		// @return [Boolean]
-		Name: "==",
-		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-			if len(args) != 1 {
-				return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 1, len(args))
-			}
-
-			right, ok := args[0].(*RegexpObject)
-			if !ok {
-				return FALSE
-			}
-
-			left := receiver.(*RegexpObject)
-
-			if left.Value() == right.Value() {
-				return TRUE
-			}
-			return FALSE
-
-		},
-	},
-	{
 		// Returns boolean value to indicate the result of regexp match with the string given. The methods evaluates a String object.
 		//
 		// ```ruby
@@ -180,4 +145,17 @@ func (r *RegexpObject) ToJSON(t *Thread) string {
 // equal checks if the string values between receiver and argument are equal
 func (r *RegexpObject) equal(e *RegexpObject) bool {
 	return r.ToString() == r.ToString()
+}
+
+func (r *RegexpObject) equalTo(with Object) bool {
+	right, ok := with.(*RegexpObject)
+	if !ok {
+		return false
+	}
+
+	if r.Value() == right.Value() {
+		return true
+	}
+
+	return false
 }

--- a/vm/regexp_test.go
+++ b/vm/regexp_test.go
@@ -198,7 +198,6 @@ func TestRegexpMatchMethodFail(t *testing.T) {
 	}
 }
 
-
 func TestRegexpDupMethod(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/vm/string.go
+++ b/vm/string.go
@@ -198,33 +198,6 @@ var builtinStringInstanceMethods = []*BuiltinMethodObject{
 		},
 	},
 	{
-		// Returns a Boolean of compared two strings.
-		//
-		// ```ruby
-		// "first" == "second" # => false
-		// "two" == "two" # => true
-		// ```
-		//
-		// @param string [String]
-		// @return [Boolean]
-		Name: "==",
-		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
-
-			right, ok := args[0].(*StringObject)
-			if !ok {
-				return FALSE
-			}
-
-			left := receiver.(*StringObject)
-			if left.value == right.value {
-				return TRUE
-			}
-
-			return FALSE
-
-		},
-	},
-	{
 		// Matches the receiver with a Regexp, and returns the number of matched strings.
 		//
 		// ```ruby
@@ -1688,6 +1661,16 @@ func (s *StringObject) ToString() string {
 // Inspect wraps ToString with double quotes
 func (s *StringObject) Inspect() string {
 	return fmt.Sprintf(`"%s"`, escapeSpecialChars(escapeBackslash(s.ToString())))
+}
+
+func (s *StringObject) equalTo(compared Object) bool {
+	right, ok := compared.(*StringObject)
+
+	if !ok {
+		return false
+	}
+
+	return s.equal(right)
 }
 
 func escapeSpecialChars(s string) string {

--- a/vm/string.go
+++ b/vm/string.go
@@ -1592,22 +1592,22 @@ var builtinStringInstanceMethods = []*BuiltinMethodObject{
 
 			return t.vm.InitStringObject(str)
 		},
-  },
+	},
 	{
 		// Returns a new String which would evaluate to self value
-    //
-    // ```ruby
-    // "string".inspect # => "\"string\""
-    // ```
-    //
-    // @return [String]
-    Name: "inspect",
-    Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+		//
+		// ```ruby
+		// "string".inspect # => "\"string\""
+		// ```
+		//
+		// @return [String]
+		Name: "inspect",
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 
-      str := receiver.(*StringObject)
+			str := receiver.(*StringObject)
 
-      return t.vm.InitStringObject(str.Inspect())
-    },
+			return t.vm.InitStringObject(str.Inspect())
+		},
 	},
 	{
 		// Returns a new String with all characters is upcase.

--- a/vm/string_test.go
+++ b/vm/string_test.go
@@ -1506,7 +1506,6 @@ ds += " Lo"
 `, []interface{}{"Stan", "Stan Lo"}},
 	}
 
-
 	for i, tt := range tests {
 		v := initTestVM()
 		evaluated := v.testEval(t, tt.input, getFilename())


### PR DESCRIPTION
Instead of defining `==` and `!=` methods separately, we can use the same method definition and rely on the underneath go function to perform the comparison check.

This PR is a prerequisite for fixing our `object_id` issue.