### PR TITLE
Cleanup goby binary executable for the case that test fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install:
 .PHONY: test
 test:
 	go test $(TEST_OPTIONS) ./...
-	go clean .
+	make clean
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ install:
 .PHONY: test
 test:
 	go test $(TEST_OPTIONS) ./...
+	go clean .
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Small fix. `make test` performs `go clean .` to cleanup the local goby binary executable when test fails.