### PR TITLE
Add random number generation by mapping rand() to math/rand

### DIFF
--- a/vm/class.go
+++ b/vm/class.go
@@ -1354,7 +1354,7 @@ var builtinClassCommonInstanceMethods = []*BuiltinMethodObject{
 				}
 				return t.vm.InitIntegerObject(rand.Intn(args[0].Value().(int)))
 			case 2:
-				_, minOk := args[1].(*IntegerObject)
+				_, minOk := args[0].(*IntegerObject)
 
 				if !minOk {
 					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)

--- a/vm/class.go
+++ b/vm/class.go
@@ -1342,12 +1342,29 @@ var builtinClassCommonInstanceMethods = []*BuiltinMethodObject{
 		Name: "rand",
 		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
 			aLen := len(args)
+
 			switch aLen {
 			case 0:
 				return t.vm.initFloatObject(rand.Float64())
 			case 1:
+				_, ok := args[0].(*IntegerObject)
+
+				if !ok {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+				}
 				return t.vm.InitIntegerObject(rand.Intn(args[0].Value().(int)))
 			case 2:
+				_, minOk := args[1].(*IntegerObject)
+
+				if !minOk {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+				}
+				_, maxOk := args[1].(*IntegerObject)
+
+				if !maxOk {
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[1].Class().Name)
+				}
+
 				return t.vm.InitIntegerObject(rand.Intn(args[1].Value().(int)-args[0].Value().(int)+1) + args[0].Value().(int))
 			default:
 				return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 2, aLen)

--- a/vm/class.go
+++ b/vm/class.go
@@ -1350,19 +1350,19 @@ var builtinClassCommonInstanceMethods = []*BuiltinMethodObject{
 				_, ok := args[0].(*IntegerObject)
 
 				if !ok {
-					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
 				}
 				return t.vm.InitIntegerObject(rand.Intn(args[0].Value().(int)))
 			case 2:
 				_, minOk := args[1].(*IntegerObject)
 
 				if !minOk {
-					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[0].Class().Name)
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[0].Class().Name)
 				}
 				_, maxOk := args[1].(*IntegerObject)
 
 				if !maxOk {
-					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.StringClass, args[1].Class().Name)
+					return t.vm.InitErrorObject(errors.TypeError, sourceLine, errors.WrongArgumentTypeFormat, classes.IntegerClass, args[1].Class().Name)
 				}
 
 				return t.vm.InitIntegerObject(rand.Intn(args[1].Value().(int)-args[0].Value().(int)+1) + args[0].Value().(int))

--- a/vm/class.go
+++ b/vm/class.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"math/rand"
 	"sort"
 
 	"github.com/goby-lang/goby/vm/classes"
@@ -1335,6 +1336,22 @@ var builtinClassCommonInstanceMethods = []*BuiltinMethodObject{
 
 			return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgumentLess, 2, aLen)
 
+		},
+	},
+	{
+		Name: "rand",
+		Fn: func(receiver Object, sourceLine int, t *Thread, args []Object, blockFrame *normalCallFrame) Object {
+			aLen := len(args)
+			switch aLen {
+			case 0:
+				return t.vm.initFloatObject(rand.Float64())
+			case 1:
+				return t.vm.InitIntegerObject(rand.Intn(args[0].Value().(int)))
+			case 2:
+				return t.vm.InitIntegerObject(rand.Intn(args[1].Value().(int)-args[0].Value().(int)+1) + args[0].Value().(int))
+			default:
+				return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, errors.WrongNumberOfArgument, 2, aLen)
+			}
 		},
 	},
 	{

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -1155,6 +1155,7 @@ func TestRandMethod(t *testing.T) {
 func TestRandMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`rand(1, 10, 100)`, "ArgumentError: Expect 2 argument(s). got: 3", 1},
+		{`rand("some string")`, "TypeError: Expect argument to be Integer. got: String", 1},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -1156,6 +1156,8 @@ func TestRandMethodFail(t *testing.T) {
 	testsFail := []errorTestCase{
 		{`rand(1, 10, 100)`, "ArgumentError: Expect 2 argument(s). got: 3", 1},
 		{`rand("some string")`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`rand("some string", "some other string")`, "TypeError: Expect argument to be Integer. got: String", 1},
+		{`rand(10, "some other string")`, "TypeError: Expect argument to be Integer. got: String", 1},
 	}
 
 	for i, tt := range testsFail {

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -1353,7 +1353,7 @@ func TestSendMethod(t *testing.T) {
 		    10
 		  end
 		end
-		
+
 		Foo.new.send(:bar)
 		`, 10},
 	}

--- a/vm/class_test.go
+++ b/vm/class_test.go
@@ -985,7 +985,7 @@ func TestInheritsMethodMissingMethod(t *testing.T) {
 		{`
 		class Bar
 		end
-		
+
 		Bar.new.inherits_method_missing?
 
 `, false},
@@ -993,7 +993,7 @@ func TestInheritsMethodMissingMethod(t *testing.T) {
 		class Bar
 		  inherits_method_missing
 		end
-		
+
 		Bar.new.inherits_method_missing?
 
 `, true},
@@ -1121,6 +1121,40 @@ func TestRaiseMethodFail(t *testing.T) {
 		{`
 		class BarError; end
 		raise BarError, "Foo", "Bar"`, "ArgumentError: Expect 2 or less argument(s). got: 3", 1},
+	}
+
+	for i, tt := range testsFail {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		checkErrorMsg(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, tt.expectedCFP)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestRandMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`rand.class.name`, "Float"},
+		{`rand(1).class.name`, "Integer"},
+		{`rand(1, 2).class.name`, "Integer"},
+		{`(60 < rand(64, 66)).to_s`, "true"},
+		{`(70 > rand(64, 66)).to_s`, "true"},
+	}
+	for i, tt := range tests {
+		v := initTestVM()
+		evaluated := v.testEval(t, tt.input, getFilename())
+		VerifyExpected(t, i, evaluated, tt.expected)
+		v.checkCFP(t, i, 0)
+		v.checkSP(t, i, 1)
+	}
+}
+
+func TestRandMethodFail(t *testing.T) {
+	testsFail := []errorTestCase{
+		{`rand(1, 10, 100)`, "ArgumentError: Expect 2 argument(s). got: 3", 1},
 	}
 
 	for i, tt := range testsFail {
@@ -1651,7 +1685,7 @@ func TestClassSingletonClassMethod(t *testing.T) {
 		`, "#<Class:Bar>"},
 		{`
 		module Bar; end
-		
+
 		Bar.singleton_class.name
 		`, "#<Class:Bar>"},
 		// Check if this works on non-class objects
@@ -1663,12 +1697,12 @@ func TestClassSingletonClassMethod(t *testing.T) {
 		// Below is for testing module inheritance chain
 		{`
 		module Bar; end
-		
+
 		Bar.singleton_class.class.name
 		`, "Class"},
 		{`
 		module Bar; end
-		
+
 		Bar.singleton_class.superclass.name
 		`, "Module"},
 	}


### PR DESCRIPTION
We're using `math/rand`, because when we're later implementing `srand()`, we need it to support seeding, which `crypto/rand` does not provide.

Fixes https://github.com/goby-lang/goby/issues/810