### PR TITLE
Fix #584

### DIFF
--- a/vm/thread.go
+++ b/vm/thread.go
@@ -152,7 +152,18 @@ func (t *Thread) evalCallFrame(cf callFrame) {
 		t.Stack.Push(&Pointer{Target: result})
 		//fmt.Println(t.callFrameStack.inspect())
 		//fmt.Println("-----------------------")
-		t.callFrameStack.pop()
+
+		// this check is to prevent popping out a call frame that should be kept
+		// usually the top call frame would be the `cf` here
+		// but in some rare cases it could be other call frame, and if we pop it here we'll have some troubles in the later execution
+		//
+		// one example of the problem would be https://github.com/goby-lang/goby/issues/584
+		// the cause of this issue is that the "break" instruction always pops 3 call frames
+		// (this is necessary, please read the comments inside `Break` instruction for more detail)
+		// and because we already popped the `cf` during the `Break` instruction, what we pop here would be the top-level call frame, which causes the program to crash
+		if t.callFrameStack.top() == cf {
+			t.callFrameStack.pop()
+		}
 	}
 
 	t.removeUselessBlockFrame(cf)

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -18,6 +18,24 @@ func TestVM_REPLExec(t *testing.T) {
 		{
 			[]string{
 				`
+x = [1, 2, 3]
+y = 0
+`,
+				`
+x.each do |i|
+  y += i
+  if i == 2
+    break
+  end
+end
+`,
+				`y`,
+			},
+			3,
+		},
+		{
+			[]string{
+				`
 				a, b = [3, 6]
 				a + b
 				`,


### PR DESCRIPTION
The cause of this issue is that Goby pops the incorrect call frame when evaluating a `break` statement inside a built-in method's block.

When evaluating a built-in method's call frame, Goby should pop it after the evaluation is finished. And we do this by calling `t.callFrameStack.pop()` directly, which makes sense in most cases.  

However, because the "break" instruction pops out 3 call frames every time (which is necessary, please read the comments inside `Break` instruction for more detail), it'd pop the built-in method's frame in advance. So when Goby finishes the built-in frame's evaluation later and tries to pop the frame from the stack, it actually pops the top frame, which later causes the nil pointer error.

