### PR TITLE
Make t.builtinMethodYield return an Object instead of a Pointer

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -44,7 +44,7 @@ var builtinArrayClassMethods = []*BuiltinMethodObject{
 
 				if blockFrame != nil && !blockIsEmpty(blockFrame) {
 					for i := range elems {
-						elems[i] = t.builtinMethodYield(blockFrame, t.vm.InitIntegerObject(i)).Target
+						elems[i] = t.builtinMethodYield(blockFrame, t.vm.InitIntegerObject(i))
 					}
 				} else {
 					var elem Object
@@ -413,7 +413,7 @@ var builtinArrayInstanceMethods = []*BuiltinMethodObject{
 			for _, obj := range arr.Elements {
 				result := t.builtinMethodYield(blockFrame, obj)
 
-				if result.Target.isTruthy() {
+				if result.isTruthy() {
 					return TRUE
 				}
 			}
@@ -541,7 +541,7 @@ var builtinArrayInstanceMethods = []*BuiltinMethodObject{
 
 				for _, obj := range arr.Elements {
 					result := t.builtinMethodYield(blockFrame, obj)
-					if result.Target.isTruthy() {
+					if result.isTruthy() {
 						count++
 					}
 				}
@@ -930,12 +930,12 @@ var builtinArrayInstanceMethods = []*BuiltinMethodObject{
 			switch len(args) {
 			case 0:
 				for _, obj := range a.Elements {
-					hash[obj.ToString()] = t.builtinMethodYield(blockFrame, obj).Target
+					hash[obj.ToString()] = t.builtinMethodYield(blockFrame, obj)
 				}
 			case 1:
 				arg := args[0]
 				for _, obj := range a.Elements {
-					switch b := t.builtinMethodYield(blockFrame, obj).Target; b.(type) {
+					switch b := t.builtinMethodYield(blockFrame, obj); b.(type) {
 					case *NullObject:
 						hash[obj.ToString()] = arg
 					default:
@@ -1104,8 +1104,7 @@ var builtinArrayInstanceMethods = []*BuiltinMethodObject{
 				}
 			} else {
 				for i, obj := range arr.Elements {
-					result := t.builtinMethodYield(blockFrame, obj)
-					elements[i] = result.Target
+					elements[i] = t.builtinMethodYield(blockFrame, obj)
 				}
 			}
 
@@ -1225,8 +1224,7 @@ var builtinArrayInstanceMethods = []*BuiltinMethodObject{
 			}
 
 			for i := start; i < len(arr.Elements); i++ {
-				result := t.builtinMethodYield(blockFrame, prev, arr.Elements[i])
-				prev = result.Target
+				prev = t.builtinMethodYield(blockFrame, prev, arr.Elements[i])
 			}
 
 			return prev
@@ -1405,7 +1403,7 @@ var builtinArrayInstanceMethods = []*BuiltinMethodObject{
 
 			for _, obj := range arr.Elements {
 				result := t.builtinMethodYield(blockFrame, obj)
-				if result.Target.isTruthy() {
+				if result.isTruthy() {
 					elements = append(elements, obj)
 				}
 			}

--- a/vm/block.go
+++ b/vm/block.go
@@ -115,7 +115,7 @@ var builtinBlockInstanceMethods = []*BuiltinMethodObject{
 			c.self = block.self
 			c.isBlock = true
 
-			return t.builtinMethodYield(c, args...).Target
+			return t.builtinMethodYield(c, args...)
 		},
 	},
 }

--- a/vm/class.go
+++ b/vm/class.go
@@ -1199,9 +1199,8 @@ var builtinClassCommonInstanceMethods = []*BuiltinMethodObject{
 			}
 
 			blockFrame.self = receiver
-			result := t.builtinMethodYield(blockFrame)
 
-			return result.Target
+			return t.builtinMethodYield(blockFrame)
 
 		},
 	},

--- a/vm/concurrent_rw_lock.go
+++ b/vm/concurrent_rw_lock.go
@@ -170,7 +170,7 @@ var builtinConcurrentRWLockInstanceMethods = []*BuiltinMethodObject{
 
 			lockObject.mutex.RLock()
 
-			blockReturnValue := t.builtinMethodYield(blockFrame).Target
+			blockReturnValue := t.builtinMethodYield(blockFrame)
 
 			lockObject.mutex.RUnlock()
 
@@ -204,7 +204,7 @@ var builtinConcurrentRWLockInstanceMethods = []*BuiltinMethodObject{
 
 			lockObject.mutex.Lock()
 
-			blockReturnValue := t.builtinMethodYield(blockFrame).Target
+			blockReturnValue := t.builtinMethodYield(blockFrame)
 
 			lockObject.mutex.Unlock()
 

--- a/vm/hash.go
+++ b/vm/hash.go
@@ -216,7 +216,7 @@ var builtinHashInstanceMethods = []*BuiltinMethodObject{
 					return NULL
 				}
 
-				if result.Target.isTruthy() {
+				if result.isTruthy() {
 					return TRUE
 				}
 			}
@@ -384,13 +384,13 @@ var builtinHashInstanceMethods = []*BuiltinMethodObject{
 				objectKey := t.vm.InitStringObject(stringKey)
 				result := t.builtinMethodYield(blockFrame, objectKey, value)
 
-				booleanResult, isResultBoolean := result.Target.(*BooleanObject)
+				booleanResult, isResultBoolean := result.(*BooleanObject)
 
 				if isResultBoolean {
 					if booleanResult.value {
 						delete(hash.Pairs, stringKey)
 					}
-				} else if result.Target != NULL {
+				} else if result != NULL {
 					delete(hash.Pairs, stringKey)
 				}
 			}
@@ -704,7 +704,7 @@ var builtinHashInstanceMethods = []*BuiltinMethodObject{
 			}
 
 			if blockFrame != nil {
-				return t.builtinMethodYield(blockFrame, key).Target
+				return t.builtinMethodYield(blockFrame, key)
 			}
 			return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "The value was not found, and no block has been provided")
 		},
@@ -746,7 +746,7 @@ var builtinHashInstanceMethods = []*BuiltinMethodObject{
 
 				if !ok {
 					if blockFrame != nil {
-						value = t.builtinMethodYield(blockFrame, objectKey).Target
+						value = t.builtinMethodYield(blockFrame, objectKey)
 						blockFramePopped = true
 					} else {
 						return t.vm.InitErrorObject(errors.ArgumentError, sourceLine, "There is no value for the key `%s`, and no block has been provided", stringKey.value)
@@ -910,7 +910,7 @@ var builtinHashInstanceMethods = []*BuiltinMethodObject{
 			}
 
 			for k, v := range h.Pairs {
-				result[k] = t.builtinMethodYield(blockFrame, v).Target
+				result[k] = t.builtinMethodYield(blockFrame, v)
 			}
 			return t.vm.InitHashObject(result)
 
@@ -1005,7 +1005,7 @@ var builtinHashInstanceMethods = []*BuiltinMethodObject{
 				objectKey := t.vm.InitStringObject(stringKey)
 				result := t.builtinMethodYield(blockFrame, objectKey, value)
 
-				if result.Target.isTruthy() {
+				if result.isTruthy() {
 					destinationPairs[stringKey] = value
 				}
 			}
@@ -1179,8 +1179,7 @@ var builtinHashInstanceMethods = []*BuiltinMethodObject{
 
 			resultHash := make(map[string]Object)
 			for k, v := range h.Pairs {
-				result := t.builtinMethodYield(blockFrame, v)
-				resultHash[k] = result.Target
+				resultHash[k] = t.builtinMethodYield(blockFrame, v)
 			}
 			return t.vm.InitHashObject(resultHash)
 

--- a/vm/http.go
+++ b/vm/http.go
@@ -168,11 +168,11 @@ var builtinHTTPClassMethods = []*BuiltinMethodObject{
 
 			result := t.builtinMethodYield(blockFrame, gobyClient)
 
-			if err, ok := result.Target.(*Error); ok {
+			if err, ok := result.(*Error); ok {
 				return err //an Error object
 			}
 
-			return result.Target
+			return result
 
 		},
 	},

--- a/vm/range.go
+++ b/vm/range.go
@@ -119,7 +119,7 @@ var builtinRangeInstanceMethods = []*BuiltinMethodObject{
 
 				result := t.builtinMethodYield(blockFrame, t.vm.InitIntegerObject(mid))
 
-				switch r := result.Target.(type) {
+				switch r := result.(type) {
 				case *BooleanObject:
 					if r.value {
 						pivot = mid
@@ -303,7 +303,7 @@ var builtinRangeInstanceMethods = []*BuiltinMethodObject{
 					el = append(el, NULL)
 				} else {
 					obj := t.vm.InitIntegerObject(i)
-					el = append(el, t.builtinMethodYield(blockFrame, obj).Target)
+					el = append(el, t.builtinMethodYield(blockFrame, obj))
 				}
 
 				return nil

--- a/vm/simple_server.go
+++ b/vm/simple_server.go
@@ -152,7 +152,7 @@ func newHandler(t *Thread, blockFrame *normalCallFrame) func(http.ResponseWriter
 		req := initRequest(t, w, r)
 		result := thread.builtinMethodYield(blockFrame, req, res)
 
-		if err, ok := result.Target.(*Error); ok {
+		if err, ok := result.(*Error); ok {
 			log.Printf("Error: %s", err.message)
 			res.InstanceVariableSet("@status", t.vm.InitIntegerObject(500))
 		}

--- a/vm/thread.go
+++ b/vm/thread.go
@@ -240,7 +240,7 @@ func (t *Thread) execInstruction(cf *normalCallFrame, i *bytecode.Instruction) {
 }
 
 // Yield to a call frame
-func (t *Thread) Yield(args ...Object) *Pointer {
+func (t *Thread) Yield(args ...Object) Object {
 	return t.builtinMethodYield(t.currentFrame.BlockFrame(), args...)
 }
 
@@ -249,9 +249,9 @@ func (t *Thread) BlockGiven() bool {
 	return t.currentFrame.BlockFrame() != nil
 }
 
-func (t *Thread) builtinMethodYield(blockFrame *normalCallFrame, args ...Object) *Pointer {
+func (t *Thread) builtinMethodYield(blockFrame *normalCallFrame, args ...Object) Object {
 	if blockFrame.IsRemoved() {
-		return &Pointer{Target: NULL}
+		return NULL
 	}
 
 	c := newNormalCallFrame(blockFrame.instructionSet, blockFrame.FileName(), blockFrame.sourceLine)
@@ -269,10 +269,10 @@ func (t *Thread) builtinMethodYield(blockFrame *normalCallFrame, args ...Object)
 	t.startFromTopFrame()
 
 	if blockFrame.IsRemoved() {
-		return &Pointer{Target: NULL}
+		return NULL
 	}
 
-	return t.Stack.top()
+	return t.Stack.top().Target
 }
 
 func (t *Thread) retrieveBlock(fileName, blockFlag string, sourceLine int) (blockFrame *normalCallFrame) {


### PR DESCRIPTION
Most of the time, we use the return value of `t.builtinMethodYield` as an object instead of pushing it to the stack (as a Pointer). So it doesn't need to and shouldn't return a pointer, which costs us an extra attribute call in many cases.