### PR TITLE
fix(CONTRIBUTING): Fix dead links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ If you are very interested in `Goby` or planning contribute `Goby` frequently, p
 
 ## What to contribute
 
-- Any issues you see, and if you think the ticket is confusing, please open an issue or ask me on [slack](https://goby-lang-slackin.herokuapp.com).
+- Any issues you see, and if you think the ticket is confusing, please open an issue or ask me on [slack](https://goby-slack-invite.herokuapp.com/).
 - Any grammar error in readme, wiki, and code comments...etc.
-- Any issues listed in goby's [codeclimate](https://codeclimate.com/github/goby-lang/goby/issues).
+- Any issues listed in goby's [codeclimate](https://codeclimate.com/github/goby-lang/api.doc/issues).
 - Play around goby and report any bug you find.
 - Write benchmarks for goby (we really need this and really haven't had time to do it yet 😢)
 - Help us document built in class and libraries' api, see the [guideline](https://github.com/goby-lang/goby/wiki/Documenting-Goby-Code)


### PR DESCRIPTION
The slack-invite link and the codeclimate links are invalid in CONTRIBUTING.md
This PR fixes those to point to appropriate URLs.