### PR TITLE
Update the instance method `last()` on array objects to not panic when used with an empty array

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -1017,6 +1017,10 @@ var builtinArrayInstanceMethods = []*BuiltinMethodObject{
 			arrLength := len(arr.Elements)
 
 			if aLen == 0 {
+				if arrLength == 0 {
+					return NULL
+				}
+
 				return arr.Elements[arrLength-1]
 			}
 

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -1356,6 +1356,14 @@ func TestArrayLastMethod(t *testing.T) {
 		a.last
 		`, nil},
 		{`
+		a = [2, 9, 7, 1, 8]
+		a.last
+		`, 8},
+		{`
+		a = [2, 9, 7, 1, 8]
+		a.last(1)
+		`, []interface{}{8}},
+		{`
 		a = [3, 4, 5, 1, 6]
 		a.last(3)
 		`, []interface{}{5, 1, 6}},

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -1349,8 +1349,12 @@ func TestArrayJoinMethodFail(t *testing.T) {
 func TestArrayLastMethod(t *testing.T) {
 	testsArray := []struct {
 		input    string
-		expected []interface{}
+		expected interface{}
 	}{
+		{`
+		a = []
+		a.last
+		`, nil},
 		{`
 		a = [3, 4, 5, 1, 6]
 		a.last(3)
@@ -1372,7 +1376,7 @@ func TestArrayLastMethod(t *testing.T) {
 	for i, tt := range testsArray {
 		vm := initTestVM()
 		evaluated := vm.testEval(t, tt.input, getFilename())
-		verifyArrayObject(t, i, evaluated, tt.expected)
+		VerifyExpected(t, i, evaluated, tt.expected)
 		vm.checkCFP(t, i, 0)
 		vm.checkSP(t, i, 1)
 	}


### PR DESCRIPTION
- Solves https://github.com/goby-lang/goby/issues/853:
```ruby
a = []
a.last # => nil
```

- Adds more tests to ensure the correct types are returned based on whether an argument is passed in or not to the `last()` method:

```ruby
a = [2, 6, 3, 4]
a.last    # => 4
a.last(1) # => [4]
```