### PR TITLE
Add t.Helper() to goby_test.go

### DIFF
--- a/goby_test.go
+++ b/goby_test.go
@@ -30,6 +30,8 @@ func init() {
 }
 
 func execGoby(t *testing.T, args ...string) (in io.WriteCloser, out io.ReadCloser, e io.ReadCloser) {
+	t.Helper()
+
 	cmd := exec.Command("./goby", args...)
 
 	in, err := cmd.StdinPipe()


### PR DESCRIPTION
https://github.com/ichiban/thelper/ suggests that the followings tests forgot to call `t.Helper()`.

```
/Users/hachi8833/go/src/github.com/goby-lang/goby/goby_test.go:32:1: unmarked test helper: call t.Helper()
/Users/hachi8833/go/src/github.com/goby-lang/goby/compiler/compiler_test.go:17:1: unmarked test helper: call t.Helper()
/Users/hachi8833/go/src/github.com/goby-lang/goby/native/db/db_test.go:10:1: unmarked test helper: call t.Helper()
/Users/hachi8833/go/src/github.com/goby-lang/goby/native/plugin/plugin_integration_test.go:76:1: unmarked test helper: call t.Helper()
/Users/hachi8833/go/src/github.com/goby-lang/goby/vm/concurrent_rw_lock_test.go:305:1: unmarked test helper: call t.Helper()
/Users/hachi8833/go/src/github.com/goby-lang/goby/vm/hash_test.go:1904:1: unmarked test helper: call t.Helper()
```

Recent Go has `t.Helper()`, which is not mandatory but this helps read the error messages during tests.