### PR TITLE
Add t.Helper() to skipRWLockTestIfRaceDetectionEnabled() helper

### DIFF
--- a/vm/concurrent_rw_lock_test.go
+++ b/vm/concurrent_rw_lock_test.go
@@ -303,6 +303,7 @@ func TestRWLockWithReadLockReadBlocksWriteNoRaceDetection(t *testing.T) {
 }
 
 func skipRWLockTestIfRaceDetectionEnabled(t *testing.T) {
+	t.Helper()
 	if os.Getenv("NO_RACE_DETECTION") == "" {
 		t.Skip("skipping RW lock related tests")
 	}


### PR DESCRIPTION
Same as #855 